### PR TITLE
Add method to stop Drop-In

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### New
 
+- Added method to stop Drop-In programmatically.
 - Added bin lookup callbacks for Card Component and Drop-In. 
 - Set minimum SDK version to Flutter 3.16/Dart 3.2
 - Android Components/Drop-in

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.flutter.dropIn.advanced.DropInPaymentMethodDeletionPla
 import com.adyen.checkout.flutter.dropIn.advanced.DropInPaymentMethodDeletionResultMessenger
 import com.adyen.checkout.flutter.dropIn.advanced.DropInPaymentResultMessenger
 import com.adyen.checkout.flutter.dropIn.advanced.DropInServiceResultMessenger
+import com.adyen.checkout.flutter.dropIn.model.DropInServiceEvent
 import com.adyen.checkout.flutter.dropIn.session.SessionDropInService
 import com.adyen.checkout.flutter.generated.CheckoutEvent
 import com.adyen.checkout.flutter.generated.CheckoutEventType
@@ -59,6 +60,7 @@ internal class DropInPlatformApi(
 
     companion object {
         val dropInMessageFlow = MutableSharedFlow<CheckoutEvent>()
+        val dropInServiceFlow = MutableSharedFlow<DropInServiceEvent>()
     }
 
     override fun showDropInSession(dropInConfigurationDTO: DropInConfigurationDTO) {
@@ -115,6 +117,12 @@ internal class DropInPlatformApi(
                     AdvancedDropInService::class.java,
                 )
             }
+        }
+    }
+
+    override fun stopDropIn() {
+        activity.lifecycleScope.launch {
+            dropInServiceFlow.emit(DropInServiceEvent.STOP)
         }
     }
 

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/advanced/AdvancedDropInService.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/advanced/AdvancedDropInService.kt
@@ -35,6 +35,7 @@ import com.adyen.checkout.flutter.generated.PaymentEventType
 import com.adyen.checkout.flutter.generated.CheckoutEvent
 import com.adyen.checkout.flutter.generated.CheckoutEventType
 import com.adyen.checkout.flutter.utils.Constants
+import com.adyen.checkout.flutter.utils.Constants.Companion.RESULT_CODE_CANCELLED
 import com.adyen.checkout.googlepay.GooglePayComponentState
 import kotlinx.coroutines.launch
 import org.json.JSONObject
