### PR TITLE
Update iOS SDK to v5.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
   | Name | Version |
   |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
   | [Android Drop-in/Components](https://docs.adyen.com/online-payments/release-notes/?title%5B0%5D=Android+Components%2FDrop-in&version%5B0%5D=5.17.0)                       |  5.17.0 |
-  | [iOS Drop-in/Components](https://docs.adyen.com/online-payments/release-notes/?title%5B0%5D=iOS+Components%2FDrop-in#releaseNote=2026-03-18-ios-componentsdrop-in-5.23.0) |  5.23.0 |
+  | [iOS Drop-in/Components](https://docs.adyen.com/online-payments/release-notes/?title%5B0%5D=iOS+Components%2FDrop-in&version%5B0%5D=5.23.1)                               |  5.23.1 |
 
 ## 1.8.1
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Adyen Flutter
 
 [![Pub Package](https://img.shields.io/pub/v/adyen_checkout.svg)](https://pub.dev/packages/adyen_checkout)
-[![Adyen iOS](https://img.shields.io/badge/ios-v5.23.0-brightgreen.svg)](https://github.com/Adyen/adyen-ios/releases/tag/5.23.0)
+[![Adyen iOS](https://img.shields.io/badge/ios-v5.23.1-brightgreen.svg)](https://github.com/Adyen/adyen-ios/releases/tag/5.23.1)
 [![Adyen Android](https://img.shields.io/badge/android-v5.17.0-brightgreen.svg)](https://github.com/Adyen/adyen-android/releases/tag/5.17.0)
 
 The Adyen Flutter package provides you with the building blocks to create a checkout experience for

--- a/ios/adyen_checkout.podspec
+++ b/ios/adyen_checkout.podspec
@@ -15,7 +15,7 @@ Adyen checkout SDK for Flutter
   s.source           = { :path => '.' }
   s.source_files = 'adyen_checkout/Sources/adyen_checkout/**/*.swift'
   s.dependency 'Flutter'
-  s.dependency 'Adyen', '5.23.0'
+  s.dependency 'Adyen', '5.23.1'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/adyen_checkout/Package.swift
+++ b/ios/adyen_checkout/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "adyen-checkout", targets: ["adyen_checkout"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Adyen/adyen-ios", exact: "5.23.0")
+        .package(url: "https://github.com/Adyen/adyen-ios", exact: "5.23.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary
- bump adyen-ios CocoaPods dependency to 5.23.1
- bump adyen-ios Swift Package pin to 5.23.1
- update the README iOS badge and changelog entry

## Validation
- verified only the expected Flutter files changed
- verified upstream iOS minimum deployment target remains 12.0