### PR TITLE
Refactored AdyenApplePayComponent build method

### DIFF
--- a/lib/src/components/apple_pay/adyen_apple_pay_component.dart
+++ b/lib/src/components/apple_pay/adyen_apple_pay_component.dart
@@ -94,18 +94,16 @@ class AdyenApplePayComponent extends StatelessWidget {
 
   pay_sdk.ApplePayButtonStyle _mapToApplePayButtonStyle() {
     return switch (style?.theme) {
-      null => pay_sdk.ApplePayButtonStyle.black,
+      null || ApplePayButtonTheme.black => pay_sdk.ApplePayButtonStyle.black,
       ApplePayButtonTheme.white => pay_sdk.ApplePayButtonStyle.white,
       ApplePayButtonTheme.whiteOutline => pay_sdk.ApplePayButtonStyle.whiteOutline,
-      ApplePayButtonTheme.black => pay_sdk.ApplePayButtonStyle.black,
       ApplePayButtonTheme.automatic => pay_sdk.ApplePayButtonStyle.automatic,
     };
   }
 
   pay_sdk.ApplePayButtonType _mapToApplePayButtonType() {
     return switch (style?.type) {
-      null => pay_sdk.ApplePayButtonType.plain,
-      ApplePayButtonType.plain => pay_sdk.ApplePayButtonType.plain,
+      null || ApplePayButtonType.plain => pay_sdk.ApplePayButtonType.plain,
       ApplePayButtonType.buy => pay_sdk.ApplePayButtonType.buy,
       ApplePayButtonType.setUp => pay_sdk.ApplePayButtonType.setUp,
       ApplePayButtonType.inStore => pay_sdk.ApplePayButtonType.inStore,

--- a/lib/src/components/apple_pay/adyen_apple_pay_component.dart
+++ b/lib/src/components/apple_pay/adyen_apple_pay_component.dart
@@ -10,17 +10,6 @@ import 'package:flutter/material.dart';
 import 'package:pay/pay.dart' as pay_sdk;
 
 class AdyenApplePayComponent extends StatelessWidget {
-  final ApplePayComponentConfiguration configuration;
-  final Map<String, dynamic> paymentMethod;
-  final Checkout checkout;
-  final Function(PaymentResult) onPaymentResult;
-  final ApplePayButtonStyle? style;
-  final Function()? onUnavailable;
-  final Widget? unavailableWidget;
-  final Widget? loadingIndicator;
-  final double? width;
-  final double? height;
-
   const AdyenApplePayComponent({
     super.key,
     required this.configuration,
@@ -35,61 +24,54 @@ class AdyenApplePayComponent extends StatelessWidget {
     this.height,
   });
 
+  final ApplePayComponentConfiguration configuration;
+  final Map<String, dynamic> paymentMethod;
+  final Checkout checkout;
+  final Function(PaymentResult) onPaymentResult;
+  final ApplePayButtonStyle? style;
+  final Function()? onUnavailable;
+  final Widget? unavailableWidget;
+  final Widget? loadingIndicator;
+  final double? width;
+  final double? height;
+
   @override
   Widget build(BuildContext context) {
-    switch (defaultTargetPlatform) {
-      case TargetPlatform.iOS:
-        return switch (checkout) {
-          SessionCheckout it => _buildApplePaySessionFlowWidget(it),
-          AdvancedCheckout it => _buildApplePayAdvancedFlowWidget(it),
-        };
-      default:
-        throw Exception(
-            "The Apple Pay component is not supported on $defaultTargetPlatform");
-    }
-  }
-
-  Widget _buildApplePaySessionFlowWidget(SessionCheckout sessionCheckout) {
-    return ApplePaySessionComponent(
-      key: key,
-      session: sessionCheckout.toDTO(),
-      applePayPaymentMethod: json.encode(paymentMethod),
-      applePayComponentConfiguration: configuration,
-      onPaymentResult: onPaymentResult,
-      style: _mapToApplePayButtonStyle(),
-      type: _mapToApplePayButtonType(),
-      width: _determineWidth(),
-      height: _determineHeight(),
-      cornerRadius: style?.cornerRadius,
-      loadingIndicator: loadingIndicator,
-      onUnavailable: onUnavailable,
-      unavailableWidget: unavailableWidget,
-    );
-  }
-
-  Widget _buildApplePayAdvancedFlowWidget(AdvancedCheckout advancedCheckout) {
-    if (configuration.amount == null) {
-      AdyenLogger.instance.print(
-          "Apple Pay requires to set an amount when using the advanced flow.");
-      onUnavailable?.call();
-      return unavailableWidget ?? const SizedBox.shrink();
-    }
-
-    return ApplePayAdvancedComponent(
-      key: key,
-      applePayPaymentMethod: json.encode(paymentMethod),
-      applePayComponentConfiguration: configuration,
-      onPaymentResult: onPaymentResult,
-      advancedCheckout: advancedCheckout,
-      style: _mapToApplePayButtonStyle(),
-      type: _mapToApplePayButtonType(),
-      width: _determineWidth(),
-      height: _determineHeight(),
-      cornerRadius: style?.cornerRadius,
-      loadingIndicator: loadingIndicator,
-      onUnavailable: onUnavailable,
-      unavailableWidget: unavailableWidget,
-    );
+    return switch (defaultTargetPlatform) {
+      TargetPlatform.iOS => switch (checkout) {
+          SessionCheckout it => ApplePaySessionComponent(
+              key: key,
+              session: it.toDTO(),
+              applePayPaymentMethod: json.encode(paymentMethod),
+              applePayComponentConfiguration: configuration,
+              onPaymentResult: onPaymentResult,
+              style: _mapToApplePayButtonStyle(),
+              type: _mapToApplePayButtonType(),
+              width: _determineWidth(),
+              height: _determineHeight(),
+              cornerRadius: style?.cornerRadius,
+              loadingIndicator: loadingIndicator,
+              onUnavailable: onUnavailable,
+              unavailableWidget: unavailableWidget,
+            ),
+          AdvancedCheckout it => _ApplePayAdvancedFlowWidget(
+              key: key,
+              paymentMethod: paymentMethod,
+              configuration: configuration,
+              onPaymentResult: onPaymentResult,
+              checkout: it,
+              style: _mapToApplePayButtonStyle(),
+              type: _mapToApplePayButtonType(),
+              width: _determineWidth(),
+              height: _determineHeight(),
+              cornerRadius: style?.cornerRadius,
+              loadingIndicator: loadingIndicator,
+              onUnavailable: onUnavailable,
+              unavailableWidget: unavailableWidget,
+            ),
+        },
+      _ => throw Exception("The Apple Pay component is not supported on $defaultTargetPlatform"),
+    };
   }
 
   double _determineWidth() {
@@ -111,56 +93,90 @@ class AdyenApplePayComponent extends StatelessWidget {
   }
 
   pay_sdk.ApplePayButtonStyle _mapToApplePayButtonStyle() {
-    switch (style?.theme) {
-      case null:
-        return pay_sdk.ApplePayButtonStyle.black;
-      case ApplePayButtonTheme.white:
-        return pay_sdk.ApplePayButtonStyle.white;
-      case ApplePayButtonTheme.whiteOutline:
-        return pay_sdk.ApplePayButtonStyle.whiteOutline;
-      case ApplePayButtonTheme.black:
-        return pay_sdk.ApplePayButtonStyle.black;
-      case ApplePayButtonTheme.automatic:
-        return pay_sdk.ApplePayButtonStyle.automatic;
-    }
+    return switch (style?.theme) {
+      null => pay_sdk.ApplePayButtonStyle.black,
+      ApplePayButtonTheme.white => pay_sdk.ApplePayButtonStyle.white,
+      ApplePayButtonTheme.whiteOutline => pay_sdk.ApplePayButtonStyle.whiteOutline,
+      ApplePayButtonTheme.black => pay_sdk.ApplePayButtonStyle.black,
+      ApplePayButtonTheme.automatic => pay_sdk.ApplePayButtonStyle.automatic,
+    };
   }
 
   pay_sdk.ApplePayButtonType _mapToApplePayButtonType() {
-    switch (style?.type) {
-      case null:
-        return pay_sdk.ApplePayButtonType.plain;
-      case ApplePayButtonType.plain:
-        return pay_sdk.ApplePayButtonType.plain;
-      case ApplePayButtonType.buy:
-        return pay_sdk.ApplePayButtonType.buy;
-      case ApplePayButtonType.setUp:
-        return pay_sdk.ApplePayButtonType.setUp;
-      case ApplePayButtonType.inStore:
-        return pay_sdk.ApplePayButtonType.inStore;
-      case ApplePayButtonType.donate:
-        return pay_sdk.ApplePayButtonType.donate;
-      case ApplePayButtonType.checkout:
-        return pay_sdk.ApplePayButtonType.checkout;
-      case ApplePayButtonType.book:
-        return pay_sdk.ApplePayButtonType.book;
-      case ApplePayButtonType.subscribe:
-        return pay_sdk.ApplePayButtonType.subscribe;
-      case ApplePayButtonType.reload:
-        return pay_sdk.ApplePayButtonType.reload;
-      case ApplePayButtonType.addMoney:
-        return pay_sdk.ApplePayButtonType.addMoney;
-      case ApplePayButtonType.topUp:
-        return pay_sdk.ApplePayButtonType.topUp;
-      case ApplePayButtonType.order:
-        return pay_sdk.ApplePayButtonType.order;
-      case ApplePayButtonType.rent:
-        return pay_sdk.ApplePayButtonType.rent;
-      case ApplePayButtonType.support:
-        return pay_sdk.ApplePayButtonType.support;
-      case ApplePayButtonType.contribute:
-        return pay_sdk.ApplePayButtonType.contribute;
-      case ApplePayButtonType.tip:
-        return pay_sdk.ApplePayButtonType.tip;
+    return switch (style?.type) {
+      null => pay_sdk.ApplePayButtonType.plain,
+      ApplePayButtonType.plain => pay_sdk.ApplePayButtonType.plain,
+      ApplePayButtonType.buy => pay_sdk.ApplePayButtonType.buy,
+      ApplePayButtonType.setUp => pay_sdk.ApplePayButtonType.setUp,
+      ApplePayButtonType.inStore => pay_sdk.ApplePayButtonType.inStore,
+      ApplePayButtonType.donate => pay_sdk.ApplePayButtonType.donate,
+      ApplePayButtonType.checkout => pay_sdk.ApplePayButtonType.checkout,
+      ApplePayButtonType.book => pay_sdk.ApplePayButtonType.book,
+      ApplePayButtonType.subscribe => pay_sdk.ApplePayButtonType.subscribe,
+      ApplePayButtonType.reload => pay_sdk.ApplePayButtonType.reload,
+      ApplePayButtonType.addMoney => pay_sdk.ApplePayButtonType.addMoney,
+      ApplePayButtonType.topUp => pay_sdk.ApplePayButtonType.topUp,
+      ApplePayButtonType.order => pay_sdk.ApplePayButtonType.order,
+      ApplePayButtonType.rent => pay_sdk.ApplePayButtonType.rent,
+      ApplePayButtonType.support => pay_sdk.ApplePayButtonType.support,
+      ApplePayButtonType.contribute => pay_sdk.ApplePayButtonType.contribute,
+      ApplePayButtonType.tip => pay_sdk.ApplePayButtonType.tip,
+    };
+  }
+}
+
+class _ApplePayAdvancedFlowWidget extends StatelessWidget {
+  const _ApplePayAdvancedFlowWidget({
+    super.key,
+    required this.paymentMethod,
+    required this.configuration,
+    required this.onPaymentResult,
+    required this.checkout,
+    required this.style,
+    required this.type,
+    required this.width,
+    required this.height,
+    this.cornerRadius,
+    this.loadingIndicator,
+    this.unavailableWidget,
+    this.onUnavailable,
+  });
+
+  final Map<String, dynamic> paymentMethod;
+  final ApplePayComponentConfiguration configuration;
+  final Function(PaymentResult result) onPaymentResult;
+  final AdvancedCheckout checkout;
+  final pay_sdk.ApplePayButtonStyle style;
+  final pay_sdk.ApplePayButtonType type;
+  final double width;
+  final double height;
+  final double? cornerRadius;
+  final Widget? loadingIndicator;
+  final Widget? unavailableWidget;
+  final Function()? onUnavailable;
+
+  @override
+  Widget build(BuildContext context) {
+    if (configuration.amount == null) {
+      AdyenLogger.instance.print("Apple Pay requires to set an amount when using the advanced flow.");
+      onUnavailable?.call();
+      return unavailableWidget ?? const SizedBox.shrink();
     }
+
+    return ApplePayAdvancedComponent(
+      key: key,
+      applePayPaymentMethod: json.encode(paymentMethod),
+      applePayComponentConfiguration: configuration,
+      onPaymentResult: onPaymentResult,
+      advancedCheckout: checkout,
+      style: style,
+      type: type,
+      width: width,
+      height: height,
+      cornerRadius: cornerRadius,
+      loadingIndicator: loadingIndicator,
+      onUnavailable: onUnavailable,
+      unavailableWidget: unavailableWidget,
+    );
   }
 }

--- a/lib/src/components/apple_pay/adyen_apple_pay_component.dart
+++ b/lib/src/components/apple_pay/adyen_apple_pay_component.dart
@@ -37,9 +37,11 @@ class AdyenApplePayComponent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return switch (defaultTargetPlatform) {
-      TargetPlatform.iOS => switch (checkout) {
-          SessionCheckout it => ApplePaySessionComponent(
+    switch (defaultTargetPlatform) {
+      case TargetPlatform.iOS:
+        switch (checkout) {
+          case SessionCheckout it:
+            return ApplePaySessionComponent(
               key: key,
               session: it.toDTO(),
               applePayPaymentMethod: json.encode(paymentMethod),
@@ -53,13 +55,19 @@ class AdyenApplePayComponent extends StatelessWidget {
               loadingIndicator: loadingIndicator,
               onUnavailable: onUnavailable,
               unavailableWidget: unavailableWidget,
-            ),
-          AdvancedCheckout it => _ApplePayAdvancedFlowWidget(
+            );
+          case AdvancedCheckout it:
+            if (configuration.amount == null) {
+              AdyenLogger.instance.print("Apple Pay requires to set an amount when using the advanced flow.");
+              onUnavailable?.call();
+              return unavailableWidget ?? const SizedBox.shrink();
+            }
+            return ApplePayAdvancedComponent(
               key: key,
-              paymentMethod: paymentMethod,
-              configuration: configuration,
+              applePayPaymentMethod: json.encode(paymentMethod),
+              applePayComponentConfiguration: configuration,
               onPaymentResult: onPaymentResult,
-              checkout: it,
+              advancedCheckout: it,
               style: _mapToApplePayButtonStyle(),
               type: _mapToApplePayButtonType(),
               width: _determineWidth(),
@@ -68,10 +76,11 @@ class AdyenApplePayComponent extends StatelessWidget {
               loadingIndicator: loadingIndicator,
               onUnavailable: onUnavailable,
               unavailableWidget: unavailableWidget,
-            ),
-        },
-      _ => throw Exception("The Apple Pay component is not supported on $defaultTargetPlatform"),
-    };
+            );
+        }
+      default:
+        throw Exception("The Apple Pay component is not supported on $defaultTargetPlatform");
+    }
   }
 
   double _determineWidth() {
@@ -120,61 +129,5 @@ class AdyenApplePayComponent extends StatelessWidget {
       ApplePayButtonType.contribute => pay_sdk.ApplePayButtonType.contribute,
       ApplePayButtonType.tip => pay_sdk.ApplePayButtonType.tip,
     };
-  }
-}
-
-class _ApplePayAdvancedFlowWidget extends StatelessWidget {
-  const _ApplePayAdvancedFlowWidget({
-    super.key,
-    required this.paymentMethod,
-    required this.configuration,
-    required this.onPaymentResult,
-    required this.checkout,
-    required this.style,
-    required this.type,
-    required this.width,
-    required this.height,
-    this.cornerRadius,
-    this.loadingIndicator,
-    this.unavailableWidget,
-    this.onUnavailable,
-  });
-
-  final Map<String, dynamic> paymentMethod;
-  final ApplePayComponentConfiguration configuration;
-  final Function(PaymentResult result) onPaymentResult;
-  final AdvancedCheckout checkout;
-  final pay_sdk.ApplePayButtonStyle style;
-  final pay_sdk.ApplePayButtonType type;
-  final double width;
-  final double height;
-  final double? cornerRadius;
-  final Widget? loadingIndicator;
-  final Widget? unavailableWidget;
-  final Function()? onUnavailable;
-
-  @override
-  Widget build(BuildContext context) {
-    if (configuration.amount == null) {
-      AdyenLogger.instance.print("Apple Pay requires to set an amount when using the advanced flow.");
-      onUnavailable?.call();
-      return unavailableWidget ?? const SizedBox.shrink();
-    }
-
-    return ApplePayAdvancedComponent(
-      key: key,
-      applePayPaymentMethod: json.encode(paymentMethod),
-      applePayComponentConfiguration: configuration,
-      onPaymentResult: onPaymentResult,
-      advancedCheckout: checkout,
-      style: style,
-      type: type,
-      width: width,
-      height: height,
-      cornerRadius: cornerRadius,
-      loadingIndicator: loadingIndicator,
-      onUnavailable: onUnavailable,
-      unavailableWidget: unavailableWidget,
-    );
   }
 }

--- a/lib/src/components/apple_pay/base_apple_pay_component.dart
+++ b/lib/src/components/apple_pay/base_apple_pay_component.dart
@@ -85,13 +85,12 @@ class _BaseApplePayComponentState extends State<BaseApplePayComponent> {
 
   @override
   void initState() {
+    super.initState();
     _componentCommunicationStream = _componentFlutterApi
         .componentCommunicationStream.stream
         .where((communicationModel) =>
             communicationModel.componentId == widget.componentId)
         .listen(widget.handleComponentCommunication);
-
-    super.initState();
   }
 
   @override

--- a/lib/src/components/apple_pay/model/apple_pay_button_style.dart
+++ b/lib/src/components/apple_pay/model/apple_pay_button_style.dart
@@ -6,7 +6,7 @@ class ApplePayButtonStyle {
   final ApplePayButtonType? type;
   final double? cornerRadius;
 
-  ApplePayButtonStyle({
+  const ApplePayButtonStyle({
     this.theme,
     this.type,
     this.cornerRadius,


### PR DESCRIPTION
This commit refactors the `build` method in `AdyenApplePayComponent` for improved readability and structure by:
- Extracting the advanced flow widget logic into a separate `_ApplePayAdvancedFlowWidget`.
- Utilizing switch expressions for cleaner conditional rendering based on platform and checkout type.

Additionally, the `ApplePayButtonStyle` constructor is now a `const` constructor.

<!-- 🎉 Thank you for submitting a pull request! 🎉  -->

## Summary
<!--
Describe the changes proposed in this pull request:
- What is the motivation for this change? 
- What existing problem does this pull request solve?
-->

## Tested scenarios
<!-- Description of tested scenarios -->


**Fixed issue**:  <!-- #-prefixed issue number -->