@@ -153,7 +154,7 @@ class AdvancedDropInService : DropInService(), LifecycleOwner {
     }
 
     private fun cancelDropIn() {
-        sendResult(DropInServiceResult.Finished(result = "Cancelled"))
+        sendResult(DropInServiceResult.Finished(result = RESULT_CODE_CANCELLED))
     }
 
     private fun onPaymentComponentState(state: PaymentComponentState<*>) {

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/advanced/AdvancedDropInService.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/advanced/AdvancedDropInService.kt
@@ -27,13 +27,13 @@ import com.adyen.checkout.flutter.dropIn.model.DropInServiceEvent
 import com.adyen.checkout.flutter.dropIn.model.DropInStoredPaymentMethodDeletionModel
 import com.adyen.checkout.flutter.dropIn.model.DropInType
 import com.adyen.checkout.flutter.generated.BinLookupDataDTO
+import com.adyen.checkout.flutter.generated.CheckoutEvent
+import com.adyen.checkout.flutter.generated.CheckoutEventType
 import com.adyen.checkout.flutter.generated.DeletedStoredPaymentMethodResultDTO
 import com.adyen.checkout.flutter.generated.ErrorDTO
 import com.adyen.checkout.flutter.generated.OrderCancelResultDTO
 import com.adyen.checkout.flutter.generated.PaymentEventDTO
 import com.adyen.checkout.flutter.generated.PaymentEventType
-import com.adyen.checkout.flutter.generated.CheckoutEvent
-import com.adyen.checkout.flutter.generated.CheckoutEventType
 import com.adyen.checkout.flutter.utils.Constants
 import com.adyen.checkout.flutter.utils.Constants.Companion.RESULT_CODE_CANCELLED
 import com.adyen.checkout.googlepay.GooglePayComponentState
@@ -147,13 +147,13 @@ class AdvancedDropInService : DropInService(), LifecycleOwner {
         lifecycleScope.launch {
             DropInPlatformApi.dropInServiceFlow.collect { event ->
                 when (event) {
-                    DropInServiceEvent.STOP -> cancelDropIn()
+                    DropInServiceEvent.STOP -> stopDropIn()
                 }
             }
         }
     }
 
-    private fun cancelDropIn() {
+    private fun stopDropIn() {
         sendResult(DropInServiceResult.Finished(result = RESULT_CODE_CANCELLED))
     }
 

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/model/DropInServiceEvent.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/model/DropInServiceEvent.kt
@@ -1,0 +1,5 @@
+package com.adyen.checkout.flutter.dropIn.model
+
+enum class DropInServiceEvent {
+    STOP
+}

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/session/SessionDropInService.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/session/SessionDropInService.kt
@@ -22,6 +22,7 @@ import com.adyen.checkout.flutter.generated.BinLookupDataDTO
 import com.adyen.checkout.flutter.generated.DeletedStoredPaymentMethodResultDTO
 import com.adyen.checkout.flutter.generated.CheckoutEvent
 import com.adyen.checkout.flutter.generated.CheckoutEventType
+import com.adyen.checkout.flutter.utils.Constants.Companion.RESULT_CODE_CANCELLED
 import kotlinx.coroutines.launch
 
 class SessionDropInService : SessionDropInService(), LifecycleOwner {
@@ -97,7 +98,7 @@ class SessionDropInService : SessionDropInService(), LifecycleOwner {
     }
 
     private fun cancelDropIn() {
-        sendResult(DropInServiceResult.Finished(result = "Cancelled"))
+        sendResult(DropInServiceResult.Finished(result = RESULT_CODE_CANCELLED))
     }
 
     override fun onBind(intent: Intent?): IBinder {

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/session/SessionDropInService.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/session/SessionDropInService.kt
@@ -19,9 +19,9 @@ import com.adyen.checkout.flutter.dropIn.model.DropInServiceEvent
 import com.adyen.checkout.flutter.dropIn.model.DropInStoredPaymentMethodDeletionModel
 import com.adyen.checkout.flutter.dropIn.model.DropInType
 import com.adyen.checkout.flutter.generated.BinLookupDataDTO
-import com.adyen.checkout.flutter.generated.DeletedStoredPaymentMethodResultDTO
 import com.adyen.checkout.flutter.generated.CheckoutEvent
 import com.adyen.checkout.flutter.generated.CheckoutEventType
+import com.adyen.checkout.flutter.generated.DeletedStoredPaymentMethodResultDTO
 import com.adyen.checkout.flutter.utils.Constants.Companion.RESULT_CODE_CANCELLED
 import kotlinx.coroutines.launch
 
@@ -91,13 +91,13 @@ class SessionDropInService : SessionDropInService(), LifecycleOwner {
         lifecycleScope.launch {
             DropInPlatformApi.dropInServiceFlow.collect { event ->
                 when (event) {
-                    DropInServiceEvent.STOP -> cancelDropIn()
+                    DropInServiceEvent.STOP -> stopDropIn()
                 }
             }
         }
     }
 
-    private fun cancelDropIn() {
+    private fun stopDropIn() {
         sendResult(DropInServiceResult.Finished(result = RESULT_CODE_CANCELLED))
     }
 

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/generated/PlatformApi.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/generated/PlatformApi.kt
@@ -1858,6 +1858,7 @@ interface CheckoutPlatformInterface {
 interface DropInPlatformInterface {
   fun showDropInSession(dropInConfigurationDTO: DropInConfigurationDTO)
   fun showDropInAdvanced(dropInConfigurationDTO: DropInConfigurationDTO, paymentMethodsResponse: String)
+  fun stopDropIn()
   fun onPaymentsResult(paymentsResult: PaymentEventDTO)
   fun onPaymentsDetailsResult(paymentsDetailsResult: PaymentEventDTO)
   fun onDeleteStoredPaymentMethodResult(deleteStoredPaymentMethodResultDTO: DeletedStoredPaymentMethodResultDTO)
@@ -1902,6 +1903,22 @@ interface DropInPlatformInterface {
             val paymentMethodsResponseArg = args[1] as String
             val wrapped: List<Any?> = try {
               api.showDropInAdvanced(dropInConfigurationDTOArg, paymentMethodsResponseArg)
+              listOf(null)
+            } catch (exception: Throwable) {
+              wrapError(exception)
+            }
+            reply.reply(wrapped)
+          }
+        } else {
+          channel.setMessageHandler(null)
+        }
+      }
+      run {
+        val channel = BasicMessageChannel<Any?>(binaryMessenger, "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.stopDropIn$separatedMessageChannelSuffix", codec)
+        if (api != null) {
+          channel.setMessageHandler { _, reply ->
+            val wrapped: List<Any?> = try {
+              api.stopDropIn()
               listOf(null)
             } catch (exception: Throwable) {
               wrapError(exception)

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/utils/Constants.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/utils/Constants.kt
@@ -20,5 +20,6 @@ class Constants {
         const val SHOULD_UPDATE_PAYMENT_METHODS_KEY = "shouldUpdatePaymentMethods"
         const val UPDATED_PAYMENT_METHODS_KEY = "updatedPaymentMethods"
         const val RESULT_CODE_KEY = "resultCode"
+        const val RESULT_CODE_CANCELLED = "cancelled"
     }
 }

--- a/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/example/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -59,6 +59,7 @@
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
+      enableGPUValidationMode = "1"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/ios/Classes/components/card/advanced/CardAdvancedComponent.swift
+++ b/ios/Classes/components/card/advanced/CardAdvancedComponent.swift
@@ -62,7 +62,7 @@ class CardAdvancedComponent: BaseCardComponent {
             cardComponentConfiguration: cardComponentConfiguration,
             componentDelegate: componentDelegate,
             cardDelegate: self
-        )        
+        )
     }
 
     private func buildActionComponent(adyenContext: AdyenContext) -> AdyenActionComponent {

--- a/ios/Classes/dropIn/DropInPlatformApi.swift
+++ b/ios/Classes/dropIn/DropInPlatformApi.swift
@@ -124,6 +124,18 @@ class DropInPlatformApi: DropInPlatformInterface {
             )
         }
     }
+    
+    func stopDropIn() throws {
+        let checkoutEvent = CheckoutEvent(
+            type: CheckoutEventType.result,
+            data: PaymentResultDTO(
+                type: PaymentResultEnum.finished,
+                result: PaymentResultModelDTO(resultCode: Constants.resultCodeCancelled)
+            )
+        )
+        checkoutFlutter.send(event: checkoutEvent, completion: { _ in })
+        finalizeAndDismiss(success: false, completion: {})
+    }
 
     func onPaymentsResult(paymentsResult: PaymentEventDTO) {
         handlePaymentEvent(paymentEventDTO: paymentsResult)

--- a/ios/Classes/generated/PlatformApi.swift
+++ b/ios/Classes/generated/PlatformApi.swift
@@ -1813,6 +1813,7 @@ class CheckoutPlatformInterfaceSetup {
 protocol DropInPlatformInterface {
     func showDropInSession(dropInConfigurationDTO: DropInConfigurationDTO) throws
     func showDropInAdvanced(dropInConfigurationDTO: DropInConfigurationDTO, paymentMethodsResponse: String) throws
+    func stopDropIn() throws
     func onPaymentsResult(paymentsResult: PaymentEventDTO) throws
     func onPaymentsDetailsResult(paymentsDetailsResult: PaymentEventDTO) throws
     func onDeleteStoredPaymentMethodResult(deleteStoredPaymentMethodResultDTO: DeletedStoredPaymentMethodResultDTO) throws
@@ -1858,6 +1859,19 @@ class DropInPlatformInterfaceSetup {
             }
         } else {
             showDropInAdvancedChannel.setMessageHandler(nil)
+        }
+        let stopDropInChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.stopDropIn\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            stopDropInChannel.setMessageHandler { _, reply in
+                do {
+                    try api.stopDropIn()
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            stopDropInChannel.setMessageHandler(nil)
         }
         let onPaymentsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onPaymentsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
         if let api {

--- a/ios/Classes/utils/Constants.swift
+++ b/ios/Classes/utils/Constants.swift
@@ -4,4 +4,5 @@ enum Constants {
     static let updatedPaymentMethodsKey = "updatedPaymentMethods"
     static let shouldUpdatePaymentMethodsKey = "shouldUpdatePaymentMethods"
     static let brandKey = "brand"
+    static let resultCodeCancelled = "cancelled"
 }

--- a/lib/src/common/adyen_checkout_advanced.dart
+++ b/lib/src/common/adyen_checkout_advanced.dart
@@ -32,4 +32,6 @@ class AdyenCheckoutAdvanced {
         configuration,
         paymentMethod,
       );
+
+  Future<void> stopDropIn() async => await dropIn.stopDropIn();
 }

--- a/lib/src/common/adyen_checkout_session.dart
+++ b/lib/src/common/adyen_checkout_session.dart
@@ -50,6 +50,8 @@ class AdyenCheckoutSession {
     );
   }
 
+  Future<void> stopDropIn() async => await dropIn.stopDropIn();
+
   Future<void> clear() async => await adyenCheckoutApi.clearSession();
 
   dynamic _mapConfiguration(

--- a/lib/src/drop_in/drop_in.dart
+++ b/lib/src/drop_in/drop_in.dart
@@ -183,6 +183,8 @@ class DropIn {
     });
   }
 
+  Future<void> stopDropIn() async => await dropInPlatformApi.stopDropIn();
+
   Future<void> _cleanUpDropIn() async {
     dropInPlatformApi.cleanUpDropIn();
     await dropInFlutter.platformEventStream?.close();

--- a/lib/src/drop_in/drop_in_platform_api.dart
+++ b/lib/src/drop_in/drop_in_platform_api.dart
@@ -21,6 +21,9 @@ class DropInPlatformApi implements DropInPlatformInterface {
       );
 
   @override
+  Future<void> stopDropIn() => _dropInPlatformInterface.stopDropIn();
+
+  @override
   Future<void> onPaymentsResult(PaymentEventDTO paymentsResult) =>
       _dropInPlatformInterface.onPaymentsResult(paymentsResult);
 

--- a/lib/src/generated/platform_api.g.dart
+++ b/lib/src/generated/platform_api.g.dart
@@ -2020,6 +2020,30 @@ class DropInPlatformInterface {
     }
   }
 
+  Future<void> stopDropIn() async {
+    final String __pigeon_channelName =
+        'dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.stopDropIn$__pigeon_messageChannelSuffix';
+    final BasicMessageChannel<Object?> __pigeon_channel =
+        BasicMessageChannel<Object?>(
+      __pigeon_channelName,
+      pigeonChannelCodec,
+      binaryMessenger: __pigeon_binaryMessenger,
+    );
+    final List<Object?>? __pigeon_replyList =
+        await __pigeon_channel.send(null) as List<Object?>?;
+    if (__pigeon_replyList == null) {
+      throw _createConnectionError(__pigeon_channelName);
+    } else if (__pigeon_replyList.length > 1) {
+      throw PlatformException(
+        code: __pigeon_replyList[0]! as String,
+        message: __pigeon_replyList[1] as String?,
+        details: __pigeon_replyList[2],
+      );
+    } else {
+      return;
+    }
+  }
+
   Future<void> onPaymentsResult(PaymentEventDTO paymentsResult) async {
     final String __pigeon_channelName =
         'dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onPaymentsResult$__pigeon_messageChannelSuffix';

--- a/pigeons/platform_api.dart
+++ b/pigeons/platform_api.dart
@@ -669,6 +669,8 @@ abstract class DropInPlatformInterface {
     String paymentMethodsResponse,
   );
 
+  void stopDropIn();
+
   void onPaymentsResult(PaymentEventDTO paymentsResult);
 
   void onPaymentsDetailsResult(PaymentEventDTO paymentsDetailsResult);


### PR DESCRIPTION
Added a method to close Drop-In programmatically without the need of interacting with the UI. It allows merchants to implement more enhanced use cases e.g. stopping the payment after a certain time of inactivity.