### PR TITLE
Add NEA environment support

### DIFF
--- a/android/src/main/kotlin/com/adyen/checkout/flutter/generated/PlatformApi.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/generated/PlatformApi.kt
@@ -53,7 +53,8 @@ enum class Environment(val raw: Int) {
   UNITED_STATES(2),
   AUSTRALIA(3),
   INDIA(4),
-  APSE(5);
+  APSE(5),
+  NEA(6);
 
   companion object {
     fun ofRaw(raw: Int): Environment? {

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/utils/ConfigurationMapper.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/utils/ConfigurationMapper.kt
@@ -242,6 +242,7 @@ object ConfigurationMapper {
             Environment.AUSTRALIA -> SDKEnvironment.AUSTRALIA
             Environment.INDIA -> SDKEnvironment.INDIA
             Environment.APSE -> SDKEnvironment.APSE
+            Environment.NEA -> SDKEnvironment.NEA
         }
 
     private fun AnalyticsOptionsDTO.mapToAnalyticsConfiguration(): AnalyticsConfiguration {

--- a/android/src/test/kotlin/com/adyen/checkout/flutter/ConfigurationMapperTest.kt
+++ b/android/src/test/kotlin/com/adyen/checkout/flutter/ConfigurationMapperTest.kt
@@ -88,6 +88,11 @@ class ConfigurationMapperTest {
         fun `when environment is APSE, then map to SDK APSE environment`() {
             assertEquals(SDKEnvironment.APSE, Environment.APSE.mapToEnvironment())
         }
+
+        @Test
+        fun `when environment is NEA, then map to SDK NEA environment`() {
+            assertEquals(SDKEnvironment.NEA, Environment.NEA.mapToEnvironment())
+        }
     }
 
     @Nested

--- a/example/ios/RunnerTests/ConfigurationMapperTests.swift
+++ b/example/ios/RunnerTests/ConfigurationMapperTests.swift
@@ -20,6 +20,7 @@ final class ConfigurationMapperTests: XCTestCase {
             (.australia, .liveAustralia),
             (.india, .liveIndia),
             (.apse, .liveApse),
+            (.nea, .liveNea),
         ]
 
         for testCase in testCases {

--- a/ios/adyen_checkout/Sources/adyen_checkout/generated/PlatformApi.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/generated/PlatformApi.swift
@@ -74,6 +74,7 @@ enum Environment: Int {
     case australia = 3
     case india = 4
     case apse = 5
+    case nea = 6
 }
 
 enum AddressMode: Int {

--- a/ios/adyen_checkout/Sources/adyen_checkout/utils/ConfigurationMapper.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/utils/ConfigurationMapper.swift
@@ -218,6 +218,8 @@ extension Environment {
             return .liveIndia
         case .apse:
             return .liveApse
+        case .nea:
+            return .liveNea
         }
     }
 }

--- a/lib/src/generated/platform_api.g.dart
+++ b/lib/src/generated/platform_api.g.dart
@@ -33,6 +33,7 @@ enum Environment {
   australia,
   india,
   apse,
+  nea,
 }
 
 enum AddressMode {

--- a/pigeons/platform_api.dart
+++ b/pigeons/platform_api.dart
@@ -21,7 +21,8 @@ enum Environment {
   unitedStates,
   australia,
   india,
-  apse;
+  apse,
+  nea;
 }
 
 enum AddressMode {


### PR DESCRIPTION
## Summary
Add support for the new NEA (Near East Asia) live environment.

### Changes
- Added `nea` to the `Environment` enum in `pigeons/platform_api.dart`
- Regenerated Pigeon platform code (Dart, Kotlin, Swift)
- Added environment mapping: Android `Environment.NEA → SDKEnvironment.NEA`
- Added environment mapping: iOS `.nea → .liveNea`
- Added unit tests for the new environment on both platforms

COSDK-870