### PR TITLE
Add 3DS2 configuration support to ActionComponentConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.10.0 (in development)
 
+### New
+
+- `ActionComponentConfiguration` now supports `ThreeDS2Configuration`, including `requestorAppURL` and 3DS2 UI customization for standalone action handling.
+
 ## 1.9.0
 
 ### New

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/generated/PlatformApi.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/generated/PlatformApi.kt
@@ -1515,7 +1515,8 @@ data class ActionComponentConfigurationDTO (
   val clientKey: String,
   val shopperLocale: String? = null,
   val amount: AmountDTO? = null,
-  val analyticsOptionsDTO: AnalyticsOptionsDTO
+  val analyticsOptionsDTO: AnalyticsOptionsDTO,
+  val threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = null
 
 ) {
   companion object {
@@ -1526,7 +1527,8 @@ data class ActionComponentConfigurationDTO (
       val shopperLocale = __pigeon_list[2] as String?
       val amount = __pigeon_list[3] as AmountDTO?
       val analyticsOptionsDTO = __pigeon_list[4] as AnalyticsOptionsDTO
-      return ActionComponentConfigurationDTO(environment, clientKey, shopperLocale, amount, analyticsOptionsDTO)
+      val threeDS2ConfigurationDTO = __pigeon_list[5] as ThreeDS2ConfigurationDTO?
+      return ActionComponentConfigurationDTO(environment, clientKey, shopperLocale, amount, analyticsOptionsDTO, threeDS2ConfigurationDTO)
     }
   }
   fun toList(): List<Any?> {
@@ -1536,6 +1538,7 @@ data class ActionComponentConfigurationDTO (
       shopperLocale,
       amount,
       analyticsOptionsDTO,
+      threeDS2ConfigurationDTO,
     )
   }
 }

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/utils/ConfigurationMapper.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/utils/ConfigurationMapper.kt
@@ -132,6 +132,7 @@ object ConfigurationMapper {
             analyticsOptionsDTO = analyticsOptionsDTO,
             shopperLocale = shopperLocale,
             amount = amount,
+            threeDS2ConfigurationDTO = threeDS2ConfigurationDTO,
         )
 
     fun InstantPaymentConfigurationDTO.toCheckoutConfiguration(): CheckoutConfiguration =

--- a/android/src/test/kotlin/com/adyen/checkout/flutter/ConfigurationMapperTest.kt
+++ b/android/src/test/kotlin/com/adyen/checkout/flutter/ConfigurationMapperTest.kt
@@ -46,6 +46,7 @@ import com.adyen.checkout.googlepay.GooglePayConfiguration
 import com.adyen.checkout.twint.TwintConfiguration
 import com.google.android.gms.wallet.WalletConstants
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -571,6 +572,7 @@ class ConfigurationMapperTest {
             assertEquals("nl-NL", checkoutConfiguration.shopperLocale?.toLanguageTag())
             assertEquals("EUR", checkoutConfiguration.amount?.currency)
             assertEquals(5000, checkoutConfiguration.amount?.value)
+            assertNull(checkoutConfiguration.getActionConfiguration(Adyen3DS2Configuration::class.java))
         }
 
         @Test
@@ -589,6 +591,7 @@ class ConfigurationMapperTest {
             assertEquals(SDKEnvironment.UNITED_STATES, checkoutConfiguration.environment)
             assertNull(checkoutConfiguration.shopperLocale)
             assertNull(checkoutConfiguration.amount)
+            assertNull(checkoutConfiguration.getActionConfiguration(Adyen3DS2Configuration::class.java))
         }
 
         @Test
@@ -607,6 +610,7 @@ class ConfigurationMapperTest {
             val checkoutConfiguration = actionConfigurationDTO.toCheckoutConfiguration()
             val threeDS2Configuration = checkoutConfiguration.getActionConfiguration(Adyen3DS2Configuration::class.java)
 
+            assertNotNull(threeDS2Configuration)
             assertEquals("https://example.com/action-3ds2", threeDS2Configuration?.threeDSRequestorAppURL)
         }
     }

--- a/android/src/test/kotlin/com/adyen/checkout/flutter/ConfigurationMapperTest.kt
+++ b/android/src/test/kotlin/com/adyen/checkout/flutter/ConfigurationMapperTest.kt
@@ -561,6 +561,7 @@ class ConfigurationMapperTest {
                 shopperLocale = "nl-NL",
                 amount = AmountDTO("EUR", 5000),
                 analyticsOptionsDTO = AnalyticsOptionsDTO(true, "1.0.0"),
+                threeDS2ConfigurationDTO = null,
             )
 
             val checkoutConfiguration = actionConfigurationDTO.toCheckoutConfiguration()
@@ -580,6 +581,7 @@ class ConfigurationMapperTest {
                 shopperLocale = null,
                 amount = null,
                 analyticsOptionsDTO = AnalyticsOptionsDTO(false, "1.0.0"),
+                threeDS2ConfigurationDTO = null,
             )
 
             val checkoutConfiguration = actionConfigurationDTO.toCheckoutConfiguration()
@@ -587,6 +589,25 @@ class ConfigurationMapperTest {
             assertEquals(SDKEnvironment.UNITED_STATES, checkoutConfiguration.environment)
             assertNull(checkoutConfiguration.shopperLocale)
             assertNull(checkoutConfiguration.amount)
+        }
+
+        @Test
+        fun `when action component configuration has 3DS2 configuration, then map correctly`() {
+            val actionConfigurationDTO = ActionComponentConfigurationDTO(
+                environment = Environment.TEST,
+                clientKey = TEST_CLIENT_KEY,
+                shopperLocale = null,
+                amount = null,
+                analyticsOptionsDTO = AnalyticsOptionsDTO(true, "1.0.0"),
+                threeDS2ConfigurationDTO = ThreeDS2ConfigurationDTO(
+                    requestorAppURL = "https://example.com/action-3ds2"
+                ),
+            )
+
+            val checkoutConfiguration = actionConfigurationDTO.toCheckoutConfiguration()
+            val threeDS2Configuration = checkoutConfiguration.getActionConfiguration(Adyen3DS2Configuration::class.java)
+
+            assertEquals("https://example.com/action-3ds2", threeDS2Configuration?.threeDSRequestorAppURL)
         }
     }
 

--- a/doc/3DS_CUSTOMIZATION.md
+++ b/doc/3DS_CUSTOMIZATION.md
@@ -18,6 +18,20 @@ final dropInConfiguration = DropInConfiguration(
 );
 ```
 
+You can apply the same `ThreeDS2Configuration` to standalone action handling:
+
+```dart
+final actionComponentConfiguration = ActionComponentConfiguration(
+  environment: Environment.test,
+  clientKey: clientKey,
+  threeDS2Configuration: ThreeDS2Configuration(
+    headingTitle: 'Custom 3DS2 Title',
+    requestorAppURL: 'myapp://adyen-redirect',
+    theme: Adyen3DSTheme.fromThemeData(Theme.of(context)),
+  ),
+);
+```
+
 `fromThemeData` uses Flutter defaults to keep UI consistent with your app:
 
 - `scaffoldBackgroundColor` for screen background
@@ -80,6 +94,7 @@ final configuration = DropInConfiguration(
 ## Notes
 
 - All properties are optional. Null values fall back to the native SDK defaults.
+- `ThreeDS2Configuration` is supported by `DropInConfiguration`, `CardComponentConfiguration`, and `ActionComponentConfiguration`.
 - Sizes are `double` in Flutter and are rounded when mapped to native SDKs.
 - Colors are converted to `#AARRGGBB` hex strings to preserve alpha.
 - `backgroundColor` affects both Android and iOS challenge screens.

--- a/example/ios/RunnerTests/ConfigurationMapperTests.swift
+++ b/example/ios/RunnerTests/ConfigurationMapperTests.swift
@@ -1,168 +1,169 @@
 @_spi(AdyenInternal) import Adyen
+@testable import adyen_checkout
 import XCTest
 
-@testable import adyen_checkout
-
 #if canImport(AdyenCard)
-  import AdyenCard
+    import AdyenCard
 #endif
 #if canImport(Adyen3DS2)
-  import Adyen3DS2
+    import Adyen3DS2
 #endif
 
 final class ConfigurationMapperTests: XCTestCase {
-  // MARK: - Environment Mapping Tests
+    // MARK: - Environment Mapping Tests
 
-  func test_mapToEnvironment_shouldMapAllEnvironmentsCorrectly() {
-    let testCases: [(environment: adyen_checkout.Environment, expected: Adyen.Environment)] = [
-      (.test, .test),
-      (.europe, .liveEurope),
-      (.unitedStates, .liveUnitedStates),
-      (.australia, .liveAustralia),
-      (.india, .liveIndia),
-      (.apse, .liveApse),
-      (.nea, .liveNea),
-    ]
+    func test_mapToEnvironment_shouldMapAllEnvironmentsCorrectly() {
+        let testCases: [(environment: adyen_checkout.Environment, expected: Adyen.Environment)] = [
+            (.test, .test),
+            (.europe, .liveEurope),
+            (.unitedStates, .liveUnitedStates),
+            (.australia, .liveAustralia),
+            (.india, .liveIndia),
+            (.apse, .liveApse),
+            (.nea, .liveNea),
+        ]
 
-    for testCase in testCases {
-      let result = testCase.environment.mapToEnvironment()
-      XCTAssertEqual(result, testCase.expected, "Failed for environment: \(testCase.environment)")
+        for testCase in testCases {
+            let result = testCase.environment.mapToEnvironment()
+            XCTAssertEqual(result, testCase.expected, "Failed for environment: \(testCase.environment)")
+        }
     }
-  }
 
-  // MARK: - Amount Mapping Tests
+    // MARK: - Amount Mapping Tests
 
-  func test_mapToAmount_withEUR_shouldMapCorrectly() {
-    let sut = AmountDTO(currency: "EUR", value: 1000)
+    func test_mapToAmount_withEUR_shouldMapCorrectly() {
+        let sut = AmountDTO(currency: "EUR", value: 1000)
 
-    let result = sut.mapToAmount()
+        let result = sut.mapToAmount()
 
-    XCTAssertEqual(result.currencyCode, "EUR")
-    XCTAssertEqual(result.value, 1000)
-  }
+        XCTAssertEqual(result.currencyCode, "EUR")
+        XCTAssertEqual(result.value, 1000)
+    }
 
-  func test_mapToAmount_withUSD_shouldMapCorrectly() {
-    let sut = AmountDTO(currency: "USD", value: 2500)
+    func test_mapToAmount_withUSD_shouldMapCorrectly() {
+        let sut = AmountDTO(currency: "USD", value: 2500)
 
-    let result = sut.mapToAmount()
+        let result = sut.mapToAmount()
 
-    XCTAssertEqual(result.currencyCode, "USD")
-    XCTAssertEqual(result.value, 2500)
-  }
+        XCTAssertEqual(result.currencyCode, "USD")
+        XCTAssertEqual(result.value, 2500)
+    }
 
-  // MARK: - FieldVisibility Mapping Tests
+    // MARK: - FieldVisibility Mapping Tests
 
-  func test_toCardFieldVisibility_withShow_shouldReturnShow() {
-    let sut = FieldVisibility.show
+    func test_toCardFieldVisibility_withShow_shouldReturnShow() {
+        let sut = FieldVisibility.show
 
-    let result = sut.toCardFieldVisibility()
+        let result = sut.toCardFieldVisibility()
 
-    XCTAssertEqual(result, CardComponent.FieldVisibility.show)
-  }
+        XCTAssertEqual(result, CardComponent.FieldVisibility.show)
+    }
 
-  func test_toCardFieldVisibility_withHide_shouldReturnHide() {
-    let sut = FieldVisibility.hide
+    func test_toCardFieldVisibility_withHide_shouldReturnHide() {
+        let sut = FieldVisibility.hide
 
-    let result = sut.toCardFieldVisibility()
+        let result = sut.toCardFieldVisibility()
 
-    XCTAssertEqual(result, CardComponent.FieldVisibility.hide)
-  }
+        XCTAssertEqual(result, CardComponent.FieldVisibility.hide)
+    }
 
-  // MARK: - ThreeDS2Configuration Mapping Tests
+    // MARK: - ThreeDS2Configuration Mapping Tests
 
-  func test_mapToThreeDS2Configuration_withValidURL_shouldSetRequestorAppURL() {
-    let sut = ThreeDS2ConfigurationDTO(requestorAppURL: "https://example.com/3ds2")
+    func test_mapToThreeDS2Configuration_withValidURL_shouldSetRequestorAppURL() {
+        let sut = ThreeDS2ConfigurationDTO(requestorAppURL: "https://example.com/3ds2")
 
-    let result = sut.mapToThreeDS2Configuration()
+        let result = sut.mapToThreeDS2Configuration()
 
-    XCTAssertEqual(result.requestorAppURL?.absoluteString, "https://example.com/3ds2")
-  }
+        XCTAssertEqual(result.requestorAppURL?.absoluteString, "https://example.com/3ds2")
+    }
 
-  func test_mapToThreeDS2Configuration_withInvalidURL_shouldReturnNilRequestorAppURL() {
-    let sut = ThreeDS2ConfigurationDTO(requestorAppURL: "")
+    func test_mapToThreeDS2Configuration_withInvalidURL_shouldReturnNilRequestorAppURL() {
+        let sut = ThreeDS2ConfigurationDTO(requestorAppURL: "")
 
-    let result = sut.mapToThreeDS2Configuration()
+        let result = sut.mapToThreeDS2Configuration()
 
-    XCTAssertNil(result.requestorAppURL)
-  }
+        XCTAssertNil(result.requestorAppURL)
+    }
 
-  // MARK: - PaymentResultEnum Mapping Tests
+    // MARK: - PaymentResultEnum Mapping Tests
 
-  func test_fromError_withComponentCancelled_shouldReturnCancelledByUser() {
-    let sut = ComponentError.cancelled
+    func test_fromError_withComponentCancelled_shouldReturnCancelledByUser() {
+        let sut = ComponentError.cancelled
 
-    let result = PaymentResultEnum.from(error: sut)
+        let result = PaymentResultEnum.from(error: sut)
 
-    XCTAssertEqual(result, PaymentResultEnum.cancelledByUser)
-  }
+        XCTAssertEqual(result, PaymentResultEnum.cancelledByUser)
+    }
 
-  func test_fromError_withGenericError_shouldReturnError() {
-    let sut = NSError(domain: "TestDomain", code: 123, userInfo: nil)
+    func test_fromError_withGenericError_shouldReturnError() {
+        let sut = NSError(domain: "TestDomain", code: 123, userInfo: nil)
 
-    let result = PaymentResultEnum.from(error: sut)
+        let result = PaymentResultEnum.from(error: sut)
 
-    XCTAssertEqual(result, PaymentResultEnum.error)
-  }
+        XCTAssertEqual(result, PaymentResultEnum.error)
+    }
 
-  func test_fromError_withThreeDS2ChallengeCancelled_shouldReturnCancelledByUser() {
-    let sut = NSError(
-      domain: ADYRuntimeErrorDomain,
-      code: Int(ADYRuntimeErrorCode.challengeCancelled.rawValue),
-      userInfo: nil
-    )
+    func test_fromError_withThreeDS2ChallengeCancelled_shouldReturnCancelledByUser() {
+        let sut = NSError(
+            domain: ADYRuntimeErrorDomain,
+            code: Int(ADYRuntimeErrorCode.challengeCancelled.rawValue),
+            userInfo: nil
+        )
 
-    let result = PaymentResultEnum.from(error: sut)
+        let result = PaymentResultEnum.from(error: sut)
 
-    XCTAssertEqual(result, PaymentResultEnum.cancelledByUser)
-  }
+        XCTAssertEqual(result, PaymentResultEnum.cancelledByUser)
+    }
 
-  // MARK: - ActionComponentConfigurationDTO Tests
+    // MARK: - ActionComponentConfigurationDTO Tests
 
-  func test_createAdyenContext_withDefaultsFromActionComponent_shouldCreateContext() throws {
-    let sut = createActionComponentConfigurationDTO()
+    func test_createAdyenContext_withDefaultsFromActionComponent_shouldCreateContext() throws {
+        let sut = createActionComponentConfigurationDTO()
 
-    let result = try sut.createAdyenContext()
+        let result = try sut.createAdyenContext()
 
-    XCTAssertNotNil(result)
-    XCTAssertNotNil(result.apiContext)
-  }
+        XCTAssertNotNil(result)
+        XCTAssertNotNil(result.apiContext)
+    }
 
-  func test_createAdyenContext_withShopperLocale_shouldCreateContext() throws {
-    let sut = createActionComponentConfigurationDTO(shopperLocale: "nl-NL")
+    func test_createAdyenContext_withShopperLocale_shouldCreateContext() throws {
+        let sut = createActionComponentConfigurationDTO(shopperLocale: "nl-NL")
 
-    let result = try sut.createAdyenContext()
+        let result = try sut.createAdyenContext()
 
-    XCTAssertNotNil(result)
-  }
+        XCTAssertNotNil(result)
+    }
 
-  func test_createAdyenContext_withoutShopperLocale_shouldCreateContext() throws {
-    let sut = createActionComponentConfigurationDTO(shopperLocale: nil)
+    func test_createAdyenContext_withoutShopperLocale_shouldCreateContext() throws {
+        let sut = createActionComponentConfigurationDTO(shopperLocale: nil)
 
-    let result = try sut.createAdyenContext()
+        let result = try sut.createAdyenContext()
 
-    XCTAssertNotNil(result)
-  }
+        XCTAssertNotNil(result)
+    }
 
-  func
-    test_createActionComponentConfiguration_withThreeDS2RequestorAppURL_shouldCreateConfiguration()
-  {
-    let sut = createActionComponentConfigurationDTO(
-      threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO(
-        requestorAppURL: "https://example.com/action-3ds2")
-    )
+    func
+        test_createActionComponentConfiguration_withThreeDS2RequestorAppURL_shouldCreateConfiguration()
+    {
+        let sut = createActionComponentConfigurationDTO(
+            threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO(
+                requestorAppURL: "https://example.com/action-3ds2"
+            )
+        )
 
-    let result = sut.threeDS2ConfigurationDTO?.buildActionComponentConfiguration()
+        let result = sut.threeDS2ConfigurationDTO?.buildActionComponentConfiguration()
 
-    XCTAssertNotNil(result)
-    XCTAssertEqual(
-      result?.threeDS.requestorAppURL?.absoluteString, "https://example.com/action-3ds2")
-  }
+        XCTAssertNotNil(result)
+        XCTAssertEqual(
+            result?.threeDS.requestorAppURL?.absoluteString, "https://example.com/action-3ds2"
+        )
+    }
 
-  func test_createActionComponentConfiguration_withoutThreeDS2_shouldReturnNil() {
-    let sut = createActionComponentConfigurationDTO(threeDS2ConfigurationDTO: nil)
+    func test_createActionComponentConfiguration_withoutThreeDS2_shouldReturnNil() {
+        let sut = createActionComponentConfigurationDTO(threeDS2ConfigurationDTO: nil)
 
-    let result = sut.threeDS2ConfigurationDTO?.buildActionComponentConfiguration()
+        let result = sut.threeDS2ConfigurationDTO?.buildActionComponentConfiguration()
 
-    XCTAssertNil(result)
-  }
+        XCTAssertNil(result)
+    }
 }

--- a/example/ios/RunnerTests/ConfigurationMapperTests.swift
+++ b/example/ios/RunnerTests/ConfigurationMapperTests.swift
@@ -1,144 +1,168 @@
 @_spi(AdyenInternal) import Adyen
-@testable import adyen_checkout
 import XCTest
 
+@testable import adyen_checkout
+
 #if canImport(AdyenCard)
-    import AdyenCard
+  import AdyenCard
 #endif
 #if canImport(Adyen3DS2)
-    import Adyen3DS2
+  import Adyen3DS2
 #endif
 
 final class ConfigurationMapperTests: XCTestCase {
-    // MARK: - Environment Mapping Tests
+  // MARK: - Environment Mapping Tests
 
-    func test_mapToEnvironment_shouldMapAllEnvironmentsCorrectly() {
-        let testCases: [(environment: adyen_checkout.Environment, expected: Adyen.Environment)] = [
-            (.test, .test),
-            (.europe, .liveEurope),
-            (.unitedStates, .liveUnitedStates),
-            (.australia, .liveAustralia),
-            (.india, .liveIndia),
-            (.apse, .liveApse),
-            (.nea, .liveNea),
-        ]
+  func test_mapToEnvironment_shouldMapAllEnvironmentsCorrectly() {
+    let testCases: [(environment: adyen_checkout.Environment, expected: Adyen.Environment)] = [
+      (.test, .test),
+      (.europe, .liveEurope),
+      (.unitedStates, .liveUnitedStates),
+      (.australia, .liveAustralia),
+      (.india, .liveIndia),
+      (.apse, .liveApse),
+      (.nea, .liveNea),
+    ]
 
-        for testCase in testCases {
-            let result = testCase.environment.mapToEnvironment()
-            XCTAssertEqual(result, testCase.expected, "Failed for environment: \(testCase.environment)")
-        }
+    for testCase in testCases {
+      let result = testCase.environment.mapToEnvironment()
+      XCTAssertEqual(result, testCase.expected, "Failed for environment: \(testCase.environment)")
     }
+  }
 
-    // MARK: - Amount Mapping Tests
+  // MARK: - Amount Mapping Tests
 
-    func test_mapToAmount_withEUR_shouldMapCorrectly() {
-        let sut = AmountDTO(currency: "EUR", value: 1000)
+  func test_mapToAmount_withEUR_shouldMapCorrectly() {
+    let sut = AmountDTO(currency: "EUR", value: 1000)
 
-        let result = sut.mapToAmount()
+    let result = sut.mapToAmount()
 
-        XCTAssertEqual(result.currencyCode, "EUR")
-        XCTAssertEqual(result.value, 1000)
-    }
+    XCTAssertEqual(result.currencyCode, "EUR")
+    XCTAssertEqual(result.value, 1000)
+  }
 
-    func test_mapToAmount_withUSD_shouldMapCorrectly() {
-        let sut = AmountDTO(currency: "USD", value: 2500)
+  func test_mapToAmount_withUSD_shouldMapCorrectly() {
+    let sut = AmountDTO(currency: "USD", value: 2500)
 
-        let result = sut.mapToAmount()
+    let result = sut.mapToAmount()
 
-        XCTAssertEqual(result.currencyCode, "USD")
-        XCTAssertEqual(result.value, 2500)
-    }
+    XCTAssertEqual(result.currencyCode, "USD")
+    XCTAssertEqual(result.value, 2500)
+  }
 
-    // MARK: - FieldVisibility Mapping Tests
+  // MARK: - FieldVisibility Mapping Tests
 
-    func test_toCardFieldVisibility_withShow_shouldReturnShow() {
-        let sut = FieldVisibility.show
+  func test_toCardFieldVisibility_withShow_shouldReturnShow() {
+    let sut = FieldVisibility.show
 
-        let result = sut.toCardFieldVisibility()
+    let result = sut.toCardFieldVisibility()
 
-        XCTAssertEqual(result, CardComponent.FieldVisibility.show)
-    }
+    XCTAssertEqual(result, CardComponent.FieldVisibility.show)
+  }
 
-    func test_toCardFieldVisibility_withHide_shouldReturnHide() {
-        let sut = FieldVisibility.hide
+  func test_toCardFieldVisibility_withHide_shouldReturnHide() {
+    let sut = FieldVisibility.hide
 
-        let result = sut.toCardFieldVisibility()
+    let result = sut.toCardFieldVisibility()
 
-        XCTAssertEqual(result, CardComponent.FieldVisibility.hide)
-    }
+    XCTAssertEqual(result, CardComponent.FieldVisibility.hide)
+  }
 
-    // MARK: - ThreeDS2Configuration Mapping Tests
+  // MARK: - ThreeDS2Configuration Mapping Tests
 
-    func test_mapToThreeDS2Configuration_withValidURL_shouldSetRequestorAppURL() {
-        let sut = ThreeDS2ConfigurationDTO(requestorAppURL: "https://example.com/3ds2")
+  func test_mapToThreeDS2Configuration_withValidURL_shouldSetRequestorAppURL() {
+    let sut = ThreeDS2ConfigurationDTO(requestorAppURL: "https://example.com/3ds2")
 
-        let result = sut.mapToThreeDS2Configuration()
+    let result = sut.mapToThreeDS2Configuration()
 
-        XCTAssertEqual(result.requestorAppURL?.absoluteString, "https://example.com/3ds2")
-    }
+    XCTAssertEqual(result.requestorAppURL?.absoluteString, "https://example.com/3ds2")
+  }
 
-    func test_mapToThreeDS2Configuration_withInvalidURL_shouldReturnNilRequestorAppURL() {
-        let sut = ThreeDS2ConfigurationDTO(requestorAppURL: "")
+  func test_mapToThreeDS2Configuration_withInvalidURL_shouldReturnNilRequestorAppURL() {
+    let sut = ThreeDS2ConfigurationDTO(requestorAppURL: "")
 
-        let result = sut.mapToThreeDS2Configuration()
+    let result = sut.mapToThreeDS2Configuration()
 
-        XCTAssertNil(result.requestorAppURL)
-    }
+    XCTAssertNil(result.requestorAppURL)
+  }
 
-    // MARK: - PaymentResultEnum Mapping Tests
+  // MARK: - PaymentResultEnum Mapping Tests
 
-    func test_fromError_withComponentCancelled_shouldReturnCancelledByUser() {
-        let sut = ComponentError.cancelled
+  func test_fromError_withComponentCancelled_shouldReturnCancelledByUser() {
+    let sut = ComponentError.cancelled
 
-        let result = PaymentResultEnum.from(error: sut)
+    let result = PaymentResultEnum.from(error: sut)
 
-        XCTAssertEqual(result, PaymentResultEnum.cancelledByUser)
-    }
+    XCTAssertEqual(result, PaymentResultEnum.cancelledByUser)
+  }
 
-    func test_fromError_withGenericError_shouldReturnError() {
-        let sut = NSError(domain: "TestDomain", code: 123, userInfo: nil)
+  func test_fromError_withGenericError_shouldReturnError() {
+    let sut = NSError(domain: "TestDomain", code: 123, userInfo: nil)
 
-        let result = PaymentResultEnum.from(error: sut)
+    let result = PaymentResultEnum.from(error: sut)
 
-        XCTAssertEqual(result, PaymentResultEnum.error)
-    }
+    XCTAssertEqual(result, PaymentResultEnum.error)
+  }
 
-    func test_fromError_withThreeDS2ChallengeCancelled_shouldReturnCancelledByUser() {
-        let sut = NSError(
-            domain: ADYRuntimeErrorDomain,
-            code: Int(ADYRuntimeErrorCode.challengeCancelled.rawValue),
-            userInfo: nil
-        )
+  func test_fromError_withThreeDS2ChallengeCancelled_shouldReturnCancelledByUser() {
+    let sut = NSError(
+      domain: ADYRuntimeErrorDomain,
+      code: Int(ADYRuntimeErrorCode.challengeCancelled.rawValue),
+      userInfo: nil
+    )
 
-        let result = PaymentResultEnum.from(error: sut)
+    let result = PaymentResultEnum.from(error: sut)
 
-        XCTAssertEqual(result, PaymentResultEnum.cancelledByUser)
-    }
+    XCTAssertEqual(result, PaymentResultEnum.cancelledByUser)
+  }
 
-    // MARK: - ActionComponentConfigurationDTO Tests
+  // MARK: - ActionComponentConfigurationDTO Tests
 
-    func test_createAdyenContext_withDefaultsFromActionComponent_shouldCreateContext() throws {
-        let sut = createActionComponentConfigurationDTO()
+  func test_createAdyenContext_withDefaultsFromActionComponent_shouldCreateContext() throws {
+    let sut = createActionComponentConfigurationDTO()
 
-        let result = try sut.createAdyenContext()
+    let result = try sut.createAdyenContext()
 
-        XCTAssertNotNil(result)
-        XCTAssertNotNil(result.apiContext)
-    }
+    XCTAssertNotNil(result)
+    XCTAssertNotNil(result.apiContext)
+  }
 
-    func test_createAdyenContext_withShopperLocale_shouldCreateContext() throws {
-        let sut = createActionComponentConfigurationDTO(shopperLocale: "nl-NL")
+  func test_createAdyenContext_withShopperLocale_shouldCreateContext() throws {
+    let sut = createActionComponentConfigurationDTO(shopperLocale: "nl-NL")
 
-        let result = try sut.createAdyenContext()
+    let result = try sut.createAdyenContext()
 
-        XCTAssertNotNil(result)
-    }
+    XCTAssertNotNil(result)
+  }
 
-    func test_createAdyenContext_withoutShopperLocale_shouldCreateContext() throws {
-        let sut = createActionComponentConfigurationDTO(shopperLocale: nil)
+  func test_createAdyenContext_withoutShopperLocale_shouldCreateContext() throws {
+    let sut = createActionComponentConfigurationDTO(shopperLocale: nil)
 
-        let result = try sut.createAdyenContext()
+    let result = try sut.createAdyenContext()
 
-        XCTAssertNotNil(result)
-    }
+    XCTAssertNotNil(result)
+  }
+
+  func
+    test_createActionComponentConfiguration_withThreeDS2RequestorAppURL_shouldCreateConfiguration()
+  {
+    let sut = createActionComponentConfigurationDTO(
+      threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO(
+        requestorAppURL: "https://example.com/action-3ds2")
+    )
+
+    let result = sut.threeDS2ConfigurationDTO?.buildActionComponentConfiguration()
+
+    XCTAssertNotNil(result)
+    XCTAssertEqual(
+      result?.threeDS.requestorAppURL?.absoluteString, "https://example.com/action-3ds2")
+  }
+
+  func test_createActionComponentConfiguration_withoutThreeDS2_shouldReturnNil() {
+    let sut = createActionComponentConfigurationDTO(threeDS2ConfigurationDTO: nil)
+
+    let result = sut.threeDS2ConfigurationDTO?.buildActionComponentConfiguration()
+
+    XCTAssertNil(result)
+  }
 }

--- a/example/ios/RunnerTests/TestUtils.swift
+++ b/example/ios/RunnerTests/TestUtils.swift
@@ -1,132 +1,131 @@
 @_spi(AdyenInternal) import Adyen
+@testable import adyen_checkout
 @_spi(AdyenInternal) import AdyenNetworking
 
-@testable import adyen_checkout
-
 #if canImport(AdyenCard)
-  import AdyenCard
+    import AdyenCard
 #endif
 #if canImport(AdyenEncryption)
-  import AdyenEncryption
+    import AdyenEncryption
 #endif
 #if canImport(AdyenActions)
-  import AdyenActions
+    import AdyenActions
 #endif
 #if canImport(Adyen3DS2)
-  import Adyen3DS2
+    import Adyen3DS2
 #endif
 
 extension CardComponent.AddressFormType: Equatable {
-  public static func == (lhs: Self, rhs: Self) -> Bool {
-    switch (lhs, rhs) {
-    case (.full, .full):
-      return true
-    case (.none, .none):
-      return true
-    case (.postalCode, .postalCode):
-      return true
-    default:
-      return false
+    public static func == (lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (.full, .full):
+            return true
+        case (.none, .none):
+            return true
+        case (.postalCode, .postalCode):
+            return true
+        default:
+            return false
+        }
     }
-  }
 }
 
 let testClientKey = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
 
 func createDropInConfigurationDTO(
-  environment: adyen_checkout.Environment = adyen_checkout.Environment.test,
-  clientKey: String = testClientKey,
-  countryCode: String = "NL",
-  amount: AmountDTO? = AmountDTO(currency: "EUR", value: 1000),
-  shopperLocale: String? = nil,
-  cardConfigurationDTO: CardConfigurationDTO? = nil,
-  applePayConfigurationDTO: ApplePayConfigurationDTO? = nil,
-  cashAppPayConfigurationDTO: CashAppPayConfigurationDTO? = nil,
-  twintConfigurationDTO: TwintConfigurationDTO? = nil,
-  threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil,
-  analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0"),
-  showPreselectedStoredPaymentMethod: Bool = true,
-  skipListWhenSinglePaymentMethod: Bool = false,
-  isRemoveStoredPaymentMethodEnabled: Bool = false
+    environment: adyen_checkout.Environment = adyen_checkout.Environment.test,
+    clientKey: String = testClientKey,
+    countryCode: String = "NL",
+    amount: AmountDTO? = AmountDTO(currency: "EUR", value: 1000),
+    shopperLocale: String? = nil,
+    cardConfigurationDTO: CardConfigurationDTO? = nil,
+    applePayConfigurationDTO: ApplePayConfigurationDTO? = nil,
+    cashAppPayConfigurationDTO: CashAppPayConfigurationDTO? = nil,
+    twintConfigurationDTO: TwintConfigurationDTO? = nil,
+    threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil,
+    analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0"),
+    showPreselectedStoredPaymentMethod: Bool = true,
+    skipListWhenSinglePaymentMethod: Bool = false,
+    isRemoveStoredPaymentMethodEnabled: Bool = false
 ) -> DropInConfigurationDTO {
-  DropInConfigurationDTO(
-    environment: environment,
-    clientKey: clientKey,
-    countryCode: countryCode,
-    amount: amount,
-    shopperLocale: shopperLocale,
-    cardConfigurationDTO: cardConfigurationDTO,
-    applePayConfigurationDTO: applePayConfigurationDTO,
-    googlePayConfigurationDTO: nil,
-    cashAppPayConfigurationDTO: cashAppPayConfigurationDTO,
-    twintConfigurationDTO: twintConfigurationDTO,
-    threeDS2ConfigurationDTO: threeDS2ConfigurationDTO,
-    analyticsOptionsDTO: analyticsOptionsDTO,
-    showPreselectedStoredPaymentMethod: showPreselectedStoredPaymentMethod,
-    skipListWhenSinglePaymentMethod: skipListWhenSinglePaymentMethod,
-    isRemoveStoredPaymentMethodEnabled: isRemoveStoredPaymentMethodEnabled,
-    preselectedPaymentMethodTitle: nil,
-    paymentMethodNames: nil,
-    isPartialPaymentSupported: false
-  )
+    DropInConfigurationDTO(
+        environment: environment,
+        clientKey: clientKey,
+        countryCode: countryCode,
+        amount: amount,
+        shopperLocale: shopperLocale,
+        cardConfigurationDTO: cardConfigurationDTO,
+        applePayConfigurationDTO: applePayConfigurationDTO,
+        googlePayConfigurationDTO: nil,
+        cashAppPayConfigurationDTO: cashAppPayConfigurationDTO,
+        twintConfigurationDTO: twintConfigurationDTO,
+        threeDS2ConfigurationDTO: threeDS2ConfigurationDTO,
+        analyticsOptionsDTO: analyticsOptionsDTO,
+        showPreselectedStoredPaymentMethod: showPreselectedStoredPaymentMethod,
+        skipListWhenSinglePaymentMethod: skipListWhenSinglePaymentMethod,
+        isRemoveStoredPaymentMethodEnabled: isRemoveStoredPaymentMethodEnabled,
+        preselectedPaymentMethodTitle: nil,
+        paymentMethodNames: nil,
+        isPartialPaymentSupported: false
+    )
 }
 
 func createCardConfigurationDTO(
-  holderNameRequired: Bool = false,
-  addressMode: AddressMode = .none,
-  showStorePaymentField: Bool = false,
-  showCvcForStoredCard: Bool = true,
-  showCvc: Bool = true,
-  kcpFieldVisibility: FieldVisibility = .hide,
-  socialSecurityNumberFieldVisibility: FieldVisibility = .hide,
-  supportedCardTypes: [String?] = [],
-  installmentConfiguration: InstallmentConfigurationDTO? = nil
+    holderNameRequired: Bool = false,
+    addressMode: AddressMode = .none,
+    showStorePaymentField: Bool = false,
+    showCvcForStoredCard: Bool = true,
+    showCvc: Bool = true,
+    kcpFieldVisibility: FieldVisibility = .hide,
+    socialSecurityNumberFieldVisibility: FieldVisibility = .hide,
+    supportedCardTypes: [String?] = [],
+    installmentConfiguration: InstallmentConfigurationDTO? = nil
 ) -> CardConfigurationDTO {
-  CardConfigurationDTO(
-    holderNameRequired: holderNameRequired,
-    addressMode: addressMode,
-    showStorePaymentField: showStorePaymentField,
-    showCvcForStoredCard: showCvcForStoredCard,
-    showCvc: showCvc,
-    kcpFieldVisibility: kcpFieldVisibility,
-    socialSecurityNumberFieldVisibility: socialSecurityNumberFieldVisibility,
-    supportedCardTypes: supportedCardTypes,
-    installmentConfiguration: installmentConfiguration
-  )
+    CardConfigurationDTO(
+        holderNameRequired: holderNameRequired,
+        addressMode: addressMode,
+        showStorePaymentField: showStorePaymentField,
+        showCvcForStoredCard: showCvcForStoredCard,
+        showCvc: showCvc,
+        kcpFieldVisibility: kcpFieldVisibility,
+        socialSecurityNumberFieldVisibility: socialSecurityNumberFieldVisibility,
+        supportedCardTypes: supportedCardTypes,
+        installmentConfiguration: installmentConfiguration
+    )
 }
 
 func createBlikComponentConfigurationDTO(
-  environment: adyen_checkout.Environment = adyen_checkout.Environment.test,
-  clientKey: String = testClientKey,
-  countryCode: String = "PL",
-  amount: AmountDTO? = AmountDTO(currency: "PLN", value: 1000),
-  shopperLocale: String? = nil,
-  analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0")
+    environment: adyen_checkout.Environment = adyen_checkout.Environment.test,
+    clientKey: String = testClientKey,
+    countryCode: String = "PL",
+    amount: AmountDTO? = AmountDTO(currency: "PLN", value: 1000),
+    shopperLocale: String? = nil,
+    analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0")
 ) -> BlikComponentConfigurationDTO {
-  BlikComponentConfigurationDTO(
-    environment: environment,
-    clientKey: clientKey,
-    countryCode: countryCode,
-    amount: amount,
-    shopperLocale: shopperLocale,
-    analyticsOptionsDTO: analyticsOptionsDTO
-  )
+    BlikComponentConfigurationDTO(
+        environment: environment,
+        clientKey: clientKey,
+        countryCode: countryCode,
+        amount: amount,
+        shopperLocale: shopperLocale,
+        analyticsOptionsDTO: analyticsOptionsDTO
+    )
 }
 
 func createActionComponentConfigurationDTO(
-  environment: adyen_checkout.Environment = adyen_checkout.Environment.test,
-  clientKey: String = testClientKey,
-  shopperLocale: String? = nil,
-  amount: AmountDTO? = nil,
-  analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0"),
-  threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil
+    environment: adyen_checkout.Environment = adyen_checkout.Environment.test,
+    clientKey: String = testClientKey,
+    shopperLocale: String? = nil,
+    amount: AmountDTO? = nil,
+    analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0"),
+    threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil
 ) -> ActionComponentConfigurationDTO {
-  ActionComponentConfigurationDTO(
-    environment: environment,
-    clientKey: clientKey,
-    shopperLocale: shopperLocale,
-    amount: amount,
-    analyticsOptionsDTO: analyticsOptionsDTO,
-    threeDS2ConfigurationDTO: threeDS2ConfigurationDTO
-  )
+    ActionComponentConfigurationDTO(
+        environment: environment,
+        clientKey: clientKey,
+        shopperLocale: shopperLocale,
+        amount: amount,
+        analyticsOptionsDTO: analyticsOptionsDTO,
+        threeDS2ConfigurationDTO: threeDS2ConfigurationDTO
+    )
 }

--- a/example/ios/RunnerTests/TestUtils.swift
+++ b/example/ios/RunnerTests/TestUtils.swift
@@ -1,129 +1,132 @@
 @_spi(AdyenInternal) import Adyen
-@testable import adyen_checkout
 @_spi(AdyenInternal) import AdyenNetworking
 
+@testable import adyen_checkout
+
 #if canImport(AdyenCard)
-    import AdyenCard
+  import AdyenCard
 #endif
 #if canImport(AdyenEncryption)
-    import AdyenEncryption
+  import AdyenEncryption
 #endif
 #if canImport(AdyenActions)
-    import AdyenActions
+  import AdyenActions
 #endif
 #if canImport(Adyen3DS2)
-    import Adyen3DS2
+  import Adyen3DS2
 #endif
 
 extension CardComponent.AddressFormType: Equatable {
-    public static func == (lhs: Self, rhs: Self) -> Bool {
-        switch (lhs, rhs) {
-        case (.full, .full):
-            return true
-        case (.none, .none):
-            return true
-        case (.postalCode, .postalCode):
-            return true
-        default:
-            return false
-        }
+  public static func == (lhs: Self, rhs: Self) -> Bool {
+    switch (lhs, rhs) {
+    case (.full, .full):
+      return true
+    case (.none, .none):
+      return true
+    case (.postalCode, .postalCode):
+      return true
+    default:
+      return false
     }
+  }
 }
 
 let testClientKey = "test_qwertyuiopasdfghjklzxcvbnmqwerty"
 
 func createDropInConfigurationDTO(
-    environment: adyen_checkout.Environment = adyen_checkout.Environment.test,
-    clientKey: String = testClientKey,
-    countryCode: String = "NL",
-    amount: AmountDTO? = AmountDTO(currency: "EUR", value: 1000),
-    shopperLocale: String? = nil,
-    cardConfigurationDTO: CardConfigurationDTO? = nil,
-    applePayConfigurationDTO: ApplePayConfigurationDTO? = nil,
-    cashAppPayConfigurationDTO: CashAppPayConfigurationDTO? = nil,
-    twintConfigurationDTO: TwintConfigurationDTO? = nil,
-    threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil,
-    analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0"),
-    showPreselectedStoredPaymentMethod: Bool = true,
-    skipListWhenSinglePaymentMethod: Bool = false,
-    isRemoveStoredPaymentMethodEnabled: Bool = false
+  environment: adyen_checkout.Environment = adyen_checkout.Environment.test,
+  clientKey: String = testClientKey,
+  countryCode: String = "NL",
+  amount: AmountDTO? = AmountDTO(currency: "EUR", value: 1000),
+  shopperLocale: String? = nil,
+  cardConfigurationDTO: CardConfigurationDTO? = nil,
+  applePayConfigurationDTO: ApplePayConfigurationDTO? = nil,
+  cashAppPayConfigurationDTO: CashAppPayConfigurationDTO? = nil,
+  twintConfigurationDTO: TwintConfigurationDTO? = nil,
+  threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil,
+  analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0"),
+  showPreselectedStoredPaymentMethod: Bool = true,
+  skipListWhenSinglePaymentMethod: Bool = false,
+  isRemoveStoredPaymentMethodEnabled: Bool = false
 ) -> DropInConfigurationDTO {
-    DropInConfigurationDTO(
-        environment: environment,
-        clientKey: clientKey,
-        countryCode: countryCode,
-        amount: amount,
-        shopperLocale: shopperLocale,
-        cardConfigurationDTO: cardConfigurationDTO,
-        applePayConfigurationDTO: applePayConfigurationDTO,
-        googlePayConfigurationDTO: nil,
-        cashAppPayConfigurationDTO: cashAppPayConfigurationDTO,
-        twintConfigurationDTO: twintConfigurationDTO,
-        threeDS2ConfigurationDTO: threeDS2ConfigurationDTO,
-        analyticsOptionsDTO: analyticsOptionsDTO,
-        showPreselectedStoredPaymentMethod: showPreselectedStoredPaymentMethod,
-        skipListWhenSinglePaymentMethod: skipListWhenSinglePaymentMethod,
-        isRemoveStoredPaymentMethodEnabled: isRemoveStoredPaymentMethodEnabled,
-        preselectedPaymentMethodTitle: nil,
-        paymentMethodNames: nil,
-        isPartialPaymentSupported: false
-    )
+  DropInConfigurationDTO(
+    environment: environment,
+    clientKey: clientKey,
+    countryCode: countryCode,
+    amount: amount,
+    shopperLocale: shopperLocale,
+    cardConfigurationDTO: cardConfigurationDTO,
+    applePayConfigurationDTO: applePayConfigurationDTO,
+    googlePayConfigurationDTO: nil,
+    cashAppPayConfigurationDTO: cashAppPayConfigurationDTO,
+    twintConfigurationDTO: twintConfigurationDTO,
+    threeDS2ConfigurationDTO: threeDS2ConfigurationDTO,
+    analyticsOptionsDTO: analyticsOptionsDTO,
+    showPreselectedStoredPaymentMethod: showPreselectedStoredPaymentMethod,
+    skipListWhenSinglePaymentMethod: skipListWhenSinglePaymentMethod,
+    isRemoveStoredPaymentMethodEnabled: isRemoveStoredPaymentMethodEnabled,
+    preselectedPaymentMethodTitle: nil,
+    paymentMethodNames: nil,
+    isPartialPaymentSupported: false
+  )
 }
 
 func createCardConfigurationDTO(
-    holderNameRequired: Bool = false,
-    addressMode: AddressMode = .none,
-    showStorePaymentField: Bool = false,
-    showCvcForStoredCard: Bool = true,
-    showCvc: Bool = true,
-    kcpFieldVisibility: FieldVisibility = .hide,
-    socialSecurityNumberFieldVisibility: FieldVisibility = .hide,
-    supportedCardTypes: [String?] = [],
-    installmentConfiguration: InstallmentConfigurationDTO? = nil
+  holderNameRequired: Bool = false,
+  addressMode: AddressMode = .none,
+  showStorePaymentField: Bool = false,
+  showCvcForStoredCard: Bool = true,
+  showCvc: Bool = true,
+  kcpFieldVisibility: FieldVisibility = .hide,
+  socialSecurityNumberFieldVisibility: FieldVisibility = .hide,
+  supportedCardTypes: [String?] = [],
+  installmentConfiguration: InstallmentConfigurationDTO? = nil
 ) -> CardConfigurationDTO {
-    CardConfigurationDTO(
-        holderNameRequired: holderNameRequired,
-        addressMode: addressMode,
-        showStorePaymentField: showStorePaymentField,
-        showCvcForStoredCard: showCvcForStoredCard,
-        showCvc: showCvc,
-        kcpFieldVisibility: kcpFieldVisibility,
-        socialSecurityNumberFieldVisibility: socialSecurityNumberFieldVisibility,
-        supportedCardTypes: supportedCardTypes,
-        installmentConfiguration: installmentConfiguration
-    )
+  CardConfigurationDTO(
+    holderNameRequired: holderNameRequired,
+    addressMode: addressMode,
+    showStorePaymentField: showStorePaymentField,
+    showCvcForStoredCard: showCvcForStoredCard,
+    showCvc: showCvc,
+    kcpFieldVisibility: kcpFieldVisibility,
+    socialSecurityNumberFieldVisibility: socialSecurityNumberFieldVisibility,
+    supportedCardTypes: supportedCardTypes,
+    installmentConfiguration: installmentConfiguration
+  )
 }
 
 func createBlikComponentConfigurationDTO(
-    environment: adyen_checkout.Environment = adyen_checkout.Environment.test,
-    clientKey: String = testClientKey,
-    countryCode: String = "PL",
-    amount: AmountDTO? = AmountDTO(currency: "PLN", value: 1000),
-    shopperLocale: String? = nil,
-    analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0")
+  environment: adyen_checkout.Environment = adyen_checkout.Environment.test,
+  clientKey: String = testClientKey,
+  countryCode: String = "PL",
+  amount: AmountDTO? = AmountDTO(currency: "PLN", value: 1000),
+  shopperLocale: String? = nil,
+  analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0")
 ) -> BlikComponentConfigurationDTO {
-    BlikComponentConfigurationDTO(
-        environment: environment,
-        clientKey: clientKey,
-        countryCode: countryCode,
-        amount: amount,
-        shopperLocale: shopperLocale,
-        analyticsOptionsDTO: analyticsOptionsDTO
-    )
+  BlikComponentConfigurationDTO(
+    environment: environment,
+    clientKey: clientKey,
+    countryCode: countryCode,
+    amount: amount,
+    shopperLocale: shopperLocale,
+    analyticsOptionsDTO: analyticsOptionsDTO
+  )
 }
 
 func createActionComponentConfigurationDTO(
-    environment: adyen_checkout.Environment = adyen_checkout.Environment.test,
-    clientKey: String = testClientKey,
-    shopperLocale: String? = nil,
-    amount: AmountDTO? = nil,
-    analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0")
+  environment: adyen_checkout.Environment = adyen_checkout.Environment.test,
+  clientKey: String = testClientKey,
+  shopperLocale: String? = nil,
+  amount: AmountDTO? = nil,
+  analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0"),
+  threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil
 ) -> ActionComponentConfigurationDTO {
-    ActionComponentConfigurationDTO(
-        environment: environment,
-        clientKey: clientKey,
-        shopperLocale: shopperLocale,
-        amount: amount,
-        analyticsOptionsDTO: analyticsOptionsDTO
-    )
+  ActionComponentConfigurationDTO(
+    environment: environment,
+    clientKey: clientKey,
+    shopperLocale: shopperLocale,
+    amount: amount,
+    analyticsOptionsDTO: analyticsOptionsDTO,
+    threeDS2ConfigurationDTO: threeDS2ConfigurationDTO
+  )
 }

--- a/example/lib/screens/api_only/card_state_notifier.dart
+++ b/example/lib/screens/api_only/card_state_notifier.dart
@@ -4,7 +4,7 @@ import 'package:adyen_checkout/adyen_checkout.dart';
 import 'package:adyen_checkout_example/config.dart';
 import 'package:adyen_checkout_example/repositories/adyen_cse_repository.dart';
 import 'package:adyen_checkout_example/screens/api_only/card_state.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 
 class CardStateNotifier extends ValueNotifier<CardState> {
   CardStateNotifier(this.repository) : super(CardState());
@@ -192,6 +192,21 @@ class CardStateNotifier extends ValueNotifier<CardState> {
       environment: Config.environment,
       clientKey: Config.clientKey,
       shopperLocale: Config.shopperLocale,
+      threeDS2Configuration: ThreeDS2Configuration(
+        headingTitle: 'Test 3DS2 title',
+        theme: const Adyen3DSTheme(
+          headerTheme: Adyen3DSHeaderTheme(
+            backgroundColor: Colors.green,
+            textColor: Colors.black,
+            cancelButtonColor: Colors.blue,
+          ),
+          primaryButtonTheme: Adyen3DSButtonTheme(
+            backgroundColor: Colors.blue,
+            textColor: Colors.white,
+            cornerRadius: 24,
+          ),
+        ),
+      ),
     );
 
     final ActionResult actionResult = await AdyenCheckout.instance.handleAction(

--- a/example/lib/screens/api_only/card_state_notifier.dart
+++ b/example/lib/screens/api_only/card_state_notifier.dart
@@ -198,11 +198,11 @@ class CardStateNotifier extends ValueNotifier<CardState> {
           headerTheme: Adyen3DSHeaderTheme(
             backgroundColor: Colors.green,
             textColor: Colors.black,
-            cancelButtonColor: Colors.blue,
+            cancelButtonColor: Colors.black,
           ),
           primaryButtonTheme: Adyen3DSButtonTheme(
-            backgroundColor: Colors.blue,
-            textColor: Colors.white,
+            backgroundColor: Colors.yellow,
+            textColor: Colors.black,
             cornerRadius: 24,
           ),
         ),

--- a/ios/adyen_checkout/Sources/adyen_checkout/CheckoutPlatformApi.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/CheckoutPlatformApi.swift
@@ -1,16 +1,16 @@
+@_spi(AdyenInternal) import Adyen
 import Foundation
 import UIKit
 
 #if canImport(AdyenSession)
-    import AdyenSession
+  import AdyenSession
 #endif
 #if canImport(AdyenCard)
-    import AdyenCard
+  import AdyenCard
 #endif
 #if canImport(AdyenActions)
-    import AdyenActions
+  import AdyenActions
 #endif
-@_spi(AdyenInternal) import Adyen
 
 // TODO: Add config:
 // 1) Add Info.plist for adding photo library usage description
@@ -18,213 +18,231 @@ import UIKit
 // 3) Add AppDelegate redirect
 
 class CheckoutPlatformApi: CheckoutPlatformInterface {
-    private let checkoutFlutter: CheckoutFlutterInterface
-    private let componentFlutterApi: ComponentFlutterInterface
-    private let sessionHolder: SessionHolder
-    private let adyenCse: AdyenCSE = .init()
+  private let checkoutFlutter: CheckoutFlutterInterface
+  private let componentFlutterApi: ComponentFlutterInterface
+  private let sessionHolder: SessionHolder
+  private let adyenCse: AdyenCSE = .init()
 
-    init(
-        checkoutFlutter: CheckoutFlutterInterface,
-        componentFlutterApi: ComponentFlutterInterface,
-        sessionHolder: SessionHolder
-    ) {
-        self.checkoutFlutter = checkoutFlutter
-        self.componentFlutterApi = componentFlutterApi
-        self.sessionHolder = sessionHolder
-    }
+  init(
+    checkoutFlutter: CheckoutFlutterInterface,
+    componentFlutterApi: ComponentFlutterInterface,
+    sessionHolder: SessionHolder
+  ) {
+    self.checkoutFlutter = checkoutFlutter
+    self.componentFlutterApi = componentFlutterApi
+    self.sessionHolder = sessionHolder
+  }
 
-    func createSession(
-        sessionId: String,
-        sessionData: String,
-        configuration: Any?,
-        completion: @escaping (Result<SessionDTO, Error>) -> Void
-    ) {
-        do {
-            switch configuration {
-            case let dropInConfigurationDTO as DropInConfigurationDTO:
-                try createSessionForDropIn(
-                    adyenContext: dropInConfigurationDTO.createAdyenContext(),
-                    actionComponentConfiguration: buildActionComponentConfiguration(from: dropInConfigurationDTO.threeDS2ConfigurationDTO),
-                    sessionId: sessionId,
-                    sessionData: sessionData,
-                    completion: completion
-                )
-            case let cardComponentConfigurationDTO as CardComponentConfigurationDTO:
-                try createSessionForComponent(
-                    adyenContext: cardComponentConfigurationDTO.createAdyenContext(),
-                    actionComponentConfiguration: buildActionComponentConfiguration(from: cardComponentConfigurationDTO.threeDS2ConfigurationDTO),
-                    sessionId: sessionId,
-                    sessionData: sessionData,
-                    completion: completion
-                )
-            case let blikComponentConfigurationDTO as BlikComponentConfigurationDTO:
-                try createSessionForComponent(
-                    adyenContext: blikComponentConfigurationDTO.createAdyenContext(),
-                    sessionId: sessionId,
-                    sessionData: sessionData,
-                    completion: completion
-                )
-            case let instantComponentConfigurationDTO as InstantPaymentConfigurationDTO:
-                try createSessionForComponent(
-                    adyenContext: instantComponentConfigurationDTO.createAdyenContext(),
-                    sessionId: sessionId,
-                    sessionData: sessionData,
-                    completion: completion
-                )
-            case .none, .some:
-                completion(Result.failure(PlatformError(errorDescription: "Configuration is not valid")))
-            }
-        } catch {
-            completion(Result.failure(error))
-        }
-    }
-    
-    func clearSession() {
-        sessionHolder.reset()
-    }
-
-    func getReturnUrl(completion: @escaping (Result<String, Error>) -> Void) {
-        completion(Result.failure(PlatformError(errorDescription: "Please use your app url type instead of this method.")))
-    }
-
-    func enableConsoleLogging(loggingEnabled: Bool) {
-        AdyenLogging.isEnabled = loggingEnabled
-    }
-    
-    func encryptCard(unencryptedCardDTO: UnencryptedCardDTO, publicKey: String, completion: @escaping (Result<EncryptedCardDTO, any Error>) -> Void) {
-        let encryptedCardResult = adyenCse.encryptCard(unencryptedCardDTO: unencryptedCardDTO, publicKey: publicKey)
-        completion(encryptedCardResult)
-    }
-    
-    func encryptBin(bin: String, publicKey: String, completion: @escaping (Result<String, any Error>) -> Void) {
-        let encryptedBinResult = adyenCse.encryptBin(bin: bin, publicKey: publicKey)
-        completion(encryptedBinResult)
-    }
-    
-    func validateCardNumber(cardNumber: String, enableLuhnCheck: Bool) throws -> CardNumberValidationResultDTO {
-        let validationResult = CardValidation().validateCardNumber(cardNumber: cardNumber, enableLuhnCheck: enableLuhnCheck)
-        return validationResult ? .valid : .invalidOtherReason
-    }
-    
-    func validateCardExpiryDate(expiryMonth: String, expiryYear: String) throws -> CardExpiryDateValidationResultDTO {
-        let validationResult = CardValidation().validateCardExpiryDate(expiryMonth: expiryMonth, expiryYear: expiryYear)
-        return validationResult ? .valid : .invalidOtherReason
-    }
-    
-    func validateCardSecurityCode(securityCode: String, cardBrand: String?) throws -> CardSecurityCodeValidationResultDTO {
-        let validationResult = CardValidation().validateCardSecurityCode(securityCode: securityCode, cardBrand: cardBrand)
-        return validationResult ? .valid : .invalid
-    }
-    
-    func getThreeDS2SdkVersion() throws -> String {
-        threeDS2SdkVersion
-    }
-
-    private func createSessionForDropIn(
-        adyenContext: AdyenContext,
-        actionComponentConfiguration: AdyenActionComponent.Configuration? = nil,
-        sessionId: String,
-        sessionData: String,
-        completion: @escaping (Result<SessionDTO, Error>) -> Void
-    ) throws {
-        let sessionDelegate = DropInSessionsDelegate(viewController: getViewController(), checkoutFlutter: checkoutFlutter)
-        try requestAndSetSession(
-            adyenContext: adyenContext,
-            sessionId: sessionId,
-            sessionData: sessionData,
-            sessionDelegate: sessionDelegate,
-            actionComponentConfiguration: actionComponentConfiguration,
-            completion: completion
+  func createSession(
+    sessionId: String,
+    sessionData: String,
+    configuration: Any?,
+    completion: @escaping (Result<SessionDTO, Error>) -> Void
+  ) {
+    do {
+      switch configuration {
+      case let dropInConfigurationDTO as DropInConfigurationDTO:
+        try createSessionForDropIn(
+          adyenContext: dropInConfigurationDTO.createAdyenContext(),
+          actionComponentConfiguration: dropInConfigurationDTO.threeDS2ConfigurationDTO?
+            .buildActionComponentConfiguration(),
+          sessionId: sessionId,
+          sessionData: sessionData,
+          completion: completion
         )
-    }
-
-    private func createSessionForComponent(
-        adyenContext: AdyenContext,
-        actionComponentConfiguration: AdyenActionComponent.Configuration? = nil,
-        sessionId: String,
-        sessionData: String,
-        completion: @escaping (Result<SessionDTO, Error>) -> Void
-    ) throws {
-        let sessionDelegate = ComponentSessionFlowHandler(componentFlutterApi: componentFlutterApi)
-        try requestAndSetSession(
-            adyenContext: adyenContext,
-            sessionId: sessionId,
-            sessionData: sessionData,
-            sessionDelegate: sessionDelegate,
-            actionComponentConfiguration: actionComponentConfiguration,
-            completion: completion
+      case let cardComponentConfigurationDTO as CardComponentConfigurationDTO:
+        try createSessionForComponent(
+          adyenContext: cardComponentConfigurationDTO.createAdyenContext(),
+          actionComponentConfiguration: cardComponentConfigurationDTO.threeDS2ConfigurationDTO?
+            .buildActionComponentConfiguration(),
+          sessionId: sessionId,
+          sessionData: sessionData,
+          completion: completion
         )
-    }
-
-    private func requestAndSetSession(
-        adyenContext: AdyenContext,
-        sessionId: String,
-        sessionData: String,
-        sessionDelegate: AdyenSessionDelegate,
-        actionComponentConfiguration: AdyenActionComponent.Configuration? = nil,
-        completion: @escaping (Result<SessionDTO, Error>) -> Void
-    ) throws {
-        guard let presentationDelegate = getViewController() else {
-            throw PlatformError(errorDescription: "Host view controller not available.")
-        }
-        
-        let sessionConfiguration = AdyenSession.Configuration(
-            sessionIdentifier: sessionId,
-            initialSessionData: sessionData,
-            context: adyenContext,
-            actionComponent: actionComponentConfiguration ?? .init()
+      case let blikComponentConfigurationDTO as BlikComponentConfigurationDTO:
+        try createSessionForComponent(
+          adyenContext: blikComponentConfigurationDTO.createAdyenContext(),
+          sessionId: sessionId,
+          sessionData: sessionData,
+          completion: completion
         )
-        AdyenSession.initialize(
-            with: sessionConfiguration,
-            delegate: sessionDelegate,
-            presentationDelegate: presentationDelegate
-        ) { [weak self] result in
-            do {
-                switch result {
-                case let .success(session):
-                    self?.sessionHolder.setup(
-                        session: session,
-                        sessionDelegate: sessionDelegate
-                    )
-                    let encodedPaymentMethods = try JSONEncoder().encode(session.sessionContext.paymentMethods)
-                    guard let encodedPaymentMethodsString = String(data: encodedPaymentMethods, encoding: .utf8) else {
-                        completion(Result.failure(PlatformError(errorDescription: "Encoding payment methods failed")))
-                        return
-                    }
-                    completion(Result.success(SessionDTO(
-                        id: sessionId,
-                        sessionData: sessionData,
-                        paymentMethodsJson: encodedPaymentMethodsString
-                    )))
-                case let .failure(error):
-                    completion(Result.failure(error))
-                }
-            } catch {
-                completion(Result.failure(error))
-            }
-        }
+      case let instantComponentConfigurationDTO as InstantPaymentConfigurationDTO:
+        try createSessionForComponent(
+          adyenContext: instantComponentConfigurationDTO.createAdyenContext(),
+          sessionId: sessionId,
+          sessionData: sessionData,
+          completion: completion
+        )
+      case .none, .some:
+        completion(Result.failure(PlatformError(errorDescription: "Configuration is not valid")))
+      }
+    } catch {
+      completion(Result.failure(error))
+    }
+  }
+
+  func clearSession() {
+    sessionHolder.reset()
+  }
+
+  func getReturnUrl(completion: @escaping (Result<String, Error>) -> Void) {
+    completion(
+      Result.failure(
+        PlatformError(errorDescription: "Please use your app url type instead of this method.")))
+  }
+
+  func enableConsoleLogging(loggingEnabled: Bool) {
+    AdyenLogging.isEnabled = loggingEnabled
+  }
+
+  func encryptCard(
+    unencryptedCardDTO: UnencryptedCardDTO, publicKey: String,
+    completion: @escaping (Result<EncryptedCardDTO, any Error>) -> Void
+  ) {
+    let encryptedCardResult = adyenCse.encryptCard(
+      unencryptedCardDTO: unencryptedCardDTO, publicKey: publicKey)
+    completion(encryptedCardResult)
+  }
+
+  func encryptBin(
+    bin: String, publicKey: String, completion: @escaping (Result<String, any Error>) -> Void
+  ) {
+    let encryptedBinResult = adyenCse.encryptBin(bin: bin, publicKey: publicKey)
+    completion(encryptedBinResult)
+  }
+
+  func validateCardNumber(cardNumber: String, enableLuhnCheck: Bool) throws
+    -> CardNumberValidationResultDTO
+  {
+    let validationResult = CardValidation().validateCardNumber(
+      cardNumber: cardNumber, enableLuhnCheck: enableLuhnCheck)
+    return validationResult ? .valid : .invalidOtherReason
+  }
+
+  func validateCardExpiryDate(expiryMonth: String, expiryYear: String) throws
+    -> CardExpiryDateValidationResultDTO
+  {
+    let validationResult = CardValidation().validateCardExpiryDate(
+      expiryMonth: expiryMonth, expiryYear: expiryYear)
+    return validationResult ? .valid : .invalidOtherReason
+  }
+
+  func validateCardSecurityCode(securityCode: String, cardBrand: String?) throws
+    -> CardSecurityCodeValidationResultDTO
+  {
+    let validationResult = CardValidation().validateCardSecurityCode(
+      securityCode: securityCode, cardBrand: cardBrand)
+    return validationResult ? .valid : .invalid
+  }
+
+  func getThreeDS2SdkVersion() throws -> String {
+    threeDS2SdkVersion
+  }
+
+  private func createSessionForDropIn(
+    adyenContext: AdyenContext,
+    actionComponentConfiguration: AdyenActionComponent.Configuration? = nil,
+    sessionId: String,
+    sessionData: String,
+    completion: @escaping (Result<SessionDTO, Error>) -> Void
+  ) throws {
+    let sessionDelegate = DropInSessionsDelegate(
+      viewController: getViewController(), checkoutFlutter: checkoutFlutter)
+    try requestAndSetSession(
+      adyenContext: adyenContext,
+      sessionId: sessionId,
+      sessionData: sessionData,
+      sessionDelegate: sessionDelegate,
+      actionComponentConfiguration: actionComponentConfiguration,
+      completion: completion
+    )
+  }
+
+  private func createSessionForComponent(
+    adyenContext: AdyenContext,
+    actionComponentConfiguration: AdyenActionComponent.Configuration? = nil,
+    sessionId: String,
+    sessionData: String,
+    completion: @escaping (Result<SessionDTO, Error>) -> Void
+  ) throws {
+    let sessionDelegate = ComponentSessionFlowHandler(componentFlutterApi: componentFlutterApi)
+    try requestAndSetSession(
+      adyenContext: adyenContext,
+      sessionId: sessionId,
+      sessionData: sessionData,
+      sessionDelegate: sessionDelegate,
+      actionComponentConfiguration: actionComponentConfiguration,
+      completion: completion
+    )
+  }
+
+  private func requestAndSetSession(
+    adyenContext: AdyenContext,
+    sessionId: String,
+    sessionData: String,
+    sessionDelegate: AdyenSessionDelegate,
+    actionComponentConfiguration: AdyenActionComponent.Configuration? = nil,
+    completion: @escaping (Result<SessionDTO, Error>) -> Void
+  ) throws {
+    guard let presentationDelegate = getViewController() else {
+      throw PlatformError(errorDescription: "Host view controller not available.")
     }
 
-    private func buildActionComponentConfiguration(from threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO?) -> AdyenActionComponent.Configuration? {
-        threeDS2ConfigurationDTO.map {
-            var actionComponentConfiguration = AdyenActionComponent.Configuration()
-            actionComponentConfiguration.threeDS = $0.mapToThreeDS2Configuration()
-            return actionComponentConfiguration
+    let sessionConfiguration = AdyenSession.Configuration(
+      sessionIdentifier: sessionId,
+      initialSessionData: sessionData,
+      context: adyenContext,
+      actionComponent: actionComponentConfiguration ?? .init()
+    )
+    AdyenSession.initialize(
+      with: sessionConfiguration,
+      delegate: sessionDelegate,
+      presentationDelegate: presentationDelegate
+    ) { [weak self] result in
+      do {
+        switch result {
+        case .success(let session):
+          self?.sessionHolder.setup(
+            session: session,
+            sessionDelegate: sessionDelegate
+          )
+          let encodedPaymentMethods = try JSONEncoder().encode(
+            session.sessionContext.paymentMethods)
+          guard
+            let encodedPaymentMethodsString = String(data: encodedPaymentMethods, encoding: .utf8)
+          else {
+            completion(
+              Result.failure(PlatformError(errorDescription: "Encoding payment methods failed")))
+            return
+          }
+          completion(
+            Result.success(
+              SessionDTO(
+                id: sessionId,
+                sessionData: sessionData,
+                paymentMethodsJson: encodedPaymentMethodsString
+              )))
+        case .failure(let error):
+          completion(Result.failure(error))
         }
+      } catch {
+        completion(Result.failure(error))
+      }
+    }
+  }
+
+  private func getViewController() -> UIViewController? {
+    var rootViewController = UIApplication.shared.adyen.mainKeyWindow?.rootViewController
+    while let presentedViewController = rootViewController?.presentedViewController {
+      let type = String(describing: type(of: presentedViewController))
+      // TODO: - We need to discuss how the SDK should react if a DropInNavigationController is already displayed
+      if type == "DropInNavigationController" {
+        return nil
+      } else {
+        rootViewController = presentedViewController
+      }
     }
 
-    private func getViewController() -> UIViewController? {
-        var rootViewController = UIApplication.shared.adyen.mainKeyWindow?.rootViewController
-        while let presentedViewController = rootViewController?.presentedViewController {
-            let type = String(describing: type(of: presentedViewController))
-            // TODO: - We need to discuss how the SDK should react if a DropInNavigationController is already displayed
-            if type == "DropInNavigationController" {
-                return nil
-            } else {
-                rootViewController = presentedViewController
-            }
-        }
-
-        return rootViewController
-    }
+    return rootViewController
+  }
 }

--- a/ios/adyen_checkout/Sources/adyen_checkout/CheckoutPlatformApi.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/CheckoutPlatformApi.swift
@@ -1,4 +1,3 @@
-@_spi(AdyenInternal) import Adyen
 import Foundation
 import UIKit
 
@@ -11,6 +10,7 @@ import UIKit
 #if canImport(AdyenActions)
     import AdyenActions
 #endif
+@_spi(AdyenInternal) import Adyen
 
 // TODO: Add config:
 // 1) Add Info.plist for adding photo library usage description
@@ -44,8 +44,7 @@ class CheckoutPlatformApi: CheckoutPlatformInterface {
             case let dropInConfigurationDTO as DropInConfigurationDTO:
                 try createSessionForDropIn(
                     adyenContext: dropInConfigurationDTO.createAdyenContext(),
-                    actionComponentConfiguration: dropInConfigurationDTO.threeDS2ConfigurationDTO?
-                        .buildActionComponentConfiguration(),
+                    actionComponentConfiguration: dropInConfigurationDTO.threeDS2ConfigurationDTO?.buildActionComponentConfiguration(),
                     sessionId: sessionId,
                     sessionData: sessionData,
                     completion: completion
@@ -53,8 +52,7 @@ class CheckoutPlatformApi: CheckoutPlatformInterface {
             case let cardComponentConfigurationDTO as CardComponentConfigurationDTO:
                 try createSessionForComponent(
                     adyenContext: cardComponentConfigurationDTO.createAdyenContext(),
-                    actionComponentConfiguration: cardComponentConfigurationDTO.threeDS2ConfigurationDTO?
-                        .buildActionComponentConfiguration(),
+                    actionComponentConfiguration: cardComponentConfigurationDTO.threeDS2ConfigurationDTO?.buildActionComponentConfiguration(),
                     sessionId: sessionId,
                     sessionData: sessionData,
                     completion: completion
@@ -80,64 +78,44 @@ class CheckoutPlatformApi: CheckoutPlatformInterface {
             completion(Result.failure(error))
         }
     }
-
+    
     func clearSession() {
         sessionHolder.reset()
     }
 
     func getReturnUrl(completion: @escaping (Result<String, Error>) -> Void) {
-        completion(
-            Result.failure(
-                PlatformError(errorDescription: "Please use your app url type instead of this method.")
-            )
-        )
+        completion(Result.failure(PlatformError(errorDescription: "Please use your app url type instead of this method.")))
     }
 
     func enableConsoleLogging(loggingEnabled: Bool) {
         AdyenLogging.isEnabled = loggingEnabled
     }
-
-    func encryptCard(
-        unencryptedCardDTO: UnencryptedCardDTO, publicKey: String,
-        completion: @escaping (Result<EncryptedCardDTO, any Error>) -> Void
-    ) {
-        let encryptedCardResult = adyenCse.encryptCard(
-            unencryptedCardDTO: unencryptedCardDTO, publicKey: publicKey
-        )
+    
+    func encryptCard(unencryptedCardDTO: UnencryptedCardDTO, publicKey: String, completion: @escaping (Result<EncryptedCardDTO, any Error>) -> Void) {
+        let encryptedCardResult = adyenCse.encryptCard(unencryptedCardDTO: unencryptedCardDTO, publicKey: publicKey)
         completion(encryptedCardResult)
     }
-
-    func encryptBin(
-        bin: String, publicKey: String, completion: @escaping (Result<String, any Error>) -> Void
-    ) {
+    
+    func encryptBin(bin: String, publicKey: String, completion: @escaping (Result<String, any Error>) -> Void) {
         let encryptedBinResult = adyenCse.encryptBin(bin: bin, publicKey: publicKey)
         completion(encryptedBinResult)
     }
-
-    func validateCardNumber(cardNumber: String, enableLuhnCheck: Bool) throws
-        -> CardNumberValidationResultDTO {
-        let validationResult = CardValidation().validateCardNumber(
-            cardNumber: cardNumber, enableLuhnCheck: enableLuhnCheck
-        )
+    
+    func validateCardNumber(cardNumber: String, enableLuhnCheck: Bool) throws -> CardNumberValidationResultDTO {
+        let validationResult = CardValidation().validateCardNumber(cardNumber: cardNumber, enableLuhnCheck: enableLuhnCheck)
         return validationResult ? .valid : .invalidOtherReason
     }
-
-    func validateCardExpiryDate(expiryMonth: String, expiryYear: String) throws
-        -> CardExpiryDateValidationResultDTO {
-        let validationResult = CardValidation().validateCardExpiryDate(
-            expiryMonth: expiryMonth, expiryYear: expiryYear
-        )
+    
+    func validateCardExpiryDate(expiryMonth: String, expiryYear: String) throws -> CardExpiryDateValidationResultDTO {
+        let validationResult = CardValidation().validateCardExpiryDate(expiryMonth: expiryMonth, expiryYear: expiryYear)
         return validationResult ? .valid : .invalidOtherReason
     }
-
-    func validateCardSecurityCode(securityCode: String, cardBrand: String?) throws
-        -> CardSecurityCodeValidationResultDTO {
-        let validationResult = CardValidation().validateCardSecurityCode(
-            securityCode: securityCode, cardBrand: cardBrand
-        )
+    
+    func validateCardSecurityCode(securityCode: String, cardBrand: String?) throws -> CardSecurityCodeValidationResultDTO {
+        let validationResult = CardValidation().validateCardSecurityCode(securityCode: securityCode, cardBrand: cardBrand)
         return validationResult ? .valid : .invalid
     }
-
+    
     func getThreeDS2SdkVersion() throws -> String {
         threeDS2SdkVersion
     }
@@ -149,9 +127,7 @@ class CheckoutPlatformApi: CheckoutPlatformInterface {
         sessionData: String,
         completion: @escaping (Result<SessionDTO, Error>) -> Void
     ) throws {
-        let sessionDelegate = DropInSessionsDelegate(
-            viewController: getViewController(), checkoutFlutter: checkoutFlutter
-        )
+        let sessionDelegate = DropInSessionsDelegate(viewController: getViewController(), checkoutFlutter: checkoutFlutter)
         try requestAndSetSession(
             adyenContext: adyenContext,
             sessionId: sessionId,
@@ -191,7 +167,7 @@ class CheckoutPlatformApi: CheckoutPlatformInterface {
         guard let presentationDelegate = getViewController() else {
             throw PlatformError(errorDescription: "Host view controller not available.")
         }
-
+        
         let sessionConfiguration = AdyenSession.Configuration(
             sessionIdentifier: sessionId,
             initialSessionData: sessionData,
@@ -210,26 +186,16 @@ class CheckoutPlatformApi: CheckoutPlatformInterface {
                         session: session,
                         sessionDelegate: sessionDelegate
                     )
-                    let encodedPaymentMethods = try JSONEncoder().encode(
-                        session.sessionContext.paymentMethods
-                    )
-                    guard
-                        let encodedPaymentMethodsString = String(data: encodedPaymentMethods, encoding: .utf8)
-                    else {
-                        completion(
-                            Result.failure(PlatformError(errorDescription: "Encoding payment methods failed"))
-                        )
+                    let encodedPaymentMethods = try JSONEncoder().encode(session.sessionContext.paymentMethods)
+                    guard let encodedPaymentMethodsString = String(data: encodedPaymentMethods, encoding: .utf8) else {
+                        completion(Result.failure(PlatformError(errorDescription: "Encoding payment methods failed")))
                         return
                     }
-                    completion(
-                        Result.success(
-                            SessionDTO(
-                                id: sessionId,
-                                sessionData: sessionData,
-                                paymentMethodsJson: encodedPaymentMethodsString
-                            )
-                        )
-                    )
+                    completion(Result.success(SessionDTO(
+                        id: sessionId,
+                        sessionData: sessionData,
+                        paymentMethodsJson: encodedPaymentMethodsString
+                    )))
                 case let .failure(error):
                     completion(Result.failure(error))
                 }

--- a/ios/adyen_checkout/Sources/adyen_checkout/CheckoutPlatformApi.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/CheckoutPlatformApi.swift
@@ -3,13 +3,13 @@ import Foundation
 import UIKit
 
 #if canImport(AdyenSession)
-  import AdyenSession
+    import AdyenSession
 #endif
 #if canImport(AdyenCard)
-  import AdyenCard
+    import AdyenCard
 #endif
 #if canImport(AdyenActions)
-  import AdyenActions
+    import AdyenActions
 #endif
 
 // TODO: Add config:
@@ -18,231 +18,239 @@ import UIKit
 // 3) Add AppDelegate redirect
 
 class CheckoutPlatformApi: CheckoutPlatformInterface {
-  private let checkoutFlutter: CheckoutFlutterInterface
-  private let componentFlutterApi: ComponentFlutterInterface
-  private let sessionHolder: SessionHolder
-  private let adyenCse: AdyenCSE = .init()
+    private let checkoutFlutter: CheckoutFlutterInterface
+    private let componentFlutterApi: ComponentFlutterInterface
+    private let sessionHolder: SessionHolder
+    private let adyenCse: AdyenCSE = .init()
 
-  init(
-    checkoutFlutter: CheckoutFlutterInterface,
-    componentFlutterApi: ComponentFlutterInterface,
-    sessionHolder: SessionHolder
-  ) {
-    self.checkoutFlutter = checkoutFlutter
-    self.componentFlutterApi = componentFlutterApi
-    self.sessionHolder = sessionHolder
-  }
-
-  func createSession(
-    sessionId: String,
-    sessionData: String,
-    configuration: Any?,
-    completion: @escaping (Result<SessionDTO, Error>) -> Void
-  ) {
-    do {
-      switch configuration {
-      case let dropInConfigurationDTO as DropInConfigurationDTO:
-        try createSessionForDropIn(
-          adyenContext: dropInConfigurationDTO.createAdyenContext(),
-          actionComponentConfiguration: dropInConfigurationDTO.threeDS2ConfigurationDTO?
-            .buildActionComponentConfiguration(),
-          sessionId: sessionId,
-          sessionData: sessionData,
-          completion: completion
-        )
-      case let cardComponentConfigurationDTO as CardComponentConfigurationDTO:
-        try createSessionForComponent(
-          adyenContext: cardComponentConfigurationDTO.createAdyenContext(),
-          actionComponentConfiguration: cardComponentConfigurationDTO.threeDS2ConfigurationDTO?
-            .buildActionComponentConfiguration(),
-          sessionId: sessionId,
-          sessionData: sessionData,
-          completion: completion
-        )
-      case let blikComponentConfigurationDTO as BlikComponentConfigurationDTO:
-        try createSessionForComponent(
-          adyenContext: blikComponentConfigurationDTO.createAdyenContext(),
-          sessionId: sessionId,
-          sessionData: sessionData,
-          completion: completion
-        )
-      case let instantComponentConfigurationDTO as InstantPaymentConfigurationDTO:
-        try createSessionForComponent(
-          adyenContext: instantComponentConfigurationDTO.createAdyenContext(),
-          sessionId: sessionId,
-          sessionData: sessionData,
-          completion: completion
-        )
-      case .none, .some:
-        completion(Result.failure(PlatformError(errorDescription: "Configuration is not valid")))
-      }
-    } catch {
-      completion(Result.failure(error))
-    }
-  }
-
-  func clearSession() {
-    sessionHolder.reset()
-  }
-
-  func getReturnUrl(completion: @escaping (Result<String, Error>) -> Void) {
-    completion(
-      Result.failure(
-        PlatformError(errorDescription: "Please use your app url type instead of this method.")))
-  }
-
-  func enableConsoleLogging(loggingEnabled: Bool) {
-    AdyenLogging.isEnabled = loggingEnabled
-  }
-
-  func encryptCard(
-    unencryptedCardDTO: UnencryptedCardDTO, publicKey: String,
-    completion: @escaping (Result<EncryptedCardDTO, any Error>) -> Void
-  ) {
-    let encryptedCardResult = adyenCse.encryptCard(
-      unencryptedCardDTO: unencryptedCardDTO, publicKey: publicKey)
-    completion(encryptedCardResult)
-  }
-
-  func encryptBin(
-    bin: String, publicKey: String, completion: @escaping (Result<String, any Error>) -> Void
-  ) {
-    let encryptedBinResult = adyenCse.encryptBin(bin: bin, publicKey: publicKey)
-    completion(encryptedBinResult)
-  }
-
-  func validateCardNumber(cardNumber: String, enableLuhnCheck: Bool) throws
-    -> CardNumberValidationResultDTO
-  {
-    let validationResult = CardValidation().validateCardNumber(
-      cardNumber: cardNumber, enableLuhnCheck: enableLuhnCheck)
-    return validationResult ? .valid : .invalidOtherReason
-  }
-
-  func validateCardExpiryDate(expiryMonth: String, expiryYear: String) throws
-    -> CardExpiryDateValidationResultDTO
-  {
-    let validationResult = CardValidation().validateCardExpiryDate(
-      expiryMonth: expiryMonth, expiryYear: expiryYear)
-    return validationResult ? .valid : .invalidOtherReason
-  }
-
-  func validateCardSecurityCode(securityCode: String, cardBrand: String?) throws
-    -> CardSecurityCodeValidationResultDTO
-  {
-    let validationResult = CardValidation().validateCardSecurityCode(
-      securityCode: securityCode, cardBrand: cardBrand)
-    return validationResult ? .valid : .invalid
-  }
-
-  func getThreeDS2SdkVersion() throws -> String {
-    threeDS2SdkVersion
-  }
-
-  private func createSessionForDropIn(
-    adyenContext: AdyenContext,
-    actionComponentConfiguration: AdyenActionComponent.Configuration? = nil,
-    sessionId: String,
-    sessionData: String,
-    completion: @escaping (Result<SessionDTO, Error>) -> Void
-  ) throws {
-    let sessionDelegate = DropInSessionsDelegate(
-      viewController: getViewController(), checkoutFlutter: checkoutFlutter)
-    try requestAndSetSession(
-      adyenContext: adyenContext,
-      sessionId: sessionId,
-      sessionData: sessionData,
-      sessionDelegate: sessionDelegate,
-      actionComponentConfiguration: actionComponentConfiguration,
-      completion: completion
-    )
-  }
-
-  private func createSessionForComponent(
-    adyenContext: AdyenContext,
-    actionComponentConfiguration: AdyenActionComponent.Configuration? = nil,
-    sessionId: String,
-    sessionData: String,
-    completion: @escaping (Result<SessionDTO, Error>) -> Void
-  ) throws {
-    let sessionDelegate = ComponentSessionFlowHandler(componentFlutterApi: componentFlutterApi)
-    try requestAndSetSession(
-      adyenContext: adyenContext,
-      sessionId: sessionId,
-      sessionData: sessionData,
-      sessionDelegate: sessionDelegate,
-      actionComponentConfiguration: actionComponentConfiguration,
-      completion: completion
-    )
-  }
-
-  private func requestAndSetSession(
-    adyenContext: AdyenContext,
-    sessionId: String,
-    sessionData: String,
-    sessionDelegate: AdyenSessionDelegate,
-    actionComponentConfiguration: AdyenActionComponent.Configuration? = nil,
-    completion: @escaping (Result<SessionDTO, Error>) -> Void
-  ) throws {
-    guard let presentationDelegate = getViewController() else {
-      throw PlatformError(errorDescription: "Host view controller not available.")
+    init(
+        checkoutFlutter: CheckoutFlutterInterface,
+        componentFlutterApi: ComponentFlutterInterface,
+        sessionHolder: SessionHolder
+    ) {
+        self.checkoutFlutter = checkoutFlutter
+        self.componentFlutterApi = componentFlutterApi
+        self.sessionHolder = sessionHolder
     }
 
-    let sessionConfiguration = AdyenSession.Configuration(
-      sessionIdentifier: sessionId,
-      initialSessionData: sessionData,
-      context: adyenContext,
-      actionComponent: actionComponentConfiguration ?? .init()
-    )
-    AdyenSession.initialize(
-      with: sessionConfiguration,
-      delegate: sessionDelegate,
-      presentationDelegate: presentationDelegate
-    ) { [weak self] result in
-      do {
-        switch result {
-        case .success(let session):
-          self?.sessionHolder.setup(
-            session: session,
-            sessionDelegate: sessionDelegate
-          )
-          let encodedPaymentMethods = try JSONEncoder().encode(
-            session.sessionContext.paymentMethods)
-          guard
-            let encodedPaymentMethodsString = String(data: encodedPaymentMethods, encoding: .utf8)
-          else {
-            completion(
-              Result.failure(PlatformError(errorDescription: "Encoding payment methods failed")))
-            return
-          }
-          completion(
-            Result.success(
-              SessionDTO(
-                id: sessionId,
-                sessionData: sessionData,
-                paymentMethodsJson: encodedPaymentMethodsString
-              )))
-        case .failure(let error):
-          completion(Result.failure(error))
+    func createSession(
+        sessionId: String,
+        sessionData: String,
+        configuration: Any?,
+        completion: @escaping (Result<SessionDTO, Error>) -> Void
+    ) {
+        do {
+            switch configuration {
+            case let dropInConfigurationDTO as DropInConfigurationDTO:
+                try createSessionForDropIn(
+                    adyenContext: dropInConfigurationDTO.createAdyenContext(),
+                    actionComponentConfiguration: dropInConfigurationDTO.threeDS2ConfigurationDTO?
+                        .buildActionComponentConfiguration(),
+                    sessionId: sessionId,
+                    sessionData: sessionData,
+                    completion: completion
+                )
+            case let cardComponentConfigurationDTO as CardComponentConfigurationDTO:
+                try createSessionForComponent(
+                    adyenContext: cardComponentConfigurationDTO.createAdyenContext(),
+                    actionComponentConfiguration: cardComponentConfigurationDTO.threeDS2ConfigurationDTO?
+                        .buildActionComponentConfiguration(),
+                    sessionId: sessionId,
+                    sessionData: sessionData,
+                    completion: completion
+                )
+            case let blikComponentConfigurationDTO as BlikComponentConfigurationDTO:
+                try createSessionForComponent(
+                    adyenContext: blikComponentConfigurationDTO.createAdyenContext(),
+                    sessionId: sessionId,
+                    sessionData: sessionData,
+                    completion: completion
+                )
+            case let instantComponentConfigurationDTO as InstantPaymentConfigurationDTO:
+                try createSessionForComponent(
+                    adyenContext: instantComponentConfigurationDTO.createAdyenContext(),
+                    sessionId: sessionId,
+                    sessionData: sessionData,
+                    completion: completion
+                )
+            case .none, .some:
+                completion(Result.failure(PlatformError(errorDescription: "Configuration is not valid")))
+            }
+        } catch {
+            completion(Result.failure(error))
         }
-      } catch {
-        completion(Result.failure(error))
-      }
-    }
-  }
-
-  private func getViewController() -> UIViewController? {
-    var rootViewController = UIApplication.shared.adyen.mainKeyWindow?.rootViewController
-    while let presentedViewController = rootViewController?.presentedViewController {
-      let type = String(describing: type(of: presentedViewController))
-      // TODO: - We need to discuss how the SDK should react if a DropInNavigationController is already displayed
-      if type == "DropInNavigationController" {
-        return nil
-      } else {
-        rootViewController = presentedViewController
-      }
     }
 
-    return rootViewController
-  }
+    func clearSession() {
+        sessionHolder.reset()
+    }
+
+    func getReturnUrl(completion: @escaping (Result<String, Error>) -> Void) {
+        completion(
+            Result.failure(
+                PlatformError(errorDescription: "Please use your app url type instead of this method.")
+            )
+        )
+    }
+
+    func enableConsoleLogging(loggingEnabled: Bool) {
+        AdyenLogging.isEnabled = loggingEnabled
+    }
+
+    func encryptCard(
+        unencryptedCardDTO: UnencryptedCardDTO, publicKey: String,
+        completion: @escaping (Result<EncryptedCardDTO, any Error>) -> Void
+    ) {
+        let encryptedCardResult = adyenCse.encryptCard(
+            unencryptedCardDTO: unencryptedCardDTO, publicKey: publicKey
+        )
+        completion(encryptedCardResult)
+    }
+
+    func encryptBin(
+        bin: String, publicKey: String, completion: @escaping (Result<String, any Error>) -> Void
+    ) {
+        let encryptedBinResult = adyenCse.encryptBin(bin: bin, publicKey: publicKey)
+        completion(encryptedBinResult)
+    }
+
+    func validateCardNumber(cardNumber: String, enableLuhnCheck: Bool) throws
+        -> CardNumberValidationResultDTO {
+        let validationResult = CardValidation().validateCardNumber(
+            cardNumber: cardNumber, enableLuhnCheck: enableLuhnCheck
+        )
+        return validationResult ? .valid : .invalidOtherReason
+    }
+
+    func validateCardExpiryDate(expiryMonth: String, expiryYear: String) throws
+        -> CardExpiryDateValidationResultDTO {
+        let validationResult = CardValidation().validateCardExpiryDate(
+            expiryMonth: expiryMonth, expiryYear: expiryYear
+        )
+        return validationResult ? .valid : .invalidOtherReason
+    }
+
+    func validateCardSecurityCode(securityCode: String, cardBrand: String?) throws
+        -> CardSecurityCodeValidationResultDTO {
+        let validationResult = CardValidation().validateCardSecurityCode(
+            securityCode: securityCode, cardBrand: cardBrand
+        )
+        return validationResult ? .valid : .invalid
+    }
+
+    func getThreeDS2SdkVersion() throws -> String {
+        threeDS2SdkVersion
+    }
+
+    private func createSessionForDropIn(
+        adyenContext: AdyenContext,
+        actionComponentConfiguration: AdyenActionComponent.Configuration? = nil,
+        sessionId: String,
+        sessionData: String,
+        completion: @escaping (Result<SessionDTO, Error>) -> Void
+    ) throws {
+        let sessionDelegate = DropInSessionsDelegate(
+            viewController: getViewController(), checkoutFlutter: checkoutFlutter
+        )
+        try requestAndSetSession(
+            adyenContext: adyenContext,
+            sessionId: sessionId,
+            sessionData: sessionData,
+            sessionDelegate: sessionDelegate,
+            actionComponentConfiguration: actionComponentConfiguration,
+            completion: completion
+        )
+    }
+
+    private func createSessionForComponent(
+        adyenContext: AdyenContext,
+        actionComponentConfiguration: AdyenActionComponent.Configuration? = nil,
+        sessionId: String,
+        sessionData: String,
+        completion: @escaping (Result<SessionDTO, Error>) -> Void
+    ) throws {
+        let sessionDelegate = ComponentSessionFlowHandler(componentFlutterApi: componentFlutterApi)
+        try requestAndSetSession(
+            adyenContext: adyenContext,
+            sessionId: sessionId,
+            sessionData: sessionData,
+            sessionDelegate: sessionDelegate,
+            actionComponentConfiguration: actionComponentConfiguration,
+            completion: completion
+        )
+    }
+
+    private func requestAndSetSession(
+        adyenContext: AdyenContext,
+        sessionId: String,
+        sessionData: String,
+        sessionDelegate: AdyenSessionDelegate,
+        actionComponentConfiguration: AdyenActionComponent.Configuration? = nil,
+        completion: @escaping (Result<SessionDTO, Error>) -> Void
+    ) throws {
+        guard let presentationDelegate = getViewController() else {
+            throw PlatformError(errorDescription: "Host view controller not available.")
+        }
+
+        let sessionConfiguration = AdyenSession.Configuration(
+            sessionIdentifier: sessionId,
+            initialSessionData: sessionData,
+            context: adyenContext,
+            actionComponent: actionComponentConfiguration ?? .init()
+        )
+        AdyenSession.initialize(
+            with: sessionConfiguration,
+            delegate: sessionDelegate,
+            presentationDelegate: presentationDelegate
+        ) { [weak self] result in
+            do {
+                switch result {
+                case let .success(session):
+                    self?.sessionHolder.setup(
+                        session: session,
+                        sessionDelegate: sessionDelegate
+                    )
+                    let encodedPaymentMethods = try JSONEncoder().encode(
+                        session.sessionContext.paymentMethods
+                    )
+                    guard
+                        let encodedPaymentMethodsString = String(data: encodedPaymentMethods, encoding: .utf8)
+                    else {
+                        completion(
+                            Result.failure(PlatformError(errorDescription: "Encoding payment methods failed"))
+                        )
+                        return
+                    }
+                    completion(
+                        Result.success(
+                            SessionDTO(
+                                id: sessionId,
+                                sessionData: sessionData,
+                                paymentMethodsJson: encodedPaymentMethodsString
+                            )
+                        )
+                    )
+                case let .failure(error):
+                    completion(Result.failure(error))
+                }
+            } catch {
+                completion(Result.failure(error))
+            }
+        }
+    }
+
+    private func getViewController() -> UIViewController? {
+        var rootViewController = UIApplication.shared.adyen.mainKeyWindow?.rootViewController
+        while let presentedViewController = rootViewController?.presentedViewController {
+            let type = String(describing: type(of: presentedViewController))
+            // TODO: - We need to discuss how the SDK should react if a DropInNavigationController is already displayed
+            if type == "DropInNavigationController" {
+                return nil
+            } else {
+                rootViewController = presentedViewController
+            }
+        }
+
+        return rootViewController
+    }
 }

--- a/ios/adyen_checkout/Sources/adyen_checkout/components/action/ActionComponentManager.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/components/action/ActionComponentManager.swift
@@ -1,10 +1,9 @@
 @_spi(AdyenInternal) import Adyen
-import Foundation
-import UIKit
-
 #if canImport(AdyenActions)
     import AdyenActions
 #endif
+import Foundation
+import UIKit
 
 class ActionComponentManager {
     private let componentFlutterApi: ComponentFlutterInterface
@@ -12,23 +11,18 @@ class ActionComponentManager {
     enum Constants {
         static let actionComponentId: String = "ACTION_COMPONENT"
     }
-
+    
     init(componentFlutterApi: ComponentFlutterInterface) {
         self.componentFlutterApi = componentFlutterApi
     }
-
-    func handleAction(
-        actionComponentConfiguration: ActionComponentConfigurationDTO, componentId: String,
-        actionResponse: [String?: Any?]
-    ) {
+    
+    func handleAction(actionComponentConfiguration: ActionComponentConfigurationDTO, componentId: String, actionResponse: [String?: Any?]) {
         do {
             let adyenContext = try actionComponentConfiguration.createAdyenContext()
-            let configuration = actionComponentConfiguration.threeDS2ConfigurationDTO?
-                .buildActionComponentConfiguration()
-            actionComponent =
-                configuration.map {
-                    AdyenActionComponent(context: adyenContext, configuration: $0)
-                } ?? AdyenActionComponent(context: adyenContext)
+            let configuration = actionComponentConfiguration.threeDS2ConfigurationDTO?.buildActionComponentConfiguration()
+            actionComponent = configuration.map {
+                AdyenActionComponent(context: adyenContext, configuration: $0)
+            } ?? AdyenActionComponent(context: adyenContext)
             actionComponent?.delegate = self
             actionComponent?.presentationDelegate = getViewController()
             let jsonData = try JSONSerialization.data(withJSONObject: actionResponse, options: [])
@@ -38,12 +32,12 @@ class ActionComponentManager {
             sendErrorToFlutterLayer(error: error)
         }
     }
-
+    
     func getViewController() -> UIViewController? {
         let rootViewController = UIApplication.shared.adyen.mainKeyWindow?.rootViewController
         return rootViewController?.adyen.topPresenter
     }
-
+    
     func finalizeCallback(success: Bool, completion: @escaping (() -> Void)) {
         actionComponent?.finalizeIfNeeded(with: success) { [weak self] in
             self?.getViewController()?.dismiss(animated: true) {
@@ -51,7 +45,7 @@ class ActionComponentManager {
             }
         }
     }
-
+    
     func onDispose() {
         actionComponent = nil
     }
@@ -75,9 +69,7 @@ class ActionComponentManager {
 extension ActionComponentManager: ActionComponentDelegate {
     func didProvide(_ data: Adyen.ActionComponentData, from component: any Adyen.ActionComponent) {
         do {
-            let actionComponentData = ActionComponentDataModel(
-                details: data.details.encodable, paymentData: data.paymentData
-            )
+            let actionComponentData = ActionComponentDataModel(details: data.details.encodable, paymentData: data.paymentData)
             let actionComponentDataJson = try JSONEncoder().encode(actionComponentData)
             let actionComponentDataString = String(data: actionComponentDataJson, encoding: .utf8)
             let componentCommunicationModel = ComponentCommunicationModel(
@@ -96,15 +88,15 @@ extension ActionComponentManager: ActionComponentDelegate {
             }
         }
     }
-
+    
     func didComplete(from component: any Adyen.ActionComponent) {
         // Only for voucher payment method - currently not supported.
     }
-
+    
     func didFail(with error: any Error, from component: any Adyen.ActionComponent) {
         finalizeCallback(success: false) { [weak self] in
             self?.sendErrorToFlutterLayer(error: error)
         }
     }
-
+    
 }

--- a/ios/adyen_checkout/Sources/adyen_checkout/components/action/ActionComponentManager.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/components/action/ActionComponentManager.swift
@@ -1,99 +1,109 @@
 @_spi(AdyenInternal) import Adyen
-#if canImport(AdyenActions)
-    import AdyenActions
-#endif
 import Foundation
 import UIKit
 
-class ActionComponentManager {
-    private let componentFlutterApi: ComponentFlutterInterface
-    private var actionComponent: AdyenActionComponent?
-    enum Constants {
-        static let actionComponentId: String = "ACTION_COMPONENT"
-    }
-    
-    init(componentFlutterApi: ComponentFlutterInterface) {
-        self.componentFlutterApi = componentFlutterApi
-    }
-    
-    func handleAction(actionComponentConfiguration: ActionComponentConfigurationDTO, componentId: String, actionResponse: [String?: Any?]) {
-        do {
-            let adyenContext = try actionComponentConfiguration.createAdyenContext()
-            actionComponent = AdyenActionComponent(context: adyenContext)
-            actionComponent?.delegate = self
-            actionComponent?.presentationDelegate = getViewController()
-            let jsonData = try JSONSerialization.data(withJSONObject: actionResponse, options: [])
-            let action = try JSONDecoder().decode(Action.self, from: jsonData)
-            actionComponent?.handle(action)
-        } catch {
-            sendErrorToFlutterLayer(error: error)
-        }
-    }
-    
-    func getViewController() -> UIViewController? {
-        let rootViewController = UIApplication.shared.adyen.mainKeyWindow?.rootViewController
-        return rootViewController?.adyen.topPresenter
-    }
-    
-    func finalizeCallback(success: Bool, completion: @escaping (() -> Void)) {
-        actionComponent?.finalizeIfNeeded(with: success) { [weak self] in
-            self?.getViewController()?.dismiss(animated: true) {
-                completion()
-            }
-        }
-    }
-    
-    func onDispose() {
-        actionComponent = nil
-    }
+#if canImport(AdyenActions)
+  import AdyenActions
+#endif
 
-    private func sendErrorToFlutterLayer(error: Error) {
-        let componentCommunicationModel = ComponentCommunicationModel(
-            type: ComponentCommunicationType.result,
-            componentId: Constants.actionComponentId,
-            paymentResult: PaymentResultDTO(
-                type: .from(error: error),
-                reason: error.localizedDescription
-            )
-        )
-        componentFlutterApi.onComponentCommunication(
-            componentCommunicationModel: componentCommunicationModel,
-            completion: { _ in }
-        )
+class ActionComponentManager {
+  private let componentFlutterApi: ComponentFlutterInterface
+  private var actionComponent: AdyenActionComponent?
+  enum Constants {
+    static let actionComponentId: String = "ACTION_COMPONENT"
+  }
+
+  init(componentFlutterApi: ComponentFlutterInterface) {
+    self.componentFlutterApi = componentFlutterApi
+  }
+
+  func handleAction(
+    actionComponentConfiguration: ActionComponentConfigurationDTO, componentId: String,
+    actionResponse: [String?: Any?]
+  ) {
+    do {
+      let adyenContext = try actionComponentConfiguration.createAdyenContext()
+      let configuration = actionComponentConfiguration.threeDS2ConfigurationDTO?
+        .buildActionComponentConfiguration()
+      actionComponent =
+        configuration.map {
+          AdyenActionComponent(context: adyenContext, configuration: $0)
+        } ?? AdyenActionComponent(context: adyenContext)
+      actionComponent?.delegate = self
+      actionComponent?.presentationDelegate = getViewController()
+      let jsonData = try JSONSerialization.data(withJSONObject: actionResponse, options: [])
+      let action = try JSONDecoder().decode(Action.self, from: jsonData)
+      actionComponent?.handle(action)
+    } catch {
+      sendErrorToFlutterLayer(error: error)
     }
+  }
+
+  func getViewController() -> UIViewController? {
+    let rootViewController = UIApplication.shared.adyen.mainKeyWindow?.rootViewController
+    return rootViewController?.adyen.topPresenter
+  }
+
+  func finalizeCallback(success: Bool, completion: @escaping (() -> Void)) {
+    actionComponent?.finalizeIfNeeded(with: success) { [weak self] in
+      self?.getViewController()?.dismiss(animated: true) {
+        completion()
+      }
+    }
+  }
+
+  func onDispose() {
+    actionComponent = nil
+  }
+
+  private func sendErrorToFlutterLayer(error: Error) {
+    let componentCommunicationModel = ComponentCommunicationModel(
+      type: ComponentCommunicationType.result,
+      componentId: Constants.actionComponentId,
+      paymentResult: PaymentResultDTO(
+        type: .from(error: error),
+        reason: error.localizedDescription
+      )
+    )
+    componentFlutterApi.onComponentCommunication(
+      componentCommunicationModel: componentCommunicationModel,
+      completion: { _ in }
+    )
+  }
 }
 
 extension ActionComponentManager: ActionComponentDelegate {
-    func didProvide(_ data: Adyen.ActionComponentData, from component: any Adyen.ActionComponent) {
-        do {
-            let actionComponentData = ActionComponentDataModel(details: data.details.encodable, paymentData: data.paymentData)
-            let actionComponentDataJson = try JSONEncoder().encode(actionComponentData)
-            let actionComponentDataString = String(data: actionComponentDataJson, encoding: .utf8)
-            let componentCommunicationModel = ComponentCommunicationModel(
-                type: ComponentCommunicationType.additionalDetails,
-                componentId: Constants.actionComponentId,
-                data: actionComponentDataString
-            )
-            componentFlutterApi.onComponentCommunication(
-                componentCommunicationModel: componentCommunicationModel,
-                completion: { _ in }
-            )
-            finalizeCallback(success: true) {}
-        } catch {
-            finalizeCallback(success: false) { [weak self] in
-                self?.sendErrorToFlutterLayer(error: error)
-            }
-        }
+  func didProvide(_ data: Adyen.ActionComponentData, from component: any Adyen.ActionComponent) {
+    do {
+      let actionComponentData = ActionComponentDataModel(
+        details: data.details.encodable, paymentData: data.paymentData)
+      let actionComponentDataJson = try JSONEncoder().encode(actionComponentData)
+      let actionComponentDataString = String(data: actionComponentDataJson, encoding: .utf8)
+      let componentCommunicationModel = ComponentCommunicationModel(
+        type: ComponentCommunicationType.additionalDetails,
+        componentId: Constants.actionComponentId,
+        data: actionComponentDataString
+      )
+      componentFlutterApi.onComponentCommunication(
+        componentCommunicationModel: componentCommunicationModel,
+        completion: { _ in }
+      )
+      finalizeCallback(success: true) {}
+    } catch {
+      finalizeCallback(success: false) { [weak self] in
+        self?.sendErrorToFlutterLayer(error: error)
+      }
     }
-    
-    func didComplete(from component: any Adyen.ActionComponent) {
-        // Only for voucher payment method - currently not supported.
+  }
+
+  func didComplete(from component: any Adyen.ActionComponent) {
+    // Only for voucher payment method - currently not supported.
+  }
+
+  func didFail(with error: any Error, from component: any Adyen.ActionComponent) {
+    finalizeCallback(success: false) { [weak self] in
+      self?.sendErrorToFlutterLayer(error: error)
     }
-    
-    func didFail(with error: any Error, from component: any Adyen.ActionComponent) {
-        finalizeCallback(success: false) { [weak self] in
-            self?.sendErrorToFlutterLayer(error: error)
-        }
-    }
-    
+  }
+
 }

--- a/ios/adyen_checkout/Sources/adyen_checkout/components/action/ActionComponentManager.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/components/action/ActionComponentManager.swift
@@ -3,107 +3,108 @@ import Foundation
 import UIKit
 
 #if canImport(AdyenActions)
-  import AdyenActions
+    import AdyenActions
 #endif
 
 class ActionComponentManager {
-  private let componentFlutterApi: ComponentFlutterInterface
-  private var actionComponent: AdyenActionComponent?
-  enum Constants {
-    static let actionComponentId: String = "ACTION_COMPONENT"
-  }
-
-  init(componentFlutterApi: ComponentFlutterInterface) {
-    self.componentFlutterApi = componentFlutterApi
-  }
-
-  func handleAction(
-    actionComponentConfiguration: ActionComponentConfigurationDTO, componentId: String,
-    actionResponse: [String?: Any?]
-  ) {
-    do {
-      let adyenContext = try actionComponentConfiguration.createAdyenContext()
-      let configuration = actionComponentConfiguration.threeDS2ConfigurationDTO?
-        .buildActionComponentConfiguration()
-      actionComponent =
-        configuration.map {
-          AdyenActionComponent(context: adyenContext, configuration: $0)
-        } ?? AdyenActionComponent(context: adyenContext)
-      actionComponent?.delegate = self
-      actionComponent?.presentationDelegate = getViewController()
-      let jsonData = try JSONSerialization.data(withJSONObject: actionResponse, options: [])
-      let action = try JSONDecoder().decode(Action.self, from: jsonData)
-      actionComponent?.handle(action)
-    } catch {
-      sendErrorToFlutterLayer(error: error)
+    private let componentFlutterApi: ComponentFlutterInterface
+    private var actionComponent: AdyenActionComponent?
+    enum Constants {
+        static let actionComponentId: String = "ACTION_COMPONENT"
     }
-  }
 
-  func getViewController() -> UIViewController? {
-    let rootViewController = UIApplication.shared.adyen.mainKeyWindow?.rootViewController
-    return rootViewController?.adyen.topPresenter
-  }
-
-  func finalizeCallback(success: Bool, completion: @escaping (() -> Void)) {
-    actionComponent?.finalizeIfNeeded(with: success) { [weak self] in
-      self?.getViewController()?.dismiss(animated: true) {
-        completion()
-      }
+    init(componentFlutterApi: ComponentFlutterInterface) {
+        self.componentFlutterApi = componentFlutterApi
     }
-  }
 
-  func onDispose() {
-    actionComponent = nil
-  }
+    func handleAction(
+        actionComponentConfiguration: ActionComponentConfigurationDTO, componentId: String,
+        actionResponse: [String?: Any?]
+    ) {
+        do {
+            let adyenContext = try actionComponentConfiguration.createAdyenContext()
+            let configuration = actionComponentConfiguration.threeDS2ConfigurationDTO?
+                .buildActionComponentConfiguration()
+            actionComponent =
+                configuration.map {
+                    AdyenActionComponent(context: adyenContext, configuration: $0)
+                } ?? AdyenActionComponent(context: adyenContext)
+            actionComponent?.delegate = self
+            actionComponent?.presentationDelegate = getViewController()
+            let jsonData = try JSONSerialization.data(withJSONObject: actionResponse, options: [])
+            let action = try JSONDecoder().decode(Action.self, from: jsonData)
+            actionComponent?.handle(action)
+        } catch {
+            sendErrorToFlutterLayer(error: error)
+        }
+    }
 
-  private func sendErrorToFlutterLayer(error: Error) {
-    let componentCommunicationModel = ComponentCommunicationModel(
-      type: ComponentCommunicationType.result,
-      componentId: Constants.actionComponentId,
-      paymentResult: PaymentResultDTO(
-        type: .from(error: error),
-        reason: error.localizedDescription
-      )
-    )
-    componentFlutterApi.onComponentCommunication(
-      componentCommunicationModel: componentCommunicationModel,
-      completion: { _ in }
-    )
-  }
+    func getViewController() -> UIViewController? {
+        let rootViewController = UIApplication.shared.adyen.mainKeyWindow?.rootViewController
+        return rootViewController?.adyen.topPresenter
+    }
+
+    func finalizeCallback(success: Bool, completion: @escaping (() -> Void)) {
+        actionComponent?.finalizeIfNeeded(with: success) { [weak self] in
+            self?.getViewController()?.dismiss(animated: true) {
+                completion()
+            }
+        }
+    }
+
+    func onDispose() {
+        actionComponent = nil
+    }
+
+    private func sendErrorToFlutterLayer(error: Error) {
+        let componentCommunicationModel = ComponentCommunicationModel(
+            type: ComponentCommunicationType.result,
+            componentId: Constants.actionComponentId,
+            paymentResult: PaymentResultDTO(
+                type: .from(error: error),
+                reason: error.localizedDescription
+            )
+        )
+        componentFlutterApi.onComponentCommunication(
+            componentCommunicationModel: componentCommunicationModel,
+            completion: { _ in }
+        )
+    }
 }
 
 extension ActionComponentManager: ActionComponentDelegate {
-  func didProvide(_ data: Adyen.ActionComponentData, from component: any Adyen.ActionComponent) {
-    do {
-      let actionComponentData = ActionComponentDataModel(
-        details: data.details.encodable, paymentData: data.paymentData)
-      let actionComponentDataJson = try JSONEncoder().encode(actionComponentData)
-      let actionComponentDataString = String(data: actionComponentDataJson, encoding: .utf8)
-      let componentCommunicationModel = ComponentCommunicationModel(
-        type: ComponentCommunicationType.additionalDetails,
-        componentId: Constants.actionComponentId,
-        data: actionComponentDataString
-      )
-      componentFlutterApi.onComponentCommunication(
-        componentCommunicationModel: componentCommunicationModel,
-        completion: { _ in }
-      )
-      finalizeCallback(success: true) {}
-    } catch {
-      finalizeCallback(success: false) { [weak self] in
-        self?.sendErrorToFlutterLayer(error: error)
-      }
+    func didProvide(_ data: Adyen.ActionComponentData, from component: any Adyen.ActionComponent) {
+        do {
+            let actionComponentData = ActionComponentDataModel(
+                details: data.details.encodable, paymentData: data.paymentData
+            )
+            let actionComponentDataJson = try JSONEncoder().encode(actionComponentData)
+            let actionComponentDataString = String(data: actionComponentDataJson, encoding: .utf8)
+            let componentCommunicationModel = ComponentCommunicationModel(
+                type: ComponentCommunicationType.additionalDetails,
+                componentId: Constants.actionComponentId,
+                data: actionComponentDataString
+            )
+            componentFlutterApi.onComponentCommunication(
+                componentCommunicationModel: componentCommunicationModel,
+                completion: { _ in }
+            )
+            finalizeCallback(success: true) {}
+        } catch {
+            finalizeCallback(success: false) { [weak self] in
+                self?.sendErrorToFlutterLayer(error: error)
+            }
+        }
     }
-  }
 
-  func didComplete(from component: any Adyen.ActionComponent) {
-    // Only for voucher payment method - currently not supported.
-  }
-
-  func didFail(with error: any Error, from component: any Adyen.ActionComponent) {
-    finalizeCallback(success: false) { [weak self] in
-      self?.sendErrorToFlutterLayer(error: error)
+    func didComplete(from component: any Adyen.ActionComponent) {
+        // Only for voucher payment method - currently not supported.
     }
-  }
+
+    func didFail(with error: any Error, from component: any Adyen.ActionComponent) {
+        finalizeCallback(success: false) { [weak self] in
+            self?.sendErrorToFlutterLayer(error: error)
+        }
+    }
 
 }

--- a/ios/adyen_checkout/Sources/adyen_checkout/generated/PlatformApi.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/generated/PlatformApi.swift
@@ -4,2712 +4,2654 @@
 import Foundation
 
 #if os(iOS)
-    import Flutter
+  import Flutter
 #elseif os(macOS)
-    import FlutterMacOS
+  import FlutterMacOS
 #else
-    #error("Unsupported platform.")
+  #error("Unsupported platform.")
 #endif
 
 /// Error class for passing custom error details to Dart side.
 final class AdyenPigeonError: Error {
-    let code: String
-    let message: String?
-    let details: Any?
+  let code: String
+  let message: String?
+  let details: Any?
 
-    init(code: String, message: String?, details: Any?) {
-        self.code = code
-        self.message = message
-        self.details = details
-    }
+  init(code: String, message: String?, details: Any?) {
+    self.code = code
+    self.message = message
+    self.details = details
+  }
 
-    var localizedDescription: String {
-        "AdyenPigeonError(code: \(code), message: \(message ?? "<nil>"), details: \(details ?? "<nil>")"
-    }
+  var localizedDescription: String {
+    return
+      "AdyenPigeonError(code: \(code), message: \(message ?? "<nil>"), details: \(details ?? "<nil>")"
+      }
 }
 
 private func wrapResult(_ result: Any?) -> [Any?] {
-    [result]
+  return [result]
 }
 
 private func wrapError(_ error: Any) -> [Any?] {
-    if let pigeonError = error as? AdyenPigeonError {
-        return [
-            pigeonError.code,
-            pigeonError.message,
-            pigeonError.details
-        ]
-    }
-    if let flutterError = error as? FlutterError {
-        return [
-            flutterError.code,
-            flutterError.message,
-            flutterError.details
-        ]
-    }
+  if let pigeonError = error as? AdyenPigeonError {
     return [
-        "\(error)",
-        "\(type(of: error))",
-        "Stacktrace: \(Thread.callStackSymbols)"
+      pigeonError.code,
+      pigeonError.message,
+      pigeonError.details,
     ]
+  }
+  if let flutterError = error as? FlutterError {
+    return [
+      flutterError.code,
+      flutterError.message,
+      flutterError.details,
+    ]
+  }
+  return [
+    "\(error)",
+    "\(type(of: error))",
+    "Stacktrace: \(Thread.callStackSymbols)",
+  ]
 }
 
 private func createConnectionError(withChannelName channelName: String) -> AdyenPigeonError {
-    AdyenPigeonError(code: "channel-error", message: "Unable to establish connection on channel: '\(channelName)'.", details: "")
+  return AdyenPigeonError(code: "channel-error", message: "Unable to establish connection on channel: '\(channelName)'.", details: "")
 }
 
 private func isNullish(_ value: Any?) -> Bool {
-    value is NSNull || value == nil
+  return value is NSNull || value == nil
 }
 
 private func nilOrValue<T>(_ value: Any?) -> T? {
-    if value is NSNull { return nil }
-    return value as! T?
+  if value is NSNull { return nil }
+  return value as! T?
 }
 
 enum Environment: Int {
-    case test = 0
-    case europe = 1
-    case unitedStates = 2
-    case australia = 3
-    case india = 4
-    case apse = 5
-    case nea = 6
+  case test = 0
+  case europe = 1
+  case unitedStates = 2
+  case australia = 3
+  case india = 4
+  case apse = 5
+  case nea = 6
 }
 
 enum AddressMode: Int {
-    case full = 0
-    case postalCode = 1
-    case none = 2
+  case full = 0
+  case postalCode = 1
+  case none = 2
 }
 
 enum CardAuthMethod: Int {
-    case panOnly = 0
-    case cryptogram3DS = 1
+  case panOnly = 0
+  case cryptogram3DS = 1
 }
 
 enum TotalPriceStatus: Int {
-    case notCurrentlyKnown = 0
-    case estimated = 1
-    case finalPrice = 2
+  case notCurrentlyKnown = 0
+  case estimated = 1
+  case finalPrice = 2
 }
 
 enum GooglePayEnvironment: Int {
-    case test = 0
-    case production = 1
+  case test = 0
+  case production = 1
 }
 
 enum CashAppPayEnvironment: Int {
-    case sandbox = 0
-    case production = 1
+  case sandbox = 0
+  case production = 1
 }
 
 enum PaymentResultEnum: Int {
-    case cancelledByUser = 0
-    case error = 1
-    case finished = 2
+  case cancelledByUser = 0
+  case error = 1
+  case finished = 2
 }
 
 enum CheckoutEventType: Int {
-    case submit = 0
-    case additionalDetails = 1
-    case result = 2
-    case deleteStoredPaymentMethod = 3
-    case balanceCheck = 4
-    case requestOrder = 5
-    case cancelOrder = 6
-    case binLookup = 7
-    case binValue = 8
+  case submit = 0
+  case additionalDetails = 1
+  case result = 2
+  case deleteStoredPaymentMethod = 3
+  case balanceCheck = 4
+  case requestOrder = 5
+  case cancelOrder = 6
+  case binLookup = 7
+  case binValue = 8
 }
 
 enum ComponentCommunicationType: Int {
-    case onSubmit = 0
-    case additionalDetails = 1
-    case loading = 2
-    case result = 3
-    case resize = 4
-    case binLookup = 5
-    case binValue = 6
-    case availability = 7
+  case onSubmit = 0
+  case additionalDetails = 1
+  case loading = 2
+  case result = 3
+  case resize = 4
+  case binLookup = 5
+  case binValue = 6
+  case availability = 7
 }
 
 enum PaymentEventType: Int {
-    case finished = 0
-    case action = 1
-    case error = 2
-    case update = 3
+  case finished = 0
+  case action = 1
+  case error = 2
+  case update = 3
 }
 
 enum FieldVisibility: Int {
-    case show = 0
-    case hide = 1
+  case show = 0
+  case hide = 1
 }
 
 enum InstantPaymentType: Int {
-    case googlePay = 0
-    case applePay = 1
-    case instant = 2
+  case googlePay = 0
+  case applePay = 1
+  case instant = 2
 }
 
 enum ApplePayShippingType: Int {
-    case shipping = 0
-    case delivery = 1
-    case storePickup = 2
-    case servicePickup = 3
+  case shipping = 0
+  case delivery = 1
+  case storePickup = 2
+  case servicePickup = 3
 }
 
 enum ApplePayMerchantCapability: Int {
-    case debit = 0
-    case credit = 1
+  case debit = 0
+  case credit = 1
 }
 
 enum ApplePaySummaryItemType: Int {
-    case pending = 0
-    case definite = 1
+  case pending = 0
+  case definite = 1
 }
 
 enum CardNumberValidationResultDTO: Int {
-    case valid = 0
-    case invalidIllegalCharacters = 1
-    case invalidLuhnCheck = 2
-    case invalidTooShort = 3
-    case invalidTooLong = 4
-    case invalidOtherReason = 5
+  case valid = 0
+  case invalidIllegalCharacters = 1
+  case invalidLuhnCheck = 2
+  case invalidTooShort = 3
+  case invalidTooLong = 4
+  case invalidOtherReason = 5
 }
 
 enum CardExpiryDateValidationResultDTO: Int {
-    case valid = 0
-    case invalidTooFarInTheFuture = 1
-    case invalidTooOld = 2
-    case nonParseableDate = 3
-    case invalidOtherReason = 4
+  case valid = 0
+  case invalidTooFarInTheFuture = 1
+  case invalidTooOld = 2
+  case nonParseableDate = 3
+  case invalidOtherReason = 4
 }
 
 enum CardSecurityCodeValidationResultDTO: Int {
-    case valid = 0
-    case invalid = 1
+  case valid = 0
+  case invalid = 1
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct SessionDTO {
-    var id: String
-    var sessionData: String
-    var paymentMethodsJson: String
+  var id: String
+  var sessionData: String
+  var paymentMethodsJson: String
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> SessionDTO? {
-        let id = __pigeon_list[0] as! String
-        let sessionData = __pigeon_list[1] as! String
-        let paymentMethodsJson = __pigeon_list[2] as! String
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> SessionDTO? {
+    let id = __pigeon_list[0] as! String
+    let sessionData = __pigeon_list[1] as! String
+    let paymentMethodsJson = __pigeon_list[2] as! String
 
-        return SessionDTO(
-            id: id,
-            sessionData: sessionData,
-            paymentMethodsJson: paymentMethodsJson
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            id,
-            sessionData,
-            paymentMethodsJson
-        ]
-    }
+    return SessionDTO(
+      id: id,
+      sessionData: sessionData,
+      paymentMethodsJson: paymentMethodsJson
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      id,
+      sessionData,
+      paymentMethodsJson,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct AmountDTO {
-    var currency: String
-    var value: Int64
+  var currency: String
+  var value: Int64
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> AmountDTO? {
-        let currency = __pigeon_list[0] as! String
-        let value = __pigeon_list[1] is Int64 ? __pigeon_list[1] as! Int64 : Int64(__pigeon_list[1] as! Int32)
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> AmountDTO? {
+    let currency = __pigeon_list[0] as! String
+    let value = __pigeon_list[1] is Int64 ? __pigeon_list[1] as! Int64 : Int64(__pigeon_list[1] as! Int32)
 
-        return AmountDTO(
-            currency: currency,
-            value: value
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            currency,
-            value
-        ]
-    }
+    return AmountDTO(
+      currency: currency,
+      value: value
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      currency,
+      value,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct AnalyticsOptionsDTO {
-    var enabled: Bool
-    var version: String
+  var enabled: Bool
+  var version: String
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> AnalyticsOptionsDTO? {
-        let enabled = __pigeon_list[0] as! Bool
-        let version = __pigeon_list[1] as! String
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> AnalyticsOptionsDTO? {
+    let enabled = __pigeon_list[0] as! Bool
+    let version = __pigeon_list[1] as! String
 
-        return AnalyticsOptionsDTO(
-            enabled: enabled,
-            version: version
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            enabled,
-            version
-        ]
-    }
+    return AnalyticsOptionsDTO(
+      enabled: enabled,
+      version: version
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      enabled,
+      version,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2UICustomizationDTO {
-    var screenCustomization: ThreeDS2ScreenCustomizationDTO?
-    var headingCustomization: ThreeDS2ToolbarCustomizationDTO?
-    var labelCustomization: ThreeDS2LabelCustomizationDTO?
-    var inputCustomization: ThreeDS2InputCustomizationDTO?
-    var selectionItemCustomization: ThreeDS2SelectionItemCustomizationDTO?
-    var primaryButtonCustomization: ThreeDS2ButtonCustomizationDTO?
-    var secondaryButtonCustomization: ThreeDS2ButtonCustomizationDTO?
+  var screenCustomization: ThreeDS2ScreenCustomizationDTO? = nil
+  var headingCustomization: ThreeDS2ToolbarCustomizationDTO? = nil
+  var labelCustomization: ThreeDS2LabelCustomizationDTO? = nil
+  var inputCustomization: ThreeDS2InputCustomizationDTO? = nil
+  var selectionItemCustomization: ThreeDS2SelectionItemCustomizationDTO? = nil
+  var primaryButtonCustomization: ThreeDS2ButtonCustomizationDTO? = nil
+  var secondaryButtonCustomization: ThreeDS2ButtonCustomizationDTO? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2UICustomizationDTO? {
-        let screenCustomization: ThreeDS2ScreenCustomizationDTO? = nilOrValue(__pigeon_list[0])
-        let headingCustomization: ThreeDS2ToolbarCustomizationDTO? = nilOrValue(__pigeon_list[1])
-        let labelCustomization: ThreeDS2LabelCustomizationDTO? = nilOrValue(__pigeon_list[2])
-        let inputCustomization: ThreeDS2InputCustomizationDTO? = nilOrValue(__pigeon_list[3])
-        let selectionItemCustomization: ThreeDS2SelectionItemCustomizationDTO? = nilOrValue(__pigeon_list[4])
-        let primaryButtonCustomization: ThreeDS2ButtonCustomizationDTO? = nilOrValue(__pigeon_list[5])
-        let secondaryButtonCustomization: ThreeDS2ButtonCustomizationDTO? = nilOrValue(__pigeon_list[6])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2UICustomizationDTO? {
+    let screenCustomization: ThreeDS2ScreenCustomizationDTO? = nilOrValue(__pigeon_list[0])
+    let headingCustomization: ThreeDS2ToolbarCustomizationDTO? = nilOrValue(__pigeon_list[1])
+    let labelCustomization: ThreeDS2LabelCustomizationDTO? = nilOrValue(__pigeon_list[2])
+    let inputCustomization: ThreeDS2InputCustomizationDTO? = nilOrValue(__pigeon_list[3])
+    let selectionItemCustomization: ThreeDS2SelectionItemCustomizationDTO? = nilOrValue(__pigeon_list[4])
+    let primaryButtonCustomization: ThreeDS2ButtonCustomizationDTO? = nilOrValue(__pigeon_list[5])
+    let secondaryButtonCustomization: ThreeDS2ButtonCustomizationDTO? = nilOrValue(__pigeon_list[6])
 
-        return ThreeDS2UICustomizationDTO(
-            screenCustomization: screenCustomization,
-            headingCustomization: headingCustomization,
-            labelCustomization: labelCustomization,
-            inputCustomization: inputCustomization,
-            selectionItemCustomization: selectionItemCustomization,
-            primaryButtonCustomization: primaryButtonCustomization,
-            secondaryButtonCustomization: secondaryButtonCustomization
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            screenCustomization,
-            headingCustomization,
-            labelCustomization,
-            inputCustomization,
-            selectionItemCustomization,
-            primaryButtonCustomization,
-            secondaryButtonCustomization
-        ]
-    }
+    return ThreeDS2UICustomizationDTO(
+      screenCustomization: screenCustomization,
+      headingCustomization: headingCustomization,
+      labelCustomization: labelCustomization,
+      inputCustomization: inputCustomization,
+      selectionItemCustomization: selectionItemCustomization,
+      primaryButtonCustomization: primaryButtonCustomization,
+      secondaryButtonCustomization: secondaryButtonCustomization
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      screenCustomization,
+      headingCustomization,
+      labelCustomization,
+      inputCustomization,
+      selectionItemCustomization,
+      primaryButtonCustomization,
+      secondaryButtonCustomization,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2ScreenCustomizationDTO {
-    var backgroundColor: String?
-    var textColor: String?
+  var backgroundColor: String? = nil
+  var textColor: String? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ScreenCustomizationDTO? {
-        let backgroundColor: String? = nilOrValue(__pigeon_list[0])
-        let textColor: String? = nilOrValue(__pigeon_list[1])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ScreenCustomizationDTO? {
+    let backgroundColor: String? = nilOrValue(__pigeon_list[0])
+    let textColor: String? = nilOrValue(__pigeon_list[1])
 
-        return ThreeDS2ScreenCustomizationDTO(
-            backgroundColor: backgroundColor,
-            textColor: textColor
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            backgroundColor,
-            textColor
-        ]
-    }
+    return ThreeDS2ScreenCustomizationDTO(
+      backgroundColor: backgroundColor,
+      textColor: textColor
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      backgroundColor,
+      textColor,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2ButtonCustomizationDTO {
-    var backgroundColor: String?
-    var textColor: String?
-    var cornerRadius: Int64?
-    var textFontSize: Int64?
+  var backgroundColor: String? = nil
+  var textColor: String? = nil
+  var cornerRadius: Int64? = nil
+  var textFontSize: Int64? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ButtonCustomizationDTO? {
-        let backgroundColor: String? = nilOrValue(__pigeon_list[0])
-        let textColor: String? = nilOrValue(__pigeon_list[1])
-        let cornerRadius: Int64? = isNullish(__pigeon_list[2]) ? nil : (__pigeon_list[2] is Int64? ? __pigeon_list[2] as! Int64? : Int64(__pigeon_list[2] as! Int32))
-        let textFontSize: Int64? = isNullish(__pigeon_list[3]) ? nil : (__pigeon_list[3] is Int64? ? __pigeon_list[3] as! Int64? : Int64(__pigeon_list[3] as! Int32))
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ButtonCustomizationDTO? {
+    let backgroundColor: String? = nilOrValue(__pigeon_list[0])
+    let textColor: String? = nilOrValue(__pigeon_list[1])
+    let cornerRadius: Int64? = isNullish(__pigeon_list[2]) ? nil : (__pigeon_list[2] is Int64? ? __pigeon_list[2] as! Int64? : Int64(__pigeon_list[2] as! Int32))
+    let textFontSize: Int64? = isNullish(__pigeon_list[3]) ? nil : (__pigeon_list[3] is Int64? ? __pigeon_list[3] as! Int64? : Int64(__pigeon_list[3] as! Int32))
 
-        return ThreeDS2ButtonCustomizationDTO(
-            backgroundColor: backgroundColor,
-            textColor: textColor,
-            cornerRadius: cornerRadius,
-            textFontSize: textFontSize
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            backgroundColor,
-            textColor,
-            cornerRadius,
-            textFontSize
-        ]
-    }
+    return ThreeDS2ButtonCustomizationDTO(
+      backgroundColor: backgroundColor,
+      textColor: textColor,
+      cornerRadius: cornerRadius,
+      textFontSize: textFontSize
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      backgroundColor,
+      textColor,
+      cornerRadius,
+      textFontSize,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2SelectionItemCustomizationDTO {
-    var selectionIndicatorTintColor: String?
-    var highlightedBackgroundColor: String?
-    var textColor: String?
+  var selectionIndicatorTintColor: String? = nil
+  var highlightedBackgroundColor: String? = nil
+  var textColor: String? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2SelectionItemCustomizationDTO? {
-        let selectionIndicatorTintColor: String? = nilOrValue(__pigeon_list[0])
-        let highlightedBackgroundColor: String? = nilOrValue(__pigeon_list[1])
-        let textColor: String? = nilOrValue(__pigeon_list[2])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2SelectionItemCustomizationDTO? {
+    let selectionIndicatorTintColor: String? = nilOrValue(__pigeon_list[0])
+    let highlightedBackgroundColor: String? = nilOrValue(__pigeon_list[1])
+    let textColor: String? = nilOrValue(__pigeon_list[2])
 
-        return ThreeDS2SelectionItemCustomizationDTO(
-            selectionIndicatorTintColor: selectionIndicatorTintColor,
-            highlightedBackgroundColor: highlightedBackgroundColor,
-            textColor: textColor
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            selectionIndicatorTintColor,
-            highlightedBackgroundColor,
-            textColor
-        ]
-    }
+    return ThreeDS2SelectionItemCustomizationDTO(
+      selectionIndicatorTintColor: selectionIndicatorTintColor,
+      highlightedBackgroundColor: highlightedBackgroundColor,
+      textColor: textColor
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      selectionIndicatorTintColor,
+      highlightedBackgroundColor,
+      textColor,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2LabelCustomizationDTO {
-    var headingTextColor: String?
-    var headingTextFontSize: Int64?
-    var inputLabelTextColor: String?
-    var inputLabelFontSize: Int64?
-    var textColor: String?
-    var textFontSize: Int64?
+  var headingTextColor: String? = nil
+  var headingTextFontSize: Int64? = nil
+  var inputLabelTextColor: String? = nil
+  var inputLabelFontSize: Int64? = nil
+  var textColor: String? = nil
+  var textFontSize: Int64? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2LabelCustomizationDTO? {
-        let headingTextColor: String? = nilOrValue(__pigeon_list[0])
-        let headingTextFontSize: Int64? = isNullish(__pigeon_list[1]) ? nil : (__pigeon_list[1] is Int64? ? __pigeon_list[1] as! Int64? : Int64(__pigeon_list[1] as! Int32))
-        let inputLabelTextColor: String? = nilOrValue(__pigeon_list[2])
-        let inputLabelFontSize: Int64? = isNullish(__pigeon_list[3]) ? nil : (__pigeon_list[3] is Int64? ? __pigeon_list[3] as! Int64? : Int64(__pigeon_list[3] as! Int32))
-        let textColor: String? = nilOrValue(__pigeon_list[4])
-        let textFontSize: Int64? = isNullish(__pigeon_list[5]) ? nil : (__pigeon_list[5] is Int64? ? __pigeon_list[5] as! Int64? : Int64(__pigeon_list[5] as! Int32))
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2LabelCustomizationDTO? {
+    let headingTextColor: String? = nilOrValue(__pigeon_list[0])
+    let headingTextFontSize: Int64? = isNullish(__pigeon_list[1]) ? nil : (__pigeon_list[1] is Int64? ? __pigeon_list[1] as! Int64? : Int64(__pigeon_list[1] as! Int32))
+    let inputLabelTextColor: String? = nilOrValue(__pigeon_list[2])
+    let inputLabelFontSize: Int64? = isNullish(__pigeon_list[3]) ? nil : (__pigeon_list[3] is Int64? ? __pigeon_list[3] as! Int64? : Int64(__pigeon_list[3] as! Int32))
+    let textColor: String? = nilOrValue(__pigeon_list[4])
+    let textFontSize: Int64? = isNullish(__pigeon_list[5]) ? nil : (__pigeon_list[5] is Int64? ? __pigeon_list[5] as! Int64? : Int64(__pigeon_list[5] as! Int32))
 
-        return ThreeDS2LabelCustomizationDTO(
-            headingTextColor: headingTextColor,
-            headingTextFontSize: headingTextFontSize,
-            inputLabelTextColor: inputLabelTextColor,
-            inputLabelFontSize: inputLabelFontSize,
-            textColor: textColor,
-            textFontSize: textFontSize
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            headingTextColor,
-            headingTextFontSize,
-            inputLabelTextColor,
-            inputLabelFontSize,
-            textColor,
-            textFontSize
-        ]
-    }
+    return ThreeDS2LabelCustomizationDTO(
+      headingTextColor: headingTextColor,
+      headingTextFontSize: headingTextFontSize,
+      inputLabelTextColor: inputLabelTextColor,
+      inputLabelFontSize: inputLabelFontSize,
+      textColor: textColor,
+      textFontSize: textFontSize
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      headingTextColor,
+      headingTextFontSize,
+      inputLabelTextColor,
+      inputLabelFontSize,
+      textColor,
+      textFontSize,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2InputCustomizationDTO {
-    var borderColor: String?
-    var borderWidth: Int64?
-    var cornerRadius: Int64?
-    var textColor: String?
+  var borderColor: String? = nil
+  var borderWidth: Int64? = nil
+  var cornerRadius: Int64? = nil
+  var textColor: String? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2InputCustomizationDTO? {
-        let borderColor: String? = nilOrValue(__pigeon_list[0])
-        let borderWidth: Int64? = isNullish(__pigeon_list[1]) ? nil : (__pigeon_list[1] is Int64? ? __pigeon_list[1] as! Int64? : Int64(__pigeon_list[1] as! Int32))
-        let cornerRadius: Int64? = isNullish(__pigeon_list[2]) ? nil : (__pigeon_list[2] is Int64? ? __pigeon_list[2] as! Int64? : Int64(__pigeon_list[2] as! Int32))
-        let textColor: String? = nilOrValue(__pigeon_list[3])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2InputCustomizationDTO? {
+    let borderColor: String? = nilOrValue(__pigeon_list[0])
+    let borderWidth: Int64? = isNullish(__pigeon_list[1]) ? nil : (__pigeon_list[1] is Int64? ? __pigeon_list[1] as! Int64? : Int64(__pigeon_list[1] as! Int32))
+    let cornerRadius: Int64? = isNullish(__pigeon_list[2]) ? nil : (__pigeon_list[2] is Int64? ? __pigeon_list[2] as! Int64? : Int64(__pigeon_list[2] as! Int32))
+    let textColor: String? = nilOrValue(__pigeon_list[3])
 
-        return ThreeDS2InputCustomizationDTO(
-            borderColor: borderColor,
-            borderWidth: borderWidth,
-            cornerRadius: cornerRadius,
-            textColor: textColor
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            borderColor,
-            borderWidth,
-            cornerRadius,
-            textColor
-        ]
-    }
+    return ThreeDS2InputCustomizationDTO(
+      borderColor: borderColor,
+      borderWidth: borderWidth,
+      cornerRadius: cornerRadius,
+      textColor: textColor
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      borderColor,
+      borderWidth,
+      cornerRadius,
+      textColor,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2ToolbarCustomizationDTO {
-    var headerText: String?
-    var textColor: String?
-    var backgroundColor: String?
-    var cancelButtonColor: String?
+  var headerText: String? = nil
+  var textColor: String? = nil
+  var backgroundColor: String? = nil
+  var cancelButtonColor: String? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ToolbarCustomizationDTO? {
-        let headerText: String? = nilOrValue(__pigeon_list[0])
-        let textColor: String? = nilOrValue(__pigeon_list[1])
-        let backgroundColor: String? = nilOrValue(__pigeon_list[2])
-        let cancelButtonColor: String? = nilOrValue(__pigeon_list[3])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ToolbarCustomizationDTO? {
+    let headerText: String? = nilOrValue(__pigeon_list[0])
+    let textColor: String? = nilOrValue(__pigeon_list[1])
+    let backgroundColor: String? = nilOrValue(__pigeon_list[2])
+    let cancelButtonColor: String? = nilOrValue(__pigeon_list[3])
 
-        return ThreeDS2ToolbarCustomizationDTO(
-            headerText: headerText,
-            textColor: textColor,
-            backgroundColor: backgroundColor,
-            cancelButtonColor: cancelButtonColor
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            headerText,
-            textColor,
-            backgroundColor,
-            cancelButtonColor
-        ]
-    }
+    return ThreeDS2ToolbarCustomizationDTO(
+      headerText: headerText,
+      textColor: textColor,
+      backgroundColor: backgroundColor,
+      cancelButtonColor: cancelButtonColor
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      headerText,
+      textColor,
+      backgroundColor,
+      cancelButtonColor,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2ConfigurationDTO {
-    var requestorAppURL: String?
-    var uiCustomization: ThreeDS2UICustomizationDTO?
+  var requestorAppURL: String? = nil
+  var uiCustomization: ThreeDS2UICustomizationDTO? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ConfigurationDTO? {
-        let requestorAppURL: String? = nilOrValue(__pigeon_list[0])
-        let uiCustomization: ThreeDS2UICustomizationDTO? = nilOrValue(__pigeon_list[1])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ConfigurationDTO? {
+    let requestorAppURL: String? = nilOrValue(__pigeon_list[0])
+    let uiCustomization: ThreeDS2UICustomizationDTO? = nilOrValue(__pigeon_list[1])
 
-        return ThreeDS2ConfigurationDTO(
-            requestorAppURL: requestorAppURL,
-            uiCustomization: uiCustomization
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            requestorAppURL,
-            uiCustomization
-        ]
-    }
+    return ThreeDS2ConfigurationDTO(
+      requestorAppURL: requestorAppURL,
+      uiCustomization: uiCustomization
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      requestorAppURL,
+      uiCustomization,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct DefaultInstallmentOptionsDTO {
-    var values: [Int64?]
-    var includesRevolving: Bool
+  var values: [Int64?]
+  var includesRevolving: Bool
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> DefaultInstallmentOptionsDTO? {
-        let values = __pigeon_list[0] as! [Int64?]
-        let includesRevolving = __pigeon_list[1] as! Bool
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> DefaultInstallmentOptionsDTO? {
+    let values = __pigeon_list[0] as! [Int64?]
+    let includesRevolving = __pigeon_list[1] as! Bool
 
-        return DefaultInstallmentOptionsDTO(
-            values: values,
-            includesRevolving: includesRevolving
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            values,
-            includesRevolving
-        ]
-    }
+    return DefaultInstallmentOptionsDTO(
+      values: values,
+      includesRevolving: includesRevolving
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      values,
+      includesRevolving,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct CardBasedInstallmentOptionsDTO {
-    var values: [Int64?]
-    var includesRevolving: Bool
-    var cardBrand: String
+  var values: [Int64?]
+  var includesRevolving: Bool
+  var cardBrand: String
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> CardBasedInstallmentOptionsDTO? {
-        let values = __pigeon_list[0] as! [Int64?]
-        let includesRevolving = __pigeon_list[1] as! Bool
-        let cardBrand = __pigeon_list[2] as! String
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> CardBasedInstallmentOptionsDTO? {
+    let values = __pigeon_list[0] as! [Int64?]
+    let includesRevolving = __pigeon_list[1] as! Bool
+    let cardBrand = __pigeon_list[2] as! String
 
-        return CardBasedInstallmentOptionsDTO(
-            values: values,
-            includesRevolving: includesRevolving,
-            cardBrand: cardBrand
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            values,
-            includesRevolving,
-            cardBrand
-        ]
-    }
+    return CardBasedInstallmentOptionsDTO(
+      values: values,
+      includesRevolving: includesRevolving,
+      cardBrand: cardBrand
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      values,
+      includesRevolving,
+      cardBrand,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct InstallmentConfigurationDTO {
-    var defaultOptions: DefaultInstallmentOptionsDTO?
-    var cardBasedOptions: [CardBasedInstallmentOptionsDTO?]?
-    var showInstallmentAmount: Bool
+  var defaultOptions: DefaultInstallmentOptionsDTO? = nil
+  var cardBasedOptions: [CardBasedInstallmentOptionsDTO?]? = nil
+  var showInstallmentAmount: Bool
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> InstallmentConfigurationDTO? {
-        let defaultOptions: DefaultInstallmentOptionsDTO? = nilOrValue(__pigeon_list[0])
-        let cardBasedOptions: [CardBasedInstallmentOptionsDTO?]? = nilOrValue(__pigeon_list[1])
-        let showInstallmentAmount = __pigeon_list[2] as! Bool
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> InstallmentConfigurationDTO? {
+    let defaultOptions: DefaultInstallmentOptionsDTO? = nilOrValue(__pigeon_list[0])
+    let cardBasedOptions: [CardBasedInstallmentOptionsDTO?]? = nilOrValue(__pigeon_list[1])
+    let showInstallmentAmount = __pigeon_list[2] as! Bool
 
-        return InstallmentConfigurationDTO(
-            defaultOptions: defaultOptions,
-            cardBasedOptions: cardBasedOptions,
-            showInstallmentAmount: showInstallmentAmount
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            defaultOptions,
-            cardBasedOptions,
-            showInstallmentAmount
-        ]
-    }
+    return InstallmentConfigurationDTO(
+      defaultOptions: defaultOptions,
+      cardBasedOptions: cardBasedOptions,
+      showInstallmentAmount: showInstallmentAmount
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      defaultOptions,
+      cardBasedOptions,
+      showInstallmentAmount,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct DropInConfigurationDTO {
-    var environment: Environment
-    var clientKey: String
-    var countryCode: String
-    var amount: AmountDTO?
-    var shopperLocale: String?
-    var cardConfigurationDTO: CardConfigurationDTO?
-    var applePayConfigurationDTO: ApplePayConfigurationDTO?
-    var googlePayConfigurationDTO: GooglePayConfigurationDTO?
-    var cashAppPayConfigurationDTO: CashAppPayConfigurationDTO?
-    var twintConfigurationDTO: TwintConfigurationDTO?
-    var threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO?
-    var analyticsOptionsDTO: AnalyticsOptionsDTO
-    var showPreselectedStoredPaymentMethod: Bool
-    var skipListWhenSinglePaymentMethod: Bool
-    var isRemoveStoredPaymentMethodEnabled: Bool
-    var preselectedPaymentMethodTitle: String?
-    var paymentMethodNames: [String?: String?]?
-    var isPartialPaymentSupported: Bool
+  var environment: Environment
+  var clientKey: String
+  var countryCode: String
+  var amount: AmountDTO? = nil
+  var shopperLocale: String? = nil
+  var cardConfigurationDTO: CardConfigurationDTO? = nil
+  var applePayConfigurationDTO: ApplePayConfigurationDTO? = nil
+  var googlePayConfigurationDTO: GooglePayConfigurationDTO? = nil
+  var cashAppPayConfigurationDTO: CashAppPayConfigurationDTO? = nil
+  var twintConfigurationDTO: TwintConfigurationDTO? = nil
+  var threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil
+  var analyticsOptionsDTO: AnalyticsOptionsDTO
+  var showPreselectedStoredPaymentMethod: Bool
+  var skipListWhenSinglePaymentMethod: Bool
+  var isRemoveStoredPaymentMethodEnabled: Bool
+  var preselectedPaymentMethodTitle: String? = nil
+  var paymentMethodNames: [String?: String?]? = nil
+  var isPartialPaymentSupported: Bool
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> DropInConfigurationDTO? {
-        let environment = __pigeon_list[0] as! Environment
-        let clientKey = __pigeon_list[1] as! String
-        let countryCode = __pigeon_list[2] as! String
-        let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
-        let shopperLocale: String? = nilOrValue(__pigeon_list[4])
-        let cardConfigurationDTO: CardConfigurationDTO? = nilOrValue(__pigeon_list[5])
-        let applePayConfigurationDTO: ApplePayConfigurationDTO? = nilOrValue(__pigeon_list[6])
-        let googlePayConfigurationDTO: GooglePayConfigurationDTO? = nilOrValue(__pigeon_list[7])
-        let cashAppPayConfigurationDTO: CashAppPayConfigurationDTO? = nilOrValue(__pigeon_list[8])
-        let twintConfigurationDTO: TwintConfigurationDTO? = nilOrValue(__pigeon_list[9])
-        let threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nilOrValue(__pigeon_list[10])
-        let analyticsOptionsDTO = __pigeon_list[11] as! AnalyticsOptionsDTO
-        let showPreselectedStoredPaymentMethod = __pigeon_list[12] as! Bool
-        let skipListWhenSinglePaymentMethod = __pigeon_list[13] as! Bool
-        let isRemoveStoredPaymentMethodEnabled = __pigeon_list[14] as! Bool
-        let preselectedPaymentMethodTitle: String? = nilOrValue(__pigeon_list[15])
-        let paymentMethodNames: [String?: String?]? = nilOrValue(__pigeon_list[16])
-        let isPartialPaymentSupported = __pigeon_list[17] as! Bool
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> DropInConfigurationDTO? {
+    let environment = __pigeon_list[0] as! Environment
+    let clientKey = __pigeon_list[1] as! String
+    let countryCode = __pigeon_list[2] as! String
+    let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
+    let shopperLocale: String? = nilOrValue(__pigeon_list[4])
+    let cardConfigurationDTO: CardConfigurationDTO? = nilOrValue(__pigeon_list[5])
+    let applePayConfigurationDTO: ApplePayConfigurationDTO? = nilOrValue(__pigeon_list[6])
+    let googlePayConfigurationDTO: GooglePayConfigurationDTO? = nilOrValue(__pigeon_list[7])
+    let cashAppPayConfigurationDTO: CashAppPayConfigurationDTO? = nilOrValue(__pigeon_list[8])
+    let twintConfigurationDTO: TwintConfigurationDTO? = nilOrValue(__pigeon_list[9])
+    let threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nilOrValue(__pigeon_list[10])
+    let analyticsOptionsDTO = __pigeon_list[11] as! AnalyticsOptionsDTO
+    let showPreselectedStoredPaymentMethod = __pigeon_list[12] as! Bool
+    let skipListWhenSinglePaymentMethod = __pigeon_list[13] as! Bool
+    let isRemoveStoredPaymentMethodEnabled = __pigeon_list[14] as! Bool
+    let preselectedPaymentMethodTitle: String? = nilOrValue(__pigeon_list[15])
+    let paymentMethodNames: [String?: String?]? = nilOrValue(__pigeon_list[16])
+    let isPartialPaymentSupported = __pigeon_list[17] as! Bool
 
-        return DropInConfigurationDTO(
-            environment: environment,
-            clientKey: clientKey,
-            countryCode: countryCode,
-            amount: amount,
-            shopperLocale: shopperLocale,
-            cardConfigurationDTO: cardConfigurationDTO,
-            applePayConfigurationDTO: applePayConfigurationDTO,
-            googlePayConfigurationDTO: googlePayConfigurationDTO,
-            cashAppPayConfigurationDTO: cashAppPayConfigurationDTO,
-            twintConfigurationDTO: twintConfigurationDTO,
-            threeDS2ConfigurationDTO: threeDS2ConfigurationDTO,
-            analyticsOptionsDTO: analyticsOptionsDTO,
-            showPreselectedStoredPaymentMethod: showPreselectedStoredPaymentMethod,
-            skipListWhenSinglePaymentMethod: skipListWhenSinglePaymentMethod,
-            isRemoveStoredPaymentMethodEnabled: isRemoveStoredPaymentMethodEnabled,
-            preselectedPaymentMethodTitle: preselectedPaymentMethodTitle,
-            paymentMethodNames: paymentMethodNames,
-            isPartialPaymentSupported: isPartialPaymentSupported
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            environment,
-            clientKey,
-            countryCode,
-            amount,
-            shopperLocale,
-            cardConfigurationDTO,
-            applePayConfigurationDTO,
-            googlePayConfigurationDTO,
-            cashAppPayConfigurationDTO,
-            twintConfigurationDTO,
-            threeDS2ConfigurationDTO,
-            analyticsOptionsDTO,
-            showPreselectedStoredPaymentMethod,
-            skipListWhenSinglePaymentMethod,
-            isRemoveStoredPaymentMethodEnabled,
-            preselectedPaymentMethodTitle,
-            paymentMethodNames,
-            isPartialPaymentSupported
-        ]
-    }
+    return DropInConfigurationDTO(
+      environment: environment,
+      clientKey: clientKey,
+      countryCode: countryCode,
+      amount: amount,
+      shopperLocale: shopperLocale,
+      cardConfigurationDTO: cardConfigurationDTO,
+      applePayConfigurationDTO: applePayConfigurationDTO,
+      googlePayConfigurationDTO: googlePayConfigurationDTO,
+      cashAppPayConfigurationDTO: cashAppPayConfigurationDTO,
+      twintConfigurationDTO: twintConfigurationDTO,
+      threeDS2ConfigurationDTO: threeDS2ConfigurationDTO,
+      analyticsOptionsDTO: analyticsOptionsDTO,
+      showPreselectedStoredPaymentMethod: showPreselectedStoredPaymentMethod,
+      skipListWhenSinglePaymentMethod: skipListWhenSinglePaymentMethod,
+      isRemoveStoredPaymentMethodEnabled: isRemoveStoredPaymentMethodEnabled,
+      preselectedPaymentMethodTitle: preselectedPaymentMethodTitle,
+      paymentMethodNames: paymentMethodNames,
+      isPartialPaymentSupported: isPartialPaymentSupported
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      environment,
+      clientKey,
+      countryCode,
+      amount,
+      shopperLocale,
+      cardConfigurationDTO,
+      applePayConfigurationDTO,
+      googlePayConfigurationDTO,
+      cashAppPayConfigurationDTO,
+      twintConfigurationDTO,
+      threeDS2ConfigurationDTO,
+      analyticsOptionsDTO,
+      showPreselectedStoredPaymentMethod,
+      skipListWhenSinglePaymentMethod,
+      isRemoveStoredPaymentMethodEnabled,
+      preselectedPaymentMethodTitle,
+      paymentMethodNames,
+      isPartialPaymentSupported,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct CardConfigurationDTO {
-    var holderNameRequired: Bool
-    var addressMode: AddressMode
-    var showStorePaymentField: Bool
-    var showCvcForStoredCard: Bool
-    var showCvc: Bool
-    var kcpFieldVisibility: FieldVisibility
-    var socialSecurityNumberFieldVisibility: FieldVisibility
-    var supportedCardTypes: [String?]
-    var installmentConfiguration: InstallmentConfigurationDTO?
+  var holderNameRequired: Bool
+  var addressMode: AddressMode
+  var showStorePaymentField: Bool
+  var showCvcForStoredCard: Bool
+  var showCvc: Bool
+  var kcpFieldVisibility: FieldVisibility
+  var socialSecurityNumberFieldVisibility: FieldVisibility
+  var supportedCardTypes: [String?]
+  var installmentConfiguration: InstallmentConfigurationDTO? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> CardConfigurationDTO? {
-        let holderNameRequired = __pigeon_list[0] as! Bool
-        let addressMode = __pigeon_list[1] as! AddressMode
-        let showStorePaymentField = __pigeon_list[2] as! Bool
-        let showCvcForStoredCard = __pigeon_list[3] as! Bool
-        let showCvc = __pigeon_list[4] as! Bool
-        let kcpFieldVisibility = __pigeon_list[5] as! FieldVisibility
-        let socialSecurityNumberFieldVisibility = __pigeon_list[6] as! FieldVisibility
-        let supportedCardTypes = __pigeon_list[7] as! [String?]
-        let installmentConfiguration: InstallmentConfigurationDTO? = nilOrValue(__pigeon_list[8])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> CardConfigurationDTO? {
+    let holderNameRequired = __pigeon_list[0] as! Bool
+    let addressMode = __pigeon_list[1] as! AddressMode
+    let showStorePaymentField = __pigeon_list[2] as! Bool
+    let showCvcForStoredCard = __pigeon_list[3] as! Bool
+    let showCvc = __pigeon_list[4] as! Bool
+    let kcpFieldVisibility = __pigeon_list[5] as! FieldVisibility
+    let socialSecurityNumberFieldVisibility = __pigeon_list[6] as! FieldVisibility
+    let supportedCardTypes = __pigeon_list[7] as! [String?]
+    let installmentConfiguration: InstallmentConfigurationDTO? = nilOrValue(__pigeon_list[8])
 
-        return CardConfigurationDTO(
-            holderNameRequired: holderNameRequired,
-            addressMode: addressMode,
-            showStorePaymentField: showStorePaymentField,
-            showCvcForStoredCard: showCvcForStoredCard,
-            showCvc: showCvc,
-            kcpFieldVisibility: kcpFieldVisibility,
-            socialSecurityNumberFieldVisibility: socialSecurityNumberFieldVisibility,
-            supportedCardTypes: supportedCardTypes,
-            installmentConfiguration: installmentConfiguration
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            holderNameRequired,
-            addressMode,
-            showStorePaymentField,
-            showCvcForStoredCard,
-            showCvc,
-            kcpFieldVisibility,
-            socialSecurityNumberFieldVisibility,
-            supportedCardTypes,
-            installmentConfiguration
-        ]
-    }
+    return CardConfigurationDTO(
+      holderNameRequired: holderNameRequired,
+      addressMode: addressMode,
+      showStorePaymentField: showStorePaymentField,
+      showCvcForStoredCard: showCvcForStoredCard,
+      showCvc: showCvc,
+      kcpFieldVisibility: kcpFieldVisibility,
+      socialSecurityNumberFieldVisibility: socialSecurityNumberFieldVisibility,
+      supportedCardTypes: supportedCardTypes,
+      installmentConfiguration: installmentConfiguration
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      holderNameRequired,
+      addressMode,
+      showStorePaymentField,
+      showCvcForStoredCard,
+      showCvc,
+      kcpFieldVisibility,
+      socialSecurityNumberFieldVisibility,
+      supportedCardTypes,
+      installmentConfiguration,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ApplePayConfigurationDTO {
-    var merchantId: String
-    var merchantName: String
-    var allowOnboarding: Bool?
-    var summaryItems: [ApplePaySummaryItemDTO?]?
-    var requiredBillingContactFields: [String?]?
-    var billingContact: ApplePayContactDTO?
-    var requiredShippingContactFields: [String?]?
-    var shippingContact: ApplePayContactDTO?
-    var applePayShippingType: ApplePayShippingType?
-    var allowShippingContactEditing: Bool?
-    var shippingMethods: [ApplePayShippingMethodDTO?]?
-    var applicationData: String?
-    var supportedCountries: [String?]?
-    var merchantCapability: ApplePayMerchantCapability?
+  var merchantId: String
+  var merchantName: String
+  var allowOnboarding: Bool? = nil
+  var summaryItems: [ApplePaySummaryItemDTO?]? = nil
+  var requiredBillingContactFields: [String?]? = nil
+  var billingContact: ApplePayContactDTO? = nil
+  var requiredShippingContactFields: [String?]? = nil
+  var shippingContact: ApplePayContactDTO? = nil
+  var applePayShippingType: ApplePayShippingType? = nil
+  var allowShippingContactEditing: Bool? = nil
+  var shippingMethods: [ApplePayShippingMethodDTO?]? = nil
+  var applicationData: String? = nil
+  var supportedCountries: [String?]? = nil
+  var merchantCapability: ApplePayMerchantCapability? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ApplePayConfigurationDTO? {
-        let merchantId = __pigeon_list[0] as! String
-        let merchantName = __pigeon_list[1] as! String
-        let allowOnboarding: Bool? = nilOrValue(__pigeon_list[2])
-        let summaryItems: [ApplePaySummaryItemDTO?]? = nilOrValue(__pigeon_list[3])
-        let requiredBillingContactFields: [String?]? = nilOrValue(__pigeon_list[4])
-        let billingContact: ApplePayContactDTO? = nilOrValue(__pigeon_list[5])
-        let requiredShippingContactFields: [String?]? = nilOrValue(__pigeon_list[6])
-        let shippingContact: ApplePayContactDTO? = nilOrValue(__pigeon_list[7])
-        let applePayShippingType: ApplePayShippingType? = nilOrValue(__pigeon_list[8])
-        let allowShippingContactEditing: Bool? = nilOrValue(__pigeon_list[9])
-        let shippingMethods: [ApplePayShippingMethodDTO?]? = nilOrValue(__pigeon_list[10])
-        let applicationData: String? = nilOrValue(__pigeon_list[11])
-        let supportedCountries: [String?]? = nilOrValue(__pigeon_list[12])
-        let merchantCapability: ApplePayMerchantCapability? = nilOrValue(__pigeon_list[13])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ApplePayConfigurationDTO? {
+    let merchantId = __pigeon_list[0] as! String
+    let merchantName = __pigeon_list[1] as! String
+    let allowOnboarding: Bool? = nilOrValue(__pigeon_list[2])
+    let summaryItems: [ApplePaySummaryItemDTO?]? = nilOrValue(__pigeon_list[3])
+    let requiredBillingContactFields: [String?]? = nilOrValue(__pigeon_list[4])
+    let billingContact: ApplePayContactDTO? = nilOrValue(__pigeon_list[5])
+    let requiredShippingContactFields: [String?]? = nilOrValue(__pigeon_list[6])
+    let shippingContact: ApplePayContactDTO? = nilOrValue(__pigeon_list[7])
+    let applePayShippingType: ApplePayShippingType? = nilOrValue(__pigeon_list[8])
+    let allowShippingContactEditing: Bool? = nilOrValue(__pigeon_list[9])
+    let shippingMethods: [ApplePayShippingMethodDTO?]? = nilOrValue(__pigeon_list[10])
+    let applicationData: String? = nilOrValue(__pigeon_list[11])
+    let supportedCountries: [String?]? = nilOrValue(__pigeon_list[12])
+    let merchantCapability: ApplePayMerchantCapability? = nilOrValue(__pigeon_list[13])
 
-        return ApplePayConfigurationDTO(
-            merchantId: merchantId,
-            merchantName: merchantName,
-            allowOnboarding: allowOnboarding,
-            summaryItems: summaryItems,
-            requiredBillingContactFields: requiredBillingContactFields,
-            billingContact: billingContact,
-            requiredShippingContactFields: requiredShippingContactFields,
-            shippingContact: shippingContact,
-            applePayShippingType: applePayShippingType,
-            allowShippingContactEditing: allowShippingContactEditing,
-            shippingMethods: shippingMethods,
-            applicationData: applicationData,
-            supportedCountries: supportedCountries,
-            merchantCapability: merchantCapability
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            merchantId,
-            merchantName,
-            allowOnboarding,
-            summaryItems,
-            requiredBillingContactFields,
-            billingContact,
-            requiredShippingContactFields,
-            shippingContact,
-            applePayShippingType,
-            allowShippingContactEditing,
-            shippingMethods,
-            applicationData,
-            supportedCountries,
-            merchantCapability
-        ]
-    }
+    return ApplePayConfigurationDTO(
+      merchantId: merchantId,
+      merchantName: merchantName,
+      allowOnboarding: allowOnboarding,
+      summaryItems: summaryItems,
+      requiredBillingContactFields: requiredBillingContactFields,
+      billingContact: billingContact,
+      requiredShippingContactFields: requiredShippingContactFields,
+      shippingContact: shippingContact,
+      applePayShippingType: applePayShippingType,
+      allowShippingContactEditing: allowShippingContactEditing,
+      shippingMethods: shippingMethods,
+      applicationData: applicationData,
+      supportedCountries: supportedCountries,
+      merchantCapability: merchantCapability
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      merchantId,
+      merchantName,
+      allowOnboarding,
+      summaryItems,
+      requiredBillingContactFields,
+      billingContact,
+      requiredShippingContactFields,
+      shippingContact,
+      applePayShippingType,
+      allowShippingContactEditing,
+      shippingMethods,
+      applicationData,
+      supportedCountries,
+      merchantCapability,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ApplePayContactDTO {
-    var phoneNumber: String?
-    var emailAddress: String?
-    var givenName: String?
-    var familyName: String?
-    var phoneticGivenName: String?
-    var phoneticFamilyName: String?
-    var addressLines: [String?]?
-    var subLocality: String?
-    var city: String?
-    var postalCode: String?
-    var subAdministrativeArea: String?
-    var administrativeArea: String?
-    var country: String?
-    var countryCode: String?
+  var phoneNumber: String? = nil
+  var emailAddress: String? = nil
+  var givenName: String? = nil
+  var familyName: String? = nil
+  var phoneticGivenName: String? = nil
+  var phoneticFamilyName: String? = nil
+  var addressLines: [String?]? = nil
+  var subLocality: String? = nil
+  var city: String? = nil
+  var postalCode: String? = nil
+  var subAdministrativeArea: String? = nil
+  var administrativeArea: String? = nil
+  var country: String? = nil
+  var countryCode: String? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ApplePayContactDTO? {
-        let phoneNumber: String? = nilOrValue(__pigeon_list[0])
-        let emailAddress: String? = nilOrValue(__pigeon_list[1])
-        let givenName: String? = nilOrValue(__pigeon_list[2])
-        let familyName: String? = nilOrValue(__pigeon_list[3])
-        let phoneticGivenName: String? = nilOrValue(__pigeon_list[4])
-        let phoneticFamilyName: String? = nilOrValue(__pigeon_list[5])
-        let addressLines: [String?]? = nilOrValue(__pigeon_list[6])
-        let subLocality: String? = nilOrValue(__pigeon_list[7])
-        let city: String? = nilOrValue(__pigeon_list[8])
-        let postalCode: String? = nilOrValue(__pigeon_list[9])
-        let subAdministrativeArea: String? = nilOrValue(__pigeon_list[10])
-        let administrativeArea: String? = nilOrValue(__pigeon_list[11])
-        let country: String? = nilOrValue(__pigeon_list[12])
-        let countryCode: String? = nilOrValue(__pigeon_list[13])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ApplePayContactDTO? {
+    let phoneNumber: String? = nilOrValue(__pigeon_list[0])
+    let emailAddress: String? = nilOrValue(__pigeon_list[1])
+    let givenName: String? = nilOrValue(__pigeon_list[2])
+    let familyName: String? = nilOrValue(__pigeon_list[3])
+    let phoneticGivenName: String? = nilOrValue(__pigeon_list[4])
+    let phoneticFamilyName: String? = nilOrValue(__pigeon_list[5])
+    let addressLines: [String?]? = nilOrValue(__pigeon_list[6])
+    let subLocality: String? = nilOrValue(__pigeon_list[7])
+    let city: String? = nilOrValue(__pigeon_list[8])
+    let postalCode: String? = nilOrValue(__pigeon_list[9])
+    let subAdministrativeArea: String? = nilOrValue(__pigeon_list[10])
+    let administrativeArea: String? = nilOrValue(__pigeon_list[11])
+    let country: String? = nilOrValue(__pigeon_list[12])
+    let countryCode: String? = nilOrValue(__pigeon_list[13])
 
-        return ApplePayContactDTO(
-            phoneNumber: phoneNumber,
-            emailAddress: emailAddress,
-            givenName: givenName,
-            familyName: familyName,
-            phoneticGivenName: phoneticGivenName,
-            phoneticFamilyName: phoneticFamilyName,
-            addressLines: addressLines,
-            subLocality: subLocality,
-            city: city,
-            postalCode: postalCode,
-            subAdministrativeArea: subAdministrativeArea,
-            administrativeArea: administrativeArea,
-            country: country,
-            countryCode: countryCode
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            phoneNumber,
-            emailAddress,
-            givenName,
-            familyName,
-            phoneticGivenName,
-            phoneticFamilyName,
-            addressLines,
-            subLocality,
-            city,
-            postalCode,
-            subAdministrativeArea,
-            administrativeArea,
-            country,
-            countryCode
-        ]
-    }
+    return ApplePayContactDTO(
+      phoneNumber: phoneNumber,
+      emailAddress: emailAddress,
+      givenName: givenName,
+      familyName: familyName,
+      phoneticGivenName: phoneticGivenName,
+      phoneticFamilyName: phoneticFamilyName,
+      addressLines: addressLines,
+      subLocality: subLocality,
+      city: city,
+      postalCode: postalCode,
+      subAdministrativeArea: subAdministrativeArea,
+      administrativeArea: administrativeArea,
+      country: country,
+      countryCode: countryCode
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      phoneNumber,
+      emailAddress,
+      givenName,
+      familyName,
+      phoneticGivenName,
+      phoneticFamilyName,
+      addressLines,
+      subLocality,
+      city,
+      postalCode,
+      subAdministrativeArea,
+      administrativeArea,
+      country,
+      countryCode,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ApplePayShippingMethodDTO {
-    var label: String
-    var detail: String
-    var amount: AmountDTO
-    var identifier: String
-    var startDate: String?
-    var endDate: String?
+  var label: String
+  var detail: String
+  var amount: AmountDTO
+  var identifier: String
+  var startDate: String? = nil
+  var endDate: String? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ApplePayShippingMethodDTO? {
-        let label = __pigeon_list[0] as! String
-        let detail = __pigeon_list[1] as! String
-        let amount = __pigeon_list[2] as! AmountDTO
-        let identifier = __pigeon_list[3] as! String
-        let startDate: String? = nilOrValue(__pigeon_list[4])
-        let endDate: String? = nilOrValue(__pigeon_list[5])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ApplePayShippingMethodDTO? {
+    let label = __pigeon_list[0] as! String
+    let detail = __pigeon_list[1] as! String
+    let amount = __pigeon_list[2] as! AmountDTO
+    let identifier = __pigeon_list[3] as! String
+    let startDate: String? = nilOrValue(__pigeon_list[4])
+    let endDate: String? = nilOrValue(__pigeon_list[5])
 
-        return ApplePayShippingMethodDTO(
-            label: label,
-            detail: detail,
-            amount: amount,
-            identifier: identifier,
-            startDate: startDate,
-            endDate: endDate
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            label,
-            detail,
-            amount,
-            identifier,
-            startDate,
-            endDate
-        ]
-    }
+    return ApplePayShippingMethodDTO(
+      label: label,
+      detail: detail,
+      amount: amount,
+      identifier: identifier,
+      startDate: startDate,
+      endDate: endDate
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      label,
+      detail,
+      amount,
+      identifier,
+      startDate,
+      endDate,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ApplePaySummaryItemDTO {
-    var label: String
-    var amount: AmountDTO
-    var type: ApplePaySummaryItemType
+  var label: String
+  var amount: AmountDTO
+  var type: ApplePaySummaryItemType
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ApplePaySummaryItemDTO? {
-        let label = __pigeon_list[0] as! String
-        let amount = __pigeon_list[1] as! AmountDTO
-        let type = __pigeon_list[2] as! ApplePaySummaryItemType
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ApplePaySummaryItemDTO? {
+    let label = __pigeon_list[0] as! String
+    let amount = __pigeon_list[1] as! AmountDTO
+    let type = __pigeon_list[2] as! ApplePaySummaryItemType
 
-        return ApplePaySummaryItemDTO(
-            label: label,
-            amount: amount,
-            type: type
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            label,
-            amount,
-            type
-        ]
-    }
+    return ApplePaySummaryItemDTO(
+      label: label,
+      amount: amount,
+      type: type
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      label,
+      amount,
+      type,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct GooglePayConfigurationDTO {
-    var googlePayEnvironment: GooglePayEnvironment
-    var merchantAccount: String?
-    var merchantInfoDTO: MerchantInfoDTO?
-    var totalPriceStatus: TotalPriceStatus?
-    var allowedCardNetworks: [String?]?
-    var allowedAuthMethods: [String?]?
-    var allowPrepaidCards: Bool?
-    var allowCreditCards: Bool?
-    var assuranceDetailsRequired: Bool?
-    var emailRequired: Bool?
-    var existingPaymentMethodRequired: Bool?
-    var shippingAddressRequired: Bool?
-    var shippingAddressParametersDTO: ShippingAddressParametersDTO?
-    var billingAddressRequired: Bool?
-    var billingAddressParametersDTO: BillingAddressParametersDTO?
+  var googlePayEnvironment: GooglePayEnvironment
+  var merchantAccount: String? = nil
+  var merchantInfoDTO: MerchantInfoDTO? = nil
+  var totalPriceStatus: TotalPriceStatus? = nil
+  var allowedCardNetworks: [String?]? = nil
+  var allowedAuthMethods: [String?]? = nil
+  var allowPrepaidCards: Bool? = nil
+  var allowCreditCards: Bool? = nil
+  var assuranceDetailsRequired: Bool? = nil
+  var emailRequired: Bool? = nil
+  var existingPaymentMethodRequired: Bool? = nil
+  var shippingAddressRequired: Bool? = nil
+  var shippingAddressParametersDTO: ShippingAddressParametersDTO? = nil
+  var billingAddressRequired: Bool? = nil
+  var billingAddressParametersDTO: BillingAddressParametersDTO? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> GooglePayConfigurationDTO? {
-        let googlePayEnvironment = __pigeon_list[0] as! GooglePayEnvironment
-        let merchantAccount: String? = nilOrValue(__pigeon_list[1])
-        let merchantInfoDTO: MerchantInfoDTO? = nilOrValue(__pigeon_list[2])
-        let totalPriceStatus: TotalPriceStatus? = nilOrValue(__pigeon_list[3])
-        let allowedCardNetworks: [String?]? = nilOrValue(__pigeon_list[4])
-        let allowedAuthMethods: [String?]? = nilOrValue(__pigeon_list[5])
-        let allowPrepaidCards: Bool? = nilOrValue(__pigeon_list[6])
-        let allowCreditCards: Bool? = nilOrValue(__pigeon_list[7])
-        let assuranceDetailsRequired: Bool? = nilOrValue(__pigeon_list[8])
-        let emailRequired: Bool? = nilOrValue(__pigeon_list[9])
-        let existingPaymentMethodRequired: Bool? = nilOrValue(__pigeon_list[10])
-        let shippingAddressRequired: Bool? = nilOrValue(__pigeon_list[11])
-        let shippingAddressParametersDTO: ShippingAddressParametersDTO? = nilOrValue(__pigeon_list[12])
-        let billingAddressRequired: Bool? = nilOrValue(__pigeon_list[13])
-        let billingAddressParametersDTO: BillingAddressParametersDTO? = nilOrValue(__pigeon_list[14])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> GooglePayConfigurationDTO? {
+    let googlePayEnvironment = __pigeon_list[0] as! GooglePayEnvironment
+    let merchantAccount: String? = nilOrValue(__pigeon_list[1])
+    let merchantInfoDTO: MerchantInfoDTO? = nilOrValue(__pigeon_list[2])
+    let totalPriceStatus: TotalPriceStatus? = nilOrValue(__pigeon_list[3])
+    let allowedCardNetworks: [String?]? = nilOrValue(__pigeon_list[4])
+    let allowedAuthMethods: [String?]? = nilOrValue(__pigeon_list[5])
+    let allowPrepaidCards: Bool? = nilOrValue(__pigeon_list[6])
+    let allowCreditCards: Bool? = nilOrValue(__pigeon_list[7])
+    let assuranceDetailsRequired: Bool? = nilOrValue(__pigeon_list[8])
+    let emailRequired: Bool? = nilOrValue(__pigeon_list[9])
+    let existingPaymentMethodRequired: Bool? = nilOrValue(__pigeon_list[10])
+    let shippingAddressRequired: Bool? = nilOrValue(__pigeon_list[11])
+    let shippingAddressParametersDTO: ShippingAddressParametersDTO? = nilOrValue(__pigeon_list[12])
+    let billingAddressRequired: Bool? = nilOrValue(__pigeon_list[13])
+    let billingAddressParametersDTO: BillingAddressParametersDTO? = nilOrValue(__pigeon_list[14])
 
-        return GooglePayConfigurationDTO(
-            googlePayEnvironment: googlePayEnvironment,
-            merchantAccount: merchantAccount,
-            merchantInfoDTO: merchantInfoDTO,
-            totalPriceStatus: totalPriceStatus,
-            allowedCardNetworks: allowedCardNetworks,
-            allowedAuthMethods: allowedAuthMethods,
-            allowPrepaidCards: allowPrepaidCards,
-            allowCreditCards: allowCreditCards,
-            assuranceDetailsRequired: assuranceDetailsRequired,
-            emailRequired: emailRequired,
-            existingPaymentMethodRequired: existingPaymentMethodRequired,
-            shippingAddressRequired: shippingAddressRequired,
-            shippingAddressParametersDTO: shippingAddressParametersDTO,
-            billingAddressRequired: billingAddressRequired,
-            billingAddressParametersDTO: billingAddressParametersDTO
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            googlePayEnvironment,
-            merchantAccount,
-            merchantInfoDTO,
-            totalPriceStatus,
-            allowedCardNetworks,
-            allowedAuthMethods,
-            allowPrepaidCards,
-            allowCreditCards,
-            assuranceDetailsRequired,
-            emailRequired,
-            existingPaymentMethodRequired,
-            shippingAddressRequired,
-            shippingAddressParametersDTO,
-            billingAddressRequired,
-            billingAddressParametersDTO
-        ]
-    }
+    return GooglePayConfigurationDTO(
+      googlePayEnvironment: googlePayEnvironment,
+      merchantAccount: merchantAccount,
+      merchantInfoDTO: merchantInfoDTO,
+      totalPriceStatus: totalPriceStatus,
+      allowedCardNetworks: allowedCardNetworks,
+      allowedAuthMethods: allowedAuthMethods,
+      allowPrepaidCards: allowPrepaidCards,
+      allowCreditCards: allowCreditCards,
+      assuranceDetailsRequired: assuranceDetailsRequired,
+      emailRequired: emailRequired,
+      existingPaymentMethodRequired: existingPaymentMethodRequired,
+      shippingAddressRequired: shippingAddressRequired,
+      shippingAddressParametersDTO: shippingAddressParametersDTO,
+      billingAddressRequired: billingAddressRequired,
+      billingAddressParametersDTO: billingAddressParametersDTO
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      googlePayEnvironment,
+      merchantAccount,
+      merchantInfoDTO,
+      totalPriceStatus,
+      allowedCardNetworks,
+      allowedAuthMethods,
+      allowPrepaidCards,
+      allowCreditCards,
+      assuranceDetailsRequired,
+      emailRequired,
+      existingPaymentMethodRequired,
+      shippingAddressRequired,
+      shippingAddressParametersDTO,
+      billingAddressRequired,
+      billingAddressParametersDTO,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct MerchantInfoDTO {
-    var merchantName: String?
-    var merchantId: String?
+  var merchantName: String? = nil
+  var merchantId: String? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> MerchantInfoDTO? {
-        let merchantName: String? = nilOrValue(__pigeon_list[0])
-        let merchantId: String? = nilOrValue(__pigeon_list[1])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> MerchantInfoDTO? {
+    let merchantName: String? = nilOrValue(__pigeon_list[0])
+    let merchantId: String? = nilOrValue(__pigeon_list[1])
 
-        return MerchantInfoDTO(
-            merchantName: merchantName,
-            merchantId: merchantId
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            merchantName,
-            merchantId
-        ]
-    }
+    return MerchantInfoDTO(
+      merchantName: merchantName,
+      merchantId: merchantId
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      merchantName,
+      merchantId,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ShippingAddressParametersDTO {
-    var allowedCountryCodes: [String?]?
-    var isPhoneNumberRequired: Bool?
+  var allowedCountryCodes: [String?]? = nil
+  var isPhoneNumberRequired: Bool? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ShippingAddressParametersDTO? {
-        let allowedCountryCodes: [String?]? = nilOrValue(__pigeon_list[0])
-        let isPhoneNumberRequired: Bool? = nilOrValue(__pigeon_list[1])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ShippingAddressParametersDTO? {
+    let allowedCountryCodes: [String?]? = nilOrValue(__pigeon_list[0])
+    let isPhoneNumberRequired: Bool? = nilOrValue(__pigeon_list[1])
 
-        return ShippingAddressParametersDTO(
-            allowedCountryCodes: allowedCountryCodes,
-            isPhoneNumberRequired: isPhoneNumberRequired
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            allowedCountryCodes,
-            isPhoneNumberRequired
-        ]
-    }
+    return ShippingAddressParametersDTO(
+      allowedCountryCodes: allowedCountryCodes,
+      isPhoneNumberRequired: isPhoneNumberRequired
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      allowedCountryCodes,
+      isPhoneNumberRequired,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct BillingAddressParametersDTO {
-    var format: String?
-    var isPhoneNumberRequired: Bool?
+  var format: String? = nil
+  var isPhoneNumberRequired: Bool? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> BillingAddressParametersDTO? {
-        let format: String? = nilOrValue(__pigeon_list[0])
-        let isPhoneNumberRequired: Bool? = nilOrValue(__pigeon_list[1])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> BillingAddressParametersDTO? {
+    let format: String? = nilOrValue(__pigeon_list[0])
+    let isPhoneNumberRequired: Bool? = nilOrValue(__pigeon_list[1])
 
-        return BillingAddressParametersDTO(
-            format: format,
-            isPhoneNumberRequired: isPhoneNumberRequired
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            format,
-            isPhoneNumberRequired
-        ]
-    }
+    return BillingAddressParametersDTO(
+      format: format,
+      isPhoneNumberRequired: isPhoneNumberRequired
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      format,
+      isPhoneNumberRequired,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct CashAppPayConfigurationDTO {
-    var cashAppPayEnvironment: CashAppPayEnvironment
-    var returnUrl: String
+  var cashAppPayEnvironment: CashAppPayEnvironment
+  var returnUrl: String
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> CashAppPayConfigurationDTO? {
-        let cashAppPayEnvironment = __pigeon_list[0] as! CashAppPayEnvironment
-        let returnUrl = __pigeon_list[1] as! String
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> CashAppPayConfigurationDTO? {
+    let cashAppPayEnvironment = __pigeon_list[0] as! CashAppPayEnvironment
+    let returnUrl = __pigeon_list[1] as! String
 
-        return CashAppPayConfigurationDTO(
-            cashAppPayEnvironment: cashAppPayEnvironment,
-            returnUrl: returnUrl
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            cashAppPayEnvironment,
-            returnUrl
-        ]
-    }
+    return CashAppPayConfigurationDTO(
+      cashAppPayEnvironment: cashAppPayEnvironment,
+      returnUrl: returnUrl
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      cashAppPayEnvironment,
+      returnUrl,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct TwintConfigurationDTO {
-    var iosCallbackAppScheme: String
-    var showStorePaymentField: Bool
+  var iosCallbackAppScheme: String
+  var showStorePaymentField: Bool
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> TwintConfigurationDTO? {
-        let iosCallbackAppScheme = __pigeon_list[0] as! String
-        let showStorePaymentField = __pigeon_list[1] as! Bool
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> TwintConfigurationDTO? {
+    let iosCallbackAppScheme = __pigeon_list[0] as! String
+    let showStorePaymentField = __pigeon_list[1] as! Bool
 
-        return TwintConfigurationDTO(
-            iosCallbackAppScheme: iosCallbackAppScheme,
-            showStorePaymentField: showStorePaymentField
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            iosCallbackAppScheme,
-            showStorePaymentField
-        ]
-    }
+    return TwintConfigurationDTO(
+      iosCallbackAppScheme: iosCallbackAppScheme,
+      showStorePaymentField: showStorePaymentField
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      iosCallbackAppScheme,
+      showStorePaymentField,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct PaymentResultDTO {
-    var type: PaymentResultEnum
-    var reason: String?
-    var result: PaymentResultModelDTO?
+  var type: PaymentResultEnum
+  var reason: String? = nil
+  var result: PaymentResultModelDTO? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> PaymentResultDTO? {
-        let type = __pigeon_list[0] as! PaymentResultEnum
-        let reason: String? = nilOrValue(__pigeon_list[1])
-        let result: PaymentResultModelDTO? = nilOrValue(__pigeon_list[2])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> PaymentResultDTO? {
+    let type = __pigeon_list[0] as! PaymentResultEnum
+    let reason: String? = nilOrValue(__pigeon_list[1])
+    let result: PaymentResultModelDTO? = nilOrValue(__pigeon_list[2])
 
-        return PaymentResultDTO(
-            type: type,
-            reason: reason,
-            result: result
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            type,
-            reason,
-            result
-        ]
-    }
+    return PaymentResultDTO(
+      type: type,
+      reason: reason,
+      result: result
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      type,
+      reason,
+      result,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct PaymentResultModelDTO {
-    var sessionId: String?
-    var sessionData: String?
-    var sessionResult: String?
-    var resultCode: String?
-    var order: OrderResponseDTO?
+  var sessionId: String? = nil
+  var sessionData: String? = nil
+  var sessionResult: String? = nil
+  var resultCode: String? = nil
+  var order: OrderResponseDTO? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> PaymentResultModelDTO? {
-        let sessionId: String? = nilOrValue(__pigeon_list[0])
-        let sessionData: String? = nilOrValue(__pigeon_list[1])
-        let sessionResult: String? = nilOrValue(__pigeon_list[2])
-        let resultCode: String? = nilOrValue(__pigeon_list[3])
-        let order: OrderResponseDTO? = nilOrValue(__pigeon_list[4])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> PaymentResultModelDTO? {
+    let sessionId: String? = nilOrValue(__pigeon_list[0])
+    let sessionData: String? = nilOrValue(__pigeon_list[1])
+    let sessionResult: String? = nilOrValue(__pigeon_list[2])
+    let resultCode: String? = nilOrValue(__pigeon_list[3])
+    let order: OrderResponseDTO? = nilOrValue(__pigeon_list[4])
 
-        return PaymentResultModelDTO(
-            sessionId: sessionId,
-            sessionData: sessionData,
-            sessionResult: sessionResult,
-            resultCode: resultCode,
-            order: order
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            sessionId,
-            sessionData,
-            sessionResult,
-            resultCode,
-            order
-        ]
-    }
+    return PaymentResultModelDTO(
+      sessionId: sessionId,
+      sessionData: sessionData,
+      sessionResult: sessionResult,
+      resultCode: resultCode,
+      order: order
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      sessionId,
+      sessionData,
+      sessionResult,
+      resultCode,
+      order,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct OrderResponseDTO {
-    var pspReference: String
-    var orderData: String
-    var amount: AmountDTO?
-    var remainingAmount: AmountDTO?
+  var pspReference: String
+  var orderData: String
+  var amount: AmountDTO? = nil
+  var remainingAmount: AmountDTO? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> OrderResponseDTO? {
-        let pspReference = __pigeon_list[0] as! String
-        let orderData = __pigeon_list[1] as! String
-        let amount: AmountDTO? = nilOrValue(__pigeon_list[2])
-        let remainingAmount: AmountDTO? = nilOrValue(__pigeon_list[3])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> OrderResponseDTO? {
+    let pspReference = __pigeon_list[0] as! String
+    let orderData = __pigeon_list[1] as! String
+    let amount: AmountDTO? = nilOrValue(__pigeon_list[2])
+    let remainingAmount: AmountDTO? = nilOrValue(__pigeon_list[3])
 
-        return OrderResponseDTO(
-            pspReference: pspReference,
-            orderData: orderData,
-            amount: amount,
-            remainingAmount: remainingAmount
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            pspReference,
-            orderData,
-            amount,
-            remainingAmount
-        ]
-    }
+    return OrderResponseDTO(
+      pspReference: pspReference,
+      orderData: orderData,
+      amount: amount,
+      remainingAmount: remainingAmount
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      pspReference,
+      orderData,
+      amount,
+      remainingAmount,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct CheckoutEvent {
-    var type: CheckoutEventType
-    var data: Any?
+  var type: CheckoutEventType
+  var data: Any? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> CheckoutEvent? {
-        let type = __pigeon_list[0] as! CheckoutEventType
-        let data: Any? = __pigeon_list[1]
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> CheckoutEvent? {
+    let type = __pigeon_list[0] as! CheckoutEventType
+    let data: Any? = __pigeon_list[1]
 
-        return CheckoutEvent(
-            type: type,
-            data: data
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            type,
-            data
-        ]
-    }
+    return CheckoutEvent(
+      type: type,
+      data: data
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      type,
+      data,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ComponentCommunicationModel {
-    var type: ComponentCommunicationType
-    var componentId: String
-    var data: Any?
-    var paymentResult: PaymentResultDTO?
+  var type: ComponentCommunicationType
+  var componentId: String
+  var data: Any? = nil
+  var paymentResult: PaymentResultDTO? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ComponentCommunicationModel? {
-        let type = __pigeon_list[0] as! ComponentCommunicationType
-        let componentId = __pigeon_list[1] as! String
-        let data: Any? = __pigeon_list[2]
-        let paymentResult: PaymentResultDTO? = nilOrValue(__pigeon_list[3])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ComponentCommunicationModel? {
+    let type = __pigeon_list[0] as! ComponentCommunicationType
+    let componentId = __pigeon_list[1] as! String
+    let data: Any? = __pigeon_list[2]
+    let paymentResult: PaymentResultDTO? = nilOrValue(__pigeon_list[3])
 
-        return ComponentCommunicationModel(
-            type: type,
-            componentId: componentId,
-            data: data,
-            paymentResult: paymentResult
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            type,
-            componentId,
-            data,
-            paymentResult
-        ]
-    }
+    return ComponentCommunicationModel(
+      type: type,
+      componentId: componentId,
+      data: data,
+      paymentResult: paymentResult
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      type,
+      componentId,
+      data,
+      paymentResult,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct PaymentEventDTO {
-    var paymentEventType: PaymentEventType
-    var result: String?
-    var data: [String?: Any?]?
-    var error: ErrorDTO?
+  var paymentEventType: PaymentEventType
+  var result: String? = nil
+  var data: [String?: Any?]? = nil
+  var error: ErrorDTO? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> PaymentEventDTO? {
-        let paymentEventType = __pigeon_list[0] as! PaymentEventType
-        let result: String? = nilOrValue(__pigeon_list[1])
-        let data: [String?: Any?]? = nilOrValue(__pigeon_list[2])
-        let error: ErrorDTO? = nilOrValue(__pigeon_list[3])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> PaymentEventDTO? {
+    let paymentEventType = __pigeon_list[0] as! PaymentEventType
+    let result: String? = nilOrValue(__pigeon_list[1])
+    let data: [String?: Any?]? = nilOrValue(__pigeon_list[2])
+    let error: ErrorDTO? = nilOrValue(__pigeon_list[3])
 
-        return PaymentEventDTO(
-            paymentEventType: paymentEventType,
-            result: result,
-            data: data,
-            error: error
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            paymentEventType,
-            result,
-            data,
-            error
-        ]
-    }
+    return PaymentEventDTO(
+      paymentEventType: paymentEventType,
+      result: result,
+      data: data,
+      error: error
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      paymentEventType,
+      result,
+      data,
+      error,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ErrorDTO {
-    var errorMessage: String?
-    var reason: String?
-    var dismissDropIn: Bool?
+  var errorMessage: String? = nil
+  var reason: String? = nil
+  var dismissDropIn: Bool? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ErrorDTO? {
-        let errorMessage: String? = nilOrValue(__pigeon_list[0])
-        let reason: String? = nilOrValue(__pigeon_list[1])
-        let dismissDropIn: Bool? = nilOrValue(__pigeon_list[2])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ErrorDTO? {
+    let errorMessage: String? = nilOrValue(__pigeon_list[0])
+    let reason: String? = nilOrValue(__pigeon_list[1])
+    let dismissDropIn: Bool? = nilOrValue(__pigeon_list[2])
 
-        return ErrorDTO(
-            errorMessage: errorMessage,
-            reason: reason,
-            dismissDropIn: dismissDropIn
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            errorMessage,
-            reason,
-            dismissDropIn
-        ]
-    }
+    return ErrorDTO(
+      errorMessage: errorMessage,
+      reason: reason,
+      dismissDropIn: dismissDropIn
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      errorMessage,
+      reason,
+      dismissDropIn,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct DeletedStoredPaymentMethodResultDTO {
-    var storedPaymentMethodId: String
-    var isSuccessfullyRemoved: Bool
+  var storedPaymentMethodId: String
+  var isSuccessfullyRemoved: Bool
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> DeletedStoredPaymentMethodResultDTO? {
-        let storedPaymentMethodId = __pigeon_list[0] as! String
-        let isSuccessfullyRemoved = __pigeon_list[1] as! Bool
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> DeletedStoredPaymentMethodResultDTO? {
+    let storedPaymentMethodId = __pigeon_list[0] as! String
+    let isSuccessfullyRemoved = __pigeon_list[1] as! Bool
 
-        return DeletedStoredPaymentMethodResultDTO(
-            storedPaymentMethodId: storedPaymentMethodId,
-            isSuccessfullyRemoved: isSuccessfullyRemoved
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            storedPaymentMethodId,
-            isSuccessfullyRemoved
-        ]
-    }
+    return DeletedStoredPaymentMethodResultDTO(
+      storedPaymentMethodId: storedPaymentMethodId,
+      isSuccessfullyRemoved: isSuccessfullyRemoved
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      storedPaymentMethodId,
+      isSuccessfullyRemoved,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct CardComponentConfigurationDTO {
-    var environment: Environment
-    var clientKey: String
-    var countryCode: String
-    var amount: AmountDTO?
-    var shopperLocale: String?
-    var cardConfiguration: CardConfigurationDTO
-    var threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO?
-    var analyticsOptionsDTO: AnalyticsOptionsDTO
+  var environment: Environment
+  var clientKey: String
+  var countryCode: String
+  var amount: AmountDTO? = nil
+  var shopperLocale: String? = nil
+  var cardConfiguration: CardConfigurationDTO
+  var threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil
+  var analyticsOptionsDTO: AnalyticsOptionsDTO
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> CardComponentConfigurationDTO? {
-        let environment = __pigeon_list[0] as! Environment
-        let clientKey = __pigeon_list[1] as! String
-        let countryCode = __pigeon_list[2] as! String
-        let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
-        let shopperLocale: String? = nilOrValue(__pigeon_list[4])
-        let cardConfiguration = __pigeon_list[5] as! CardConfigurationDTO
-        let threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nilOrValue(__pigeon_list[6])
-        let analyticsOptionsDTO = __pigeon_list[7] as! AnalyticsOptionsDTO
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> CardComponentConfigurationDTO? {
+    let environment = __pigeon_list[0] as! Environment
+    let clientKey = __pigeon_list[1] as! String
+    let countryCode = __pigeon_list[2] as! String
+    let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
+    let shopperLocale: String? = nilOrValue(__pigeon_list[4])
+    let cardConfiguration = __pigeon_list[5] as! CardConfigurationDTO
+    let threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nilOrValue(__pigeon_list[6])
+    let analyticsOptionsDTO = __pigeon_list[7] as! AnalyticsOptionsDTO
 
-        return CardComponentConfigurationDTO(
-            environment: environment,
-            clientKey: clientKey,
-            countryCode: countryCode,
-            amount: amount,
-            shopperLocale: shopperLocale,
-            cardConfiguration: cardConfiguration,
-            threeDS2ConfigurationDTO: threeDS2ConfigurationDTO,
-            analyticsOptionsDTO: analyticsOptionsDTO
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            environment,
-            clientKey,
-            countryCode,
-            amount,
-            shopperLocale,
-            cardConfiguration,
-            threeDS2ConfigurationDTO,
-            analyticsOptionsDTO
-        ]
-    }
+    return CardComponentConfigurationDTO(
+      environment: environment,
+      clientKey: clientKey,
+      countryCode: countryCode,
+      amount: amount,
+      shopperLocale: shopperLocale,
+      cardConfiguration: cardConfiguration,
+      threeDS2ConfigurationDTO: threeDS2ConfigurationDTO,
+      analyticsOptionsDTO: analyticsOptionsDTO
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      environment,
+      clientKey,
+      countryCode,
+      amount,
+      shopperLocale,
+      cardConfiguration,
+      threeDS2ConfigurationDTO,
+      analyticsOptionsDTO,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct BlikComponentConfigurationDTO {
-    var environment: Environment
-    var clientKey: String
-    var countryCode: String
-    var amount: AmountDTO?
-    var shopperLocale: String?
-    var analyticsOptionsDTO: AnalyticsOptionsDTO
+  var environment: Environment
+  var clientKey: String
+  var countryCode: String
+  var amount: AmountDTO? = nil
+  var shopperLocale: String? = nil
+  var analyticsOptionsDTO: AnalyticsOptionsDTO
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> BlikComponentConfigurationDTO? {
-        let environment = __pigeon_list[0] as! Environment
-        let clientKey = __pigeon_list[1] as! String
-        let countryCode = __pigeon_list[2] as! String
-        let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
-        let shopperLocale: String? = nilOrValue(__pigeon_list[4])
-        let analyticsOptionsDTO = __pigeon_list[5] as! AnalyticsOptionsDTO
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> BlikComponentConfigurationDTO? {
+    let environment = __pigeon_list[0] as! Environment
+    let clientKey = __pigeon_list[1] as! String
+    let countryCode = __pigeon_list[2] as! String
+    let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
+    let shopperLocale: String? = nilOrValue(__pigeon_list[4])
+    let analyticsOptionsDTO = __pigeon_list[5] as! AnalyticsOptionsDTO
 
-        return BlikComponentConfigurationDTO(
-            environment: environment,
-            clientKey: clientKey,
-            countryCode: countryCode,
-            amount: amount,
-            shopperLocale: shopperLocale,
-            analyticsOptionsDTO: analyticsOptionsDTO
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            environment,
-            clientKey,
-            countryCode,
-            amount,
-            shopperLocale,
-            analyticsOptionsDTO
-        ]
-    }
+    return BlikComponentConfigurationDTO(
+      environment: environment,
+      clientKey: clientKey,
+      countryCode: countryCode,
+      amount: amount,
+      shopperLocale: shopperLocale,
+      analyticsOptionsDTO: analyticsOptionsDTO
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      environment,
+      clientKey,
+      countryCode,
+      amount,
+      shopperLocale,
+      analyticsOptionsDTO,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct InstantPaymentConfigurationDTO {
-    var instantPaymentType: InstantPaymentType
-    var environment: Environment
-    var clientKey: String
-    var countryCode: String
-    var amount: AmountDTO?
-    var shopperLocale: String?
-    var analyticsOptionsDTO: AnalyticsOptionsDTO
-    var googlePayConfigurationDTO: GooglePayConfigurationDTO?
-    var applePayConfigurationDTO: ApplePayConfigurationDTO?
+  var instantPaymentType: InstantPaymentType
+  var environment: Environment
+  var clientKey: String
+  var countryCode: String
+  var amount: AmountDTO? = nil
+  var shopperLocale: String? = nil
+  var analyticsOptionsDTO: AnalyticsOptionsDTO
+  var googlePayConfigurationDTO: GooglePayConfigurationDTO? = nil
+  var applePayConfigurationDTO: ApplePayConfigurationDTO? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> InstantPaymentConfigurationDTO? {
-        let instantPaymentType = __pigeon_list[0] as! InstantPaymentType
-        let environment = __pigeon_list[1] as! Environment
-        let clientKey = __pigeon_list[2] as! String
-        let countryCode = __pigeon_list[3] as! String
-        let amount: AmountDTO? = nilOrValue(__pigeon_list[4])
-        let shopperLocale: String? = nilOrValue(__pigeon_list[5])
-        let analyticsOptionsDTO = __pigeon_list[6] as! AnalyticsOptionsDTO
-        let googlePayConfigurationDTO: GooglePayConfigurationDTO? = nilOrValue(__pigeon_list[7])
-        let applePayConfigurationDTO: ApplePayConfigurationDTO? = nilOrValue(__pigeon_list[8])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> InstantPaymentConfigurationDTO? {
+    let instantPaymentType = __pigeon_list[0] as! InstantPaymentType
+    let environment = __pigeon_list[1] as! Environment
+    let clientKey = __pigeon_list[2] as! String
+    let countryCode = __pigeon_list[3] as! String
+    let amount: AmountDTO? = nilOrValue(__pigeon_list[4])
+    let shopperLocale: String? = nilOrValue(__pigeon_list[5])
+    let analyticsOptionsDTO = __pigeon_list[6] as! AnalyticsOptionsDTO
+    let googlePayConfigurationDTO: GooglePayConfigurationDTO? = nilOrValue(__pigeon_list[7])
+    let applePayConfigurationDTO: ApplePayConfigurationDTO? = nilOrValue(__pigeon_list[8])
 
-        return InstantPaymentConfigurationDTO(
-            instantPaymentType: instantPaymentType,
-            environment: environment,
-            clientKey: clientKey,
-            countryCode: countryCode,
-            amount: amount,
-            shopperLocale: shopperLocale,
-            analyticsOptionsDTO: analyticsOptionsDTO,
-            googlePayConfigurationDTO: googlePayConfigurationDTO,
-            applePayConfigurationDTO: applePayConfigurationDTO
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            instantPaymentType,
-            environment,
-            clientKey,
-            countryCode,
-            amount,
-            shopperLocale,
-            analyticsOptionsDTO,
-            googlePayConfigurationDTO,
-            applePayConfigurationDTO
-        ]
-    }
+    return InstantPaymentConfigurationDTO(
+      instantPaymentType: instantPaymentType,
+      environment: environment,
+      clientKey: clientKey,
+      countryCode: countryCode,
+      amount: amount,
+      shopperLocale: shopperLocale,
+      analyticsOptionsDTO: analyticsOptionsDTO,
+      googlePayConfigurationDTO: googlePayConfigurationDTO,
+      applePayConfigurationDTO: applePayConfigurationDTO
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      instantPaymentType,
+      environment,
+      clientKey,
+      countryCode,
+      amount,
+      shopperLocale,
+      analyticsOptionsDTO,
+      googlePayConfigurationDTO,
+      applePayConfigurationDTO,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct InstantPaymentSetupResultDTO {
-    var instantPaymentType: InstantPaymentType
-    var isSupported: Bool
-    var resultData: Any?
+  var instantPaymentType: InstantPaymentType
+  var isSupported: Bool
+  var resultData: Any? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> InstantPaymentSetupResultDTO? {
-        let instantPaymentType = __pigeon_list[0] as! InstantPaymentType
-        let isSupported = __pigeon_list[1] as! Bool
-        let resultData: Any? = __pigeon_list[2]
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> InstantPaymentSetupResultDTO? {
+    let instantPaymentType = __pigeon_list[0] as! InstantPaymentType
+    let isSupported = __pigeon_list[1] as! Bool
+    let resultData: Any? = __pigeon_list[2]
 
-        return InstantPaymentSetupResultDTO(
-            instantPaymentType: instantPaymentType,
-            isSupported: isSupported,
-            resultData: resultData
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            instantPaymentType,
-            isSupported,
-            resultData
-        ]
-    }
+    return InstantPaymentSetupResultDTO(
+      instantPaymentType: instantPaymentType,
+      isSupported: isSupported,
+      resultData: resultData
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      instantPaymentType,
+      isSupported,
+      resultData,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct UnencryptedCardDTO {
-    var cardNumber: String?
-    var expiryMonth: String?
-    var expiryYear: String?
-    var cvc: String?
+  var cardNumber: String? = nil
+  var expiryMonth: String? = nil
+  var expiryYear: String? = nil
+  var cvc: String? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> UnencryptedCardDTO? {
-        let cardNumber: String? = nilOrValue(__pigeon_list[0])
-        let expiryMonth: String? = nilOrValue(__pigeon_list[1])
-        let expiryYear: String? = nilOrValue(__pigeon_list[2])
-        let cvc: String? = nilOrValue(__pigeon_list[3])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> UnencryptedCardDTO? {
+    let cardNumber: String? = nilOrValue(__pigeon_list[0])
+    let expiryMonth: String? = nilOrValue(__pigeon_list[1])
+    let expiryYear: String? = nilOrValue(__pigeon_list[2])
+    let cvc: String? = nilOrValue(__pigeon_list[3])
 
-        return UnencryptedCardDTO(
-            cardNumber: cardNumber,
-            expiryMonth: expiryMonth,
-            expiryYear: expiryYear,
-            cvc: cvc
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            cardNumber,
-            expiryMonth,
-            expiryYear,
-            cvc
-        ]
-    }
+    return UnencryptedCardDTO(
+      cardNumber: cardNumber,
+      expiryMonth: expiryMonth,
+      expiryYear: expiryYear,
+      cvc: cvc
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      cardNumber,
+      expiryMonth,
+      expiryYear,
+      cvc,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct EncryptedCardDTO {
-    var encryptedCardNumber: String?
-    var encryptedExpiryMonth: String?
-    var encryptedExpiryYear: String?
-    var encryptedSecurityCode: String?
+  var encryptedCardNumber: String? = nil
+  var encryptedExpiryMonth: String? = nil
+  var encryptedExpiryYear: String? = nil
+  var encryptedSecurityCode: String? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> EncryptedCardDTO? {
-        let encryptedCardNumber: String? = nilOrValue(__pigeon_list[0])
-        let encryptedExpiryMonth: String? = nilOrValue(__pigeon_list[1])
-        let encryptedExpiryYear: String? = nilOrValue(__pigeon_list[2])
-        let encryptedSecurityCode: String? = nilOrValue(__pigeon_list[3])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> EncryptedCardDTO? {
+    let encryptedCardNumber: String? = nilOrValue(__pigeon_list[0])
+    let encryptedExpiryMonth: String? = nilOrValue(__pigeon_list[1])
+    let encryptedExpiryYear: String? = nilOrValue(__pigeon_list[2])
+    let encryptedSecurityCode: String? = nilOrValue(__pigeon_list[3])
 
-        return EncryptedCardDTO(
-            encryptedCardNumber: encryptedCardNumber,
-            encryptedExpiryMonth: encryptedExpiryMonth,
-            encryptedExpiryYear: encryptedExpiryYear,
-            encryptedSecurityCode: encryptedSecurityCode
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            encryptedCardNumber,
-            encryptedExpiryMonth,
-            encryptedExpiryYear,
-            encryptedSecurityCode
-        ]
-    }
+    return EncryptedCardDTO(
+      encryptedCardNumber: encryptedCardNumber,
+      encryptedExpiryMonth: encryptedExpiryMonth,
+      encryptedExpiryYear: encryptedExpiryYear,
+      encryptedSecurityCode: encryptedSecurityCode
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      encryptedCardNumber,
+      encryptedExpiryMonth,
+      encryptedExpiryYear,
+      encryptedSecurityCode,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ActionComponentConfigurationDTO {
-    var environment: Environment
-    var clientKey: String
-    var shopperLocale: String?
-    var amount: AmountDTO?
-    var analyticsOptionsDTO: AnalyticsOptionsDTO
+  var environment: Environment
+  var clientKey: String
+  var shopperLocale: String? = nil
+  var amount: AmountDTO? = nil
+  var analyticsOptionsDTO: AnalyticsOptionsDTO
+  var threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> ActionComponentConfigurationDTO? {
-        let environment = __pigeon_list[0] as! Environment
-        let clientKey = __pigeon_list[1] as! String
-        let shopperLocale: String? = nilOrValue(__pigeon_list[2])
-        let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
-        let analyticsOptionsDTO = __pigeon_list[4] as! AnalyticsOptionsDTO
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> ActionComponentConfigurationDTO? {
+    let environment = __pigeon_list[0] as! Environment
+    let clientKey = __pigeon_list[1] as! String
+    let shopperLocale: String? = nilOrValue(__pigeon_list[2])
+    let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
+    let analyticsOptionsDTO = __pigeon_list[4] as! AnalyticsOptionsDTO
+    let threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nilOrValue(__pigeon_list[5])
 
-        return ActionComponentConfigurationDTO(
-            environment: environment,
-            clientKey: clientKey,
-            shopperLocale: shopperLocale,
-            amount: amount,
-            analyticsOptionsDTO: analyticsOptionsDTO
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            environment,
-            clientKey,
-            shopperLocale,
-            amount,
-            analyticsOptionsDTO
-        ]
-    }
+    return ActionComponentConfigurationDTO(
+      environment: environment,
+      clientKey: clientKey,
+      shopperLocale: shopperLocale,
+      amount: amount,
+      analyticsOptionsDTO: analyticsOptionsDTO,
+      threeDS2ConfigurationDTO: threeDS2ConfigurationDTO
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      environment,
+      clientKey,
+      shopperLocale,
+      amount,
+      analyticsOptionsDTO,
+      threeDS2ConfigurationDTO,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct OrderCancelResultDTO {
-    var orderCancelResponseBody: [String?: Any?]
-    var updatedPaymentMethodsResponseBody: [String?: Any?]?
+  var orderCancelResponseBody: [String?: Any?]
+  var updatedPaymentMethodsResponseBody: [String?: Any?]? = nil
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> OrderCancelResultDTO? {
-        let orderCancelResponseBody = __pigeon_list[0] as! [String?: Any?]
-        let updatedPaymentMethodsResponseBody: [String?: Any?]? = nilOrValue(__pigeon_list[1])
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> OrderCancelResultDTO? {
+    let orderCancelResponseBody = __pigeon_list[0] as! [String?: Any?]
+    let updatedPaymentMethodsResponseBody: [String?: Any?]? = nilOrValue(__pigeon_list[1])
 
-        return OrderCancelResultDTO(
-            orderCancelResponseBody: orderCancelResponseBody,
-            updatedPaymentMethodsResponseBody: updatedPaymentMethodsResponseBody
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            orderCancelResponseBody,
-            updatedPaymentMethodsResponseBody
-        ]
-    }
+    return OrderCancelResultDTO(
+      orderCancelResponseBody: orderCancelResponseBody,
+      updatedPaymentMethodsResponseBody: updatedPaymentMethodsResponseBody
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      orderCancelResponseBody,
+      updatedPaymentMethodsResponseBody,
+    ]
+  }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct BinLookupDataDTO {
-    var brand: String
+  var brand: String
 
-    // swift-format-ignore: AlwaysUseLowerCamelCase
-    static func fromList(_ __pigeon_list: [Any?]) -> BinLookupDataDTO? {
-        let brand = __pigeon_list[0] as! String
+  // swift-format-ignore: AlwaysUseLowerCamelCase
+  static func fromList(_ __pigeon_list: [Any?]) -> BinLookupDataDTO? {
+    let brand = __pigeon_list[0] as! String
 
-        return BinLookupDataDTO(
-            brand: brand
-        )
-    }
-
-    func toList() -> [Any?] {
-        [
-            brand
-        ]
-    }
+    return BinLookupDataDTO(
+      brand: brand
+    )
+  }
+  func toList() -> [Any?] {
+    return [
+      brand
+    ]
+  }
 }
-
 private class PlatformApiPigeonCodecReader: FlutterStandardReader {
-    override func readValue(ofType type: UInt8) -> Any? {
-        switch type {
-        case 129:
-            return SessionDTO.fromList(self.readValue() as! [Any?])
-        case 130:
-            return AmountDTO.fromList(self.readValue() as! [Any?])
-        case 131:
-            return AnalyticsOptionsDTO.fromList(self.readValue() as! [Any?])
-        case 132:
-            return ThreeDS2UICustomizationDTO.fromList(self.readValue() as! [Any?])
-        case 133:
-            return ThreeDS2ScreenCustomizationDTO.fromList(self.readValue() as! [Any?])
-        case 134:
-            return ThreeDS2ButtonCustomizationDTO.fromList(self.readValue() as! [Any?])
-        case 135:
-            return ThreeDS2SelectionItemCustomizationDTO.fromList(self.readValue() as! [Any?])
-        case 136:
-            return ThreeDS2LabelCustomizationDTO.fromList(self.readValue() as! [Any?])
-        case 137:
-            return ThreeDS2InputCustomizationDTO.fromList(self.readValue() as! [Any?])
-        case 138:
-            return ThreeDS2ToolbarCustomizationDTO.fromList(self.readValue() as! [Any?])
-        case 139:
-            return ThreeDS2ConfigurationDTO.fromList(self.readValue() as! [Any?])
-        case 140:
-            return DefaultInstallmentOptionsDTO.fromList(self.readValue() as! [Any?])
-        case 141:
-            return CardBasedInstallmentOptionsDTO.fromList(self.readValue() as! [Any?])
-        case 142:
-            return InstallmentConfigurationDTO.fromList(self.readValue() as! [Any?])
-        case 143:
-            return DropInConfigurationDTO.fromList(self.readValue() as! [Any?])
-        case 144:
-            return CardConfigurationDTO.fromList(self.readValue() as! [Any?])
-        case 145:
-            return ApplePayConfigurationDTO.fromList(self.readValue() as! [Any?])
-        case 146:
-            return ApplePayContactDTO.fromList(self.readValue() as! [Any?])
-        case 147:
-            return ApplePayShippingMethodDTO.fromList(self.readValue() as! [Any?])
-        case 148:
-            return ApplePaySummaryItemDTO.fromList(self.readValue() as! [Any?])
-        case 149:
-            return GooglePayConfigurationDTO.fromList(self.readValue() as! [Any?])
-        case 150:
-            return MerchantInfoDTO.fromList(self.readValue() as! [Any?])
-        case 151:
-            return ShippingAddressParametersDTO.fromList(self.readValue() as! [Any?])
-        case 152:
-            return BillingAddressParametersDTO.fromList(self.readValue() as! [Any?])
-        case 153:
-            return CashAppPayConfigurationDTO.fromList(self.readValue() as! [Any?])
-        case 154:
-            return TwintConfigurationDTO.fromList(self.readValue() as! [Any?])
-        case 155:
-            return PaymentResultDTO.fromList(self.readValue() as! [Any?])
-        case 156:
-            return PaymentResultModelDTO.fromList(self.readValue() as! [Any?])
-        case 157:
-            return OrderResponseDTO.fromList(self.readValue() as! [Any?])
-        case 158:
-            return CheckoutEvent.fromList(self.readValue() as! [Any?])
-        case 159:
-            return ComponentCommunicationModel.fromList(self.readValue() as! [Any?])
-        case 160:
-            return PaymentEventDTO.fromList(self.readValue() as! [Any?])
-        case 161:
-            return ErrorDTO.fromList(self.readValue() as! [Any?])
-        case 162:
-            return DeletedStoredPaymentMethodResultDTO.fromList(self.readValue() as! [Any?])
-        case 163:
-            return CardComponentConfigurationDTO.fromList(self.readValue() as! [Any?])
-        case 164:
-            return BlikComponentConfigurationDTO.fromList(self.readValue() as! [Any?])
-        case 165:
-            return InstantPaymentConfigurationDTO.fromList(self.readValue() as! [Any?])
-        case 166:
-            return InstantPaymentSetupResultDTO.fromList(self.readValue() as! [Any?])
-        case 167:
-            return UnencryptedCardDTO.fromList(self.readValue() as! [Any?])
-        case 168:
-            return EncryptedCardDTO.fromList(self.readValue() as! [Any?])
-        case 169:
-            return ActionComponentConfigurationDTO.fromList(self.readValue() as! [Any?])
-        case 170:
-            return OrderCancelResultDTO.fromList(self.readValue() as! [Any?])
-        case 171:
-            return BinLookupDataDTO.fromList(self.readValue() as! [Any?])
-        case 172:
-            var enumResult: Environment? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = Environment(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 173:
-            var enumResult: AddressMode? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = AddressMode(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 174:
-            var enumResult: CardAuthMethod? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = CardAuthMethod(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 175:
-            var enumResult: TotalPriceStatus? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = TotalPriceStatus(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 176:
-            var enumResult: GooglePayEnvironment? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = GooglePayEnvironment(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 177:
-            var enumResult: CashAppPayEnvironment? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = CashAppPayEnvironment(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 178:
-            var enumResult: PaymentResultEnum? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = PaymentResultEnum(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 179:
-            var enumResult: CheckoutEventType? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = CheckoutEventType(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 180:
-            var enumResult: ComponentCommunicationType? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = ComponentCommunicationType(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 181:
-            var enumResult: PaymentEventType? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = PaymentEventType(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 182:
-            var enumResult: FieldVisibility? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = FieldVisibility(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 183:
-            var enumResult: InstantPaymentType? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = InstantPaymentType(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 184:
-            var enumResult: ApplePayShippingType? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = ApplePayShippingType(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 185:
-            var enumResult: ApplePayMerchantCapability? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = ApplePayMerchantCapability(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 186:
-            var enumResult: ApplePaySummaryItemType? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = ApplePaySummaryItemType(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 187:
-            var enumResult: CardNumberValidationResultDTO? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = CardNumberValidationResultDTO(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 188:
-            var enumResult: CardExpiryDateValidationResultDTO? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = CardExpiryDateValidationResultDTO(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        case 189:
-            var enumResult: CardSecurityCodeValidationResultDTO? = nil
-            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-            if let enumResultAsInt {
-                enumResult = CardSecurityCodeValidationResultDTO(rawValue: enumResultAsInt)
-            }
-            return enumResult
-        default:
-            return super.readValue(ofType: type)
-        }
+  override func readValue(ofType type: UInt8) -> Any? {
+    switch type {
+    case 129:
+      return SessionDTO.fromList(self.readValue() as! [Any?])
+    case 130:
+      return AmountDTO.fromList(self.readValue() as! [Any?])
+    case 131:
+      return AnalyticsOptionsDTO.fromList(self.readValue() as! [Any?])
+    case 132:
+      return ThreeDS2UICustomizationDTO.fromList(self.readValue() as! [Any?])
+    case 133:
+      return ThreeDS2ScreenCustomizationDTO.fromList(self.readValue() as! [Any?])
+    case 134:
+      return ThreeDS2ButtonCustomizationDTO.fromList(self.readValue() as! [Any?])
+    case 135:
+      return ThreeDS2SelectionItemCustomizationDTO.fromList(self.readValue() as! [Any?])
+    case 136:
+      return ThreeDS2LabelCustomizationDTO.fromList(self.readValue() as! [Any?])
+    case 137:
+      return ThreeDS2InputCustomizationDTO.fromList(self.readValue() as! [Any?])
+    case 138:
+      return ThreeDS2ToolbarCustomizationDTO.fromList(self.readValue() as! [Any?])
+    case 139:
+      return ThreeDS2ConfigurationDTO.fromList(self.readValue() as! [Any?])
+    case 140:
+      return DefaultInstallmentOptionsDTO.fromList(self.readValue() as! [Any?])
+    case 141:
+      return CardBasedInstallmentOptionsDTO.fromList(self.readValue() as! [Any?])
+    case 142:
+      return InstallmentConfigurationDTO.fromList(self.readValue() as! [Any?])
+    case 143:
+      return DropInConfigurationDTO.fromList(self.readValue() as! [Any?])
+    case 144:
+      return CardConfigurationDTO.fromList(self.readValue() as! [Any?])
+    case 145:
+      return ApplePayConfigurationDTO.fromList(self.readValue() as! [Any?])
+    case 146:
+      return ApplePayContactDTO.fromList(self.readValue() as! [Any?])
+    case 147:
+      return ApplePayShippingMethodDTO.fromList(self.readValue() as! [Any?])
+    case 148:
+      return ApplePaySummaryItemDTO.fromList(self.readValue() as! [Any?])
+    case 149:
+      return GooglePayConfigurationDTO.fromList(self.readValue() as! [Any?])
+    case 150:
+      return MerchantInfoDTO.fromList(self.readValue() as! [Any?])
+    case 151:
+      return ShippingAddressParametersDTO.fromList(self.readValue() as! [Any?])
+    case 152:
+      return BillingAddressParametersDTO.fromList(self.readValue() as! [Any?])
+    case 153:
+      return CashAppPayConfigurationDTO.fromList(self.readValue() as! [Any?])
+    case 154:
+      return TwintConfigurationDTO.fromList(self.readValue() as! [Any?])
+    case 155:
+      return PaymentResultDTO.fromList(self.readValue() as! [Any?])
+    case 156:
+      return PaymentResultModelDTO.fromList(self.readValue() as! [Any?])
+    case 157:
+      return OrderResponseDTO.fromList(self.readValue() as! [Any?])
+    case 158:
+      return CheckoutEvent.fromList(self.readValue() as! [Any?])
+    case 159:
+      return ComponentCommunicationModel.fromList(self.readValue() as! [Any?])
+    case 160:
+      return PaymentEventDTO.fromList(self.readValue() as! [Any?])
+    case 161:
+      return ErrorDTO.fromList(self.readValue() as! [Any?])
+    case 162:
+      return DeletedStoredPaymentMethodResultDTO.fromList(self.readValue() as! [Any?])
+    case 163:
+      return CardComponentConfigurationDTO.fromList(self.readValue() as! [Any?])
+    case 164:
+      return BlikComponentConfigurationDTO.fromList(self.readValue() as! [Any?])
+    case 165:
+      return InstantPaymentConfigurationDTO.fromList(self.readValue() as! [Any?])
+    case 166:
+      return InstantPaymentSetupResultDTO.fromList(self.readValue() as! [Any?])
+    case 167:
+      return UnencryptedCardDTO.fromList(self.readValue() as! [Any?])
+    case 168:
+      return EncryptedCardDTO.fromList(self.readValue() as! [Any?])
+    case 169:
+      return ActionComponentConfigurationDTO.fromList(self.readValue() as! [Any?])
+    case 170:
+      return OrderCancelResultDTO.fromList(self.readValue() as! [Any?])
+    case 171:
+      return BinLookupDataDTO.fromList(self.readValue() as! [Any?])
+    case 172:
+      var enumResult: Environment? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = Environment(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 173:
+      var enumResult: AddressMode? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = AddressMode(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 174:
+      var enumResult: CardAuthMethod? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = CardAuthMethod(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 175:
+      var enumResult: TotalPriceStatus? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = TotalPriceStatus(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 176:
+      var enumResult: GooglePayEnvironment? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = GooglePayEnvironment(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 177:
+      var enumResult: CashAppPayEnvironment? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = CashAppPayEnvironment(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 178:
+      var enumResult: PaymentResultEnum? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = PaymentResultEnum(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 179:
+      var enumResult: CheckoutEventType? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = CheckoutEventType(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 180:
+      var enumResult: ComponentCommunicationType? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = ComponentCommunicationType(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 181:
+      var enumResult: PaymentEventType? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = PaymentEventType(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 182:
+      var enumResult: FieldVisibility? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = FieldVisibility(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 183:
+      var enumResult: InstantPaymentType? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = InstantPaymentType(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 184:
+      var enumResult: ApplePayShippingType? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = ApplePayShippingType(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 185:
+      var enumResult: ApplePayMerchantCapability? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = ApplePayMerchantCapability(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 186:
+      var enumResult: ApplePaySummaryItemType? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = ApplePaySummaryItemType(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 187:
+      var enumResult: CardNumberValidationResultDTO? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = CardNumberValidationResultDTO(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 188:
+      var enumResult: CardExpiryDateValidationResultDTO? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = CardExpiryDateValidationResultDTO(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    case 189:
+      var enumResult: CardSecurityCodeValidationResultDTO? = nil
+      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+      if let enumResultAsInt = enumResultAsInt {
+        enumResult = CardSecurityCodeValidationResultDTO(rawValue: enumResultAsInt)
+      }
+      return enumResult
+    default:
+      return super.readValue(ofType: type)
     }
+  }
 }
 
 private class PlatformApiPigeonCodecWriter: FlutterStandardWriter {
-    override func writeValue(_ value: Any) {
-        if let value = value as? SessionDTO {
-            super.writeByte(129)
-            super.writeValue(value.toList())
-        } else if let value = value as? AmountDTO {
-            super.writeByte(130)
-            super.writeValue(value.toList())
-        } else if let value = value as? AnalyticsOptionsDTO {
-            super.writeByte(131)
-            super.writeValue(value.toList())
-        } else if let value = value as? ThreeDS2UICustomizationDTO {
-            super.writeByte(132)
-            super.writeValue(value.toList())
-        } else if let value = value as? ThreeDS2ScreenCustomizationDTO {
-            super.writeByte(133)
-            super.writeValue(value.toList())
-        } else if let value = value as? ThreeDS2ButtonCustomizationDTO {
-            super.writeByte(134)
-            super.writeValue(value.toList())
-        } else if let value = value as? ThreeDS2SelectionItemCustomizationDTO {
-            super.writeByte(135)
-            super.writeValue(value.toList())
-        } else if let value = value as? ThreeDS2LabelCustomizationDTO {
-            super.writeByte(136)
-            super.writeValue(value.toList())
-        } else if let value = value as? ThreeDS2InputCustomizationDTO {
-            super.writeByte(137)
-            super.writeValue(value.toList())
-        } else if let value = value as? ThreeDS2ToolbarCustomizationDTO {
-            super.writeByte(138)
-            super.writeValue(value.toList())
-        } else if let value = value as? ThreeDS2ConfigurationDTO {
-            super.writeByte(139)
-            super.writeValue(value.toList())
-        } else if let value = value as? DefaultInstallmentOptionsDTO {
-            super.writeByte(140)
-            super.writeValue(value.toList())
-        } else if let value = value as? CardBasedInstallmentOptionsDTO {
-            super.writeByte(141)
-            super.writeValue(value.toList())
-        } else if let value = value as? InstallmentConfigurationDTO {
-            super.writeByte(142)
-            super.writeValue(value.toList())
-        } else if let value = value as? DropInConfigurationDTO {
-            super.writeByte(143)
-            super.writeValue(value.toList())
-        } else if let value = value as? CardConfigurationDTO {
-            super.writeByte(144)
-            super.writeValue(value.toList())
-        } else if let value = value as? ApplePayConfigurationDTO {
-            super.writeByte(145)
-            super.writeValue(value.toList())
-        } else if let value = value as? ApplePayContactDTO {
-            super.writeByte(146)
-            super.writeValue(value.toList())
-        } else if let value = value as? ApplePayShippingMethodDTO {
-            super.writeByte(147)
-            super.writeValue(value.toList())
-        } else if let value = value as? ApplePaySummaryItemDTO {
-            super.writeByte(148)
-            super.writeValue(value.toList())
-        } else if let value = value as? GooglePayConfigurationDTO {
-            super.writeByte(149)
-            super.writeValue(value.toList())
-        } else if let value = value as? MerchantInfoDTO {
-            super.writeByte(150)
-            super.writeValue(value.toList())
-        } else if let value = value as? ShippingAddressParametersDTO {
-            super.writeByte(151)
-            super.writeValue(value.toList())
-        } else if let value = value as? BillingAddressParametersDTO {
-            super.writeByte(152)
-            super.writeValue(value.toList())
-        } else if let value = value as? CashAppPayConfigurationDTO {
-            super.writeByte(153)
-            super.writeValue(value.toList())
-        } else if let value = value as? TwintConfigurationDTO {
-            super.writeByte(154)
-            super.writeValue(value.toList())
-        } else if let value = value as? PaymentResultDTO {
-            super.writeByte(155)
-            super.writeValue(value.toList())
-        } else if let value = value as? PaymentResultModelDTO {
-            super.writeByte(156)
-            super.writeValue(value.toList())
-        } else if let value = value as? OrderResponseDTO {
-            super.writeByte(157)
-            super.writeValue(value.toList())
-        } else if let value = value as? CheckoutEvent {
-            super.writeByte(158)
-            super.writeValue(value.toList())
-        } else if let value = value as? ComponentCommunicationModel {
-            super.writeByte(159)
-            super.writeValue(value.toList())
-        } else if let value = value as? PaymentEventDTO {
-            super.writeByte(160)
-            super.writeValue(value.toList())
-        } else if let value = value as? ErrorDTO {
-            super.writeByte(161)
-            super.writeValue(value.toList())
-        } else if let value = value as? DeletedStoredPaymentMethodResultDTO {
-            super.writeByte(162)
-            super.writeValue(value.toList())
-        } else if let value = value as? CardComponentConfigurationDTO {
-            super.writeByte(163)
-            super.writeValue(value.toList())
-        } else if let value = value as? BlikComponentConfigurationDTO {
-            super.writeByte(164)
-            super.writeValue(value.toList())
-        } else if let value = value as? InstantPaymentConfigurationDTO {
-            super.writeByte(165)
-            super.writeValue(value.toList())
-        } else if let value = value as? InstantPaymentSetupResultDTO {
-            super.writeByte(166)
-            super.writeValue(value.toList())
-        } else if let value = value as? UnencryptedCardDTO {
-            super.writeByte(167)
-            super.writeValue(value.toList())
-        } else if let value = value as? EncryptedCardDTO {
-            super.writeByte(168)
-            super.writeValue(value.toList())
-        } else if let value = value as? ActionComponentConfigurationDTO {
-            super.writeByte(169)
-            super.writeValue(value.toList())
-        } else if let value = value as? OrderCancelResultDTO {
-            super.writeByte(170)
-            super.writeValue(value.toList())
-        } else if let value = value as? BinLookupDataDTO {
-            super.writeByte(171)
-            super.writeValue(value.toList())
-        } else if let value = value as? Environment {
-            super.writeByte(172)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? AddressMode {
-            super.writeByte(173)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? CardAuthMethod {
-            super.writeByte(174)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? TotalPriceStatus {
-            super.writeByte(175)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? GooglePayEnvironment {
-            super.writeByte(176)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? CashAppPayEnvironment {
-            super.writeByte(177)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? PaymentResultEnum {
-            super.writeByte(178)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? CheckoutEventType {
-            super.writeByte(179)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? ComponentCommunicationType {
-            super.writeByte(180)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? PaymentEventType {
-            super.writeByte(181)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? FieldVisibility {
-            super.writeByte(182)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? InstantPaymentType {
-            super.writeByte(183)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? ApplePayShippingType {
-            super.writeByte(184)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? ApplePayMerchantCapability {
-            super.writeByte(185)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? ApplePaySummaryItemType {
-            super.writeByte(186)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? CardNumberValidationResultDTO {
-            super.writeByte(187)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? CardExpiryDateValidationResultDTO {
-            super.writeByte(188)
-            super.writeValue(value.rawValue)
-        } else if let value = value as? CardSecurityCodeValidationResultDTO {
-            super.writeByte(189)
-            super.writeValue(value.rawValue)
-        } else {
-            super.writeValue(value)
-        }
+  override func writeValue(_ value: Any) {
+    if let value = value as? SessionDTO {
+      super.writeByte(129)
+      super.writeValue(value.toList())
+    } else if let value = value as? AmountDTO {
+      super.writeByte(130)
+      super.writeValue(value.toList())
+    } else if let value = value as? AnalyticsOptionsDTO {
+      super.writeByte(131)
+      super.writeValue(value.toList())
+    } else if let value = value as? ThreeDS2UICustomizationDTO {
+      super.writeByte(132)
+      super.writeValue(value.toList())
+    } else if let value = value as? ThreeDS2ScreenCustomizationDTO {
+      super.writeByte(133)
+      super.writeValue(value.toList())
+    } else if let value = value as? ThreeDS2ButtonCustomizationDTO {
+      super.writeByte(134)
+      super.writeValue(value.toList())
+    } else if let value = value as? ThreeDS2SelectionItemCustomizationDTO {
+      super.writeByte(135)
+      super.writeValue(value.toList())
+    } else if let value = value as? ThreeDS2LabelCustomizationDTO {
+      super.writeByte(136)
+      super.writeValue(value.toList())
+    } else if let value = value as? ThreeDS2InputCustomizationDTO {
+      super.writeByte(137)
+      super.writeValue(value.toList())
+    } else if let value = value as? ThreeDS2ToolbarCustomizationDTO {
+      super.writeByte(138)
+      super.writeValue(value.toList())
+    } else if let value = value as? ThreeDS2ConfigurationDTO {
+      super.writeByte(139)
+      super.writeValue(value.toList())
+    } else if let value = value as? DefaultInstallmentOptionsDTO {
+      super.writeByte(140)
+      super.writeValue(value.toList())
+    } else if let value = value as? CardBasedInstallmentOptionsDTO {
+      super.writeByte(141)
+      super.writeValue(value.toList())
+    } else if let value = value as? InstallmentConfigurationDTO {
+      super.writeByte(142)
+      super.writeValue(value.toList())
+    } else if let value = value as? DropInConfigurationDTO {
+      super.writeByte(143)
+      super.writeValue(value.toList())
+    } else if let value = value as? CardConfigurationDTO {
+      super.writeByte(144)
+      super.writeValue(value.toList())
+    } else if let value = value as? ApplePayConfigurationDTO {
+      super.writeByte(145)
+      super.writeValue(value.toList())
+    } else if let value = value as? ApplePayContactDTO {
+      super.writeByte(146)
+      super.writeValue(value.toList())
+    } else if let value = value as? ApplePayShippingMethodDTO {
+      super.writeByte(147)
+      super.writeValue(value.toList())
+    } else if let value = value as? ApplePaySummaryItemDTO {
+      super.writeByte(148)
+      super.writeValue(value.toList())
+    } else if let value = value as? GooglePayConfigurationDTO {
+      super.writeByte(149)
+      super.writeValue(value.toList())
+    } else if let value = value as? MerchantInfoDTO {
+      super.writeByte(150)
+      super.writeValue(value.toList())
+    } else if let value = value as? ShippingAddressParametersDTO {
+      super.writeByte(151)
+      super.writeValue(value.toList())
+    } else if let value = value as? BillingAddressParametersDTO {
+      super.writeByte(152)
+      super.writeValue(value.toList())
+    } else if let value = value as? CashAppPayConfigurationDTO {
+      super.writeByte(153)
+      super.writeValue(value.toList())
+    } else if let value = value as? TwintConfigurationDTO {
+      super.writeByte(154)
+      super.writeValue(value.toList())
+    } else if let value = value as? PaymentResultDTO {
+      super.writeByte(155)
+      super.writeValue(value.toList())
+    } else if let value = value as? PaymentResultModelDTO {
+      super.writeByte(156)
+      super.writeValue(value.toList())
+    } else if let value = value as? OrderResponseDTO {
+      super.writeByte(157)
+      super.writeValue(value.toList())
+    } else if let value = value as? CheckoutEvent {
+      super.writeByte(158)
+      super.writeValue(value.toList())
+    } else if let value = value as? ComponentCommunicationModel {
+      super.writeByte(159)
+      super.writeValue(value.toList())
+    } else if let value = value as? PaymentEventDTO {
+      super.writeByte(160)
+      super.writeValue(value.toList())
+    } else if let value = value as? ErrorDTO {
+      super.writeByte(161)
+      super.writeValue(value.toList())
+    } else if let value = value as? DeletedStoredPaymentMethodResultDTO {
+      super.writeByte(162)
+      super.writeValue(value.toList())
+    } else if let value = value as? CardComponentConfigurationDTO {
+      super.writeByte(163)
+      super.writeValue(value.toList())
+    } else if let value = value as? BlikComponentConfigurationDTO {
+      super.writeByte(164)
+      super.writeValue(value.toList())
+    } else if let value = value as? InstantPaymentConfigurationDTO {
+      super.writeByte(165)
+      super.writeValue(value.toList())
+    } else if let value = value as? InstantPaymentSetupResultDTO {
+      super.writeByte(166)
+      super.writeValue(value.toList())
+    } else if let value = value as? UnencryptedCardDTO {
+      super.writeByte(167)
+      super.writeValue(value.toList())
+    } else if let value = value as? EncryptedCardDTO {
+      super.writeByte(168)
+      super.writeValue(value.toList())
+    } else if let value = value as? ActionComponentConfigurationDTO {
+      super.writeByte(169)
+      super.writeValue(value.toList())
+    } else if let value = value as? OrderCancelResultDTO {
+      super.writeByte(170)
+      super.writeValue(value.toList())
+    } else if let value = value as? BinLookupDataDTO {
+      super.writeByte(171)
+      super.writeValue(value.toList())
+    } else if let value = value as? Environment {
+      super.writeByte(172)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? AddressMode {
+      super.writeByte(173)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? CardAuthMethod {
+      super.writeByte(174)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? TotalPriceStatus {
+      super.writeByte(175)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? GooglePayEnvironment {
+      super.writeByte(176)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? CashAppPayEnvironment {
+      super.writeByte(177)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? PaymentResultEnum {
+      super.writeByte(178)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? CheckoutEventType {
+      super.writeByte(179)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? ComponentCommunicationType {
+      super.writeByte(180)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? PaymentEventType {
+      super.writeByte(181)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? FieldVisibility {
+      super.writeByte(182)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? InstantPaymentType {
+      super.writeByte(183)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? ApplePayShippingType {
+      super.writeByte(184)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? ApplePayMerchantCapability {
+      super.writeByte(185)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? ApplePaySummaryItemType {
+      super.writeByte(186)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? CardNumberValidationResultDTO {
+      super.writeByte(187)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? CardExpiryDateValidationResultDTO {
+      super.writeByte(188)
+      super.writeValue(value.rawValue)
+    } else if let value = value as? CardSecurityCodeValidationResultDTO {
+      super.writeByte(189)
+      super.writeValue(value.rawValue)
+    } else {
+      super.writeValue(value)
     }
+  }
 }
 
 private class PlatformApiPigeonCodecReaderWriter: FlutterStandardReaderWriter {
-    override func reader(with data: Data) -> FlutterStandardReader {
-        PlatformApiPigeonCodecReader(data: data)
-    }
+  override func reader(with data: Data) -> FlutterStandardReader {
+    return PlatformApiPigeonCodecReader(data: data)
+  }
 
-    override func writer(with data: NSMutableData) -> FlutterStandardWriter {
-        PlatformApiPigeonCodecWriter(data: data)
-    }
+  override func writer(with data: NSMutableData) -> FlutterStandardWriter {
+    return PlatformApiPigeonCodecWriter(data: data)
+  }
 }
 
 class PlatformApiPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable {
-    static let shared = PlatformApiPigeonCodec(readerWriter: PlatformApiPigeonCodecReaderWriter())
+  static let shared = PlatformApiPigeonCodec(readerWriter: PlatformApiPigeonCodecReaderWriter())
 }
+
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol CheckoutPlatformInterface {
-    func getReturnUrl(completion: @escaping (Result<String, Error>) -> Void)
-    func createSession(sessionId: String, sessionData: String, configuration: Any?, completion: @escaping (Result<SessionDTO, Error>) -> Void)
-    func clearSession() throws
-    func encryptCard(unencryptedCardDTO: UnencryptedCardDTO, publicKey: String, completion: @escaping (Result<EncryptedCardDTO, Error>) -> Void)
-    func encryptBin(bin: String, publicKey: String, completion: @escaping (Result<String, Error>) -> Void)
-    func validateCardNumber(cardNumber: String, enableLuhnCheck: Bool) throws -> CardNumberValidationResultDTO
-    func validateCardExpiryDate(expiryMonth: String, expiryYear: String) throws -> CardExpiryDateValidationResultDTO
-    func validateCardSecurityCode(securityCode: String, cardBrand: String?) throws -> CardSecurityCodeValidationResultDTO
-    func enableConsoleLogging(loggingEnabled: Bool) throws
-    func getThreeDS2SdkVersion() throws -> String
+  func getReturnUrl(completion: @escaping (Result<String, Error>) -> Void)
+  func createSession(sessionId: String, sessionData: String, configuration: Any?, completion: @escaping (Result<SessionDTO, Error>) -> Void)
+  func clearSession() throws
+  func encryptCard(unencryptedCardDTO: UnencryptedCardDTO, publicKey: String, completion: @escaping (Result<EncryptedCardDTO, Error>) -> Void)
+  func encryptBin(bin: String, publicKey: String, completion: @escaping (Result<String, Error>) -> Void)
+  func validateCardNumber(cardNumber: String, enableLuhnCheck: Bool) throws -> CardNumberValidationResultDTO
+  func validateCardExpiryDate(expiryMonth: String, expiryYear: String) throws -> CardExpiryDateValidationResultDTO
+  func validateCardSecurityCode(securityCode: String, cardBrand: String?) throws -> CardSecurityCodeValidationResultDTO
+  func enableConsoleLogging(loggingEnabled: Bool) throws
+  func getThreeDS2SdkVersion() throws -> String
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
 class CheckoutPlatformInterfaceSetup {
-    static var codec: FlutterStandardMessageCodec {
-        PlatformApiPigeonCodec.shared
+  static var codec: FlutterStandardMessageCodec { PlatformApiPigeonCodec.shared }
+  /// Sets up an instance of `CheckoutPlatformInterface` to handle messages through the `binaryMessenger`.
+  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: CheckoutPlatformInterface?, messageChannelSuffix: String = "") {
+    let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
+    let getReturnUrlChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.getReturnUrl\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      getReturnUrlChannel.setMessageHandler { _, reply in
+        api.getReturnUrl { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      getReturnUrlChannel.setMessageHandler(nil)
     }
-
-    /// Sets up an instance of `CheckoutPlatformInterface` to handle messages through the `binaryMessenger`.
-    static func setUp(binaryMessenger: FlutterBinaryMessenger, api: CheckoutPlatformInterface?, messageChannelSuffix: String = "") {
-        let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-        let getReturnUrlChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.getReturnUrl\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            getReturnUrlChannel.setMessageHandler { _, reply in
-                api.getReturnUrl { result in
-                    switch result {
-                    case let .success(res):
-                        reply(wrapResult(res))
-                    case let .failure(error):
-                        reply(wrapError(error))
-                    }
-                }
-            }
-        } else {
-            getReturnUrlChannel.setMessageHandler(nil)
+    let createSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.createSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      createSessionChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let sessionIdArg = args[0] as! String
+        let sessionDataArg = args[1] as! String
+        let configurationArg: Any? = args[2]
+        api.createSession(sessionId: sessionIdArg, sessionData: sessionDataArg, configuration: configurationArg) { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
         }
-        let createSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.createSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            createSessionChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let sessionIdArg = args[0] as! String
-                let sessionDataArg = args[1] as! String
-                let configurationArg: Any? = args[2]
-                api.createSession(sessionId: sessionIdArg, sessionData: sessionDataArg, configuration: configurationArg) { result in
-                    switch result {
-                    case let .success(res):
-                        reply(wrapResult(res))
-                    case let .failure(error):
-                        reply(wrapError(error))
-                    }
-                }
-            }
-        } else {
-            createSessionChannel.setMessageHandler(nil)
-        }
-        let clearSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.clearSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            clearSessionChannel.setMessageHandler { _, reply in
-                do {
-                    try api.clearSession()
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            clearSessionChannel.setMessageHandler(nil)
-        }
-        let encryptCardChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.encryptCard\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            encryptCardChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let unencryptedCardDTOArg = args[0] as! UnencryptedCardDTO
-                let publicKeyArg = args[1] as! String
-                api.encryptCard(unencryptedCardDTO: unencryptedCardDTOArg, publicKey: publicKeyArg) { result in
-                    switch result {
-                    case let .success(res):
-                        reply(wrapResult(res))
-                    case let .failure(error):
-                        reply(wrapError(error))
-                    }
-                }
-            }
-        } else {
-            encryptCardChannel.setMessageHandler(nil)
-        }
-        let encryptBinChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.encryptBin\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            encryptBinChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let binArg = args[0] as! String
-                let publicKeyArg = args[1] as! String
-                api.encryptBin(bin: binArg, publicKey: publicKeyArg) { result in
-                    switch result {
-                    case let .success(res):
-                        reply(wrapResult(res))
-                    case let .failure(error):
-                        reply(wrapError(error))
-                    }
-                }
-            }
-        } else {
-            encryptBinChannel.setMessageHandler(nil)
-        }
-        let validateCardNumberChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.validateCardNumber\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            validateCardNumberChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let cardNumberArg = args[0] as! String
-                let enableLuhnCheckArg = args[1] as! Bool
-                do {
-                    let result = try api.validateCardNumber(cardNumber: cardNumberArg, enableLuhnCheck: enableLuhnCheckArg)
-                    reply(wrapResult(result))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            validateCardNumberChannel.setMessageHandler(nil)
-        }
-        let validateCardExpiryDateChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.validateCardExpiryDate\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            validateCardExpiryDateChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let expiryMonthArg = args[0] as! String
-                let expiryYearArg = args[1] as! String
-                do {
-                    let result = try api.validateCardExpiryDate(expiryMonth: expiryMonthArg, expiryYear: expiryYearArg)
-                    reply(wrapResult(result))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            validateCardExpiryDateChannel.setMessageHandler(nil)
-        }
-        let validateCardSecurityCodeChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.validateCardSecurityCode\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            validateCardSecurityCodeChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let securityCodeArg = args[0] as! String
-                let cardBrandArg: String? = nilOrValue(args[1])
-                do {
-                    let result = try api.validateCardSecurityCode(securityCode: securityCodeArg, cardBrand: cardBrandArg)
-                    reply(wrapResult(result))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            validateCardSecurityCodeChannel.setMessageHandler(nil)
-        }
-        let enableConsoleLoggingChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.enableConsoleLogging\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            enableConsoleLoggingChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let loggingEnabledArg = args[0] as! Bool
-                do {
-                    try api.enableConsoleLogging(loggingEnabled: loggingEnabledArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            enableConsoleLoggingChannel.setMessageHandler(nil)
-        }
-        let getThreeDS2SdkVersionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.getThreeDS2SdkVersion\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            getThreeDS2SdkVersionChannel.setMessageHandler { _, reply in
-                do {
-                    let result = try api.getThreeDS2SdkVersion()
-                    reply(wrapResult(result))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            getThreeDS2SdkVersionChannel.setMessageHandler(nil)
-        }
+      }
+    } else {
+      createSessionChannel.setMessageHandler(nil)
     }
+    let clearSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.clearSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      clearSessionChannel.setMessageHandler { _, reply in
+        do {
+          try api.clearSession()
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      clearSessionChannel.setMessageHandler(nil)
+    }
+    let encryptCardChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.encryptCard\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      encryptCardChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let unencryptedCardDTOArg = args[0] as! UnencryptedCardDTO
+        let publicKeyArg = args[1] as! String
+        api.encryptCard(unencryptedCardDTO: unencryptedCardDTOArg, publicKey: publicKeyArg) { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      encryptCardChannel.setMessageHandler(nil)
+    }
+    let encryptBinChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.encryptBin\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      encryptBinChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let binArg = args[0] as! String
+        let publicKeyArg = args[1] as! String
+        api.encryptBin(bin: binArg, publicKey: publicKeyArg) { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      encryptBinChannel.setMessageHandler(nil)
+    }
+    let validateCardNumberChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.validateCardNumber\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      validateCardNumberChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let cardNumberArg = args[0] as! String
+        let enableLuhnCheckArg = args[1] as! Bool
+        do {
+          let result = try api.validateCardNumber(cardNumber: cardNumberArg, enableLuhnCheck: enableLuhnCheckArg)
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      validateCardNumberChannel.setMessageHandler(nil)
+    }
+    let validateCardExpiryDateChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.validateCardExpiryDate\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      validateCardExpiryDateChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let expiryMonthArg = args[0] as! String
+        let expiryYearArg = args[1] as! String
+        do {
+          let result = try api.validateCardExpiryDate(expiryMonth: expiryMonthArg, expiryYear: expiryYearArg)
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      validateCardExpiryDateChannel.setMessageHandler(nil)
+    }
+    let validateCardSecurityCodeChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.validateCardSecurityCode\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      validateCardSecurityCodeChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let securityCodeArg = args[0] as! String
+        let cardBrandArg: String? = nilOrValue(args[1])
+        do {
+          let result = try api.validateCardSecurityCode(securityCode: securityCodeArg, cardBrand: cardBrandArg)
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      validateCardSecurityCodeChannel.setMessageHandler(nil)
+    }
+    let enableConsoleLoggingChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.enableConsoleLogging\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      enableConsoleLoggingChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let loggingEnabledArg = args[0] as! Bool
+        do {
+          try api.enableConsoleLogging(loggingEnabled: loggingEnabledArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      enableConsoleLoggingChannel.setMessageHandler(nil)
+    }
+    let getThreeDS2SdkVersionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.getThreeDS2SdkVersion\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      getThreeDS2SdkVersionChannel.setMessageHandler { _, reply in
+        do {
+          let result = try api.getThreeDS2SdkVersion()
+          reply(wrapResult(result))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      getThreeDS2SdkVersionChannel.setMessageHandler(nil)
+    }
+  }
 }
-
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol DropInPlatformInterface {
-    func showDropInSession(dropInConfigurationDTO: DropInConfigurationDTO) throws
-    func showDropInAdvanced(dropInConfigurationDTO: DropInConfigurationDTO, paymentMethodsResponse: String) throws
-    func stopDropIn() throws
-    func onPaymentsResult(paymentsResult: PaymentEventDTO) throws
-    func onPaymentsDetailsResult(paymentsDetailsResult: PaymentEventDTO) throws
-    func onDeleteStoredPaymentMethodResult(deleteStoredPaymentMethodResultDTO: DeletedStoredPaymentMethodResultDTO) throws
-    func onBalanceCheckResult(balanceCheckResponse: String) throws
-    func onOrderRequestResult(orderRequestResponse: String) throws
-    func onOrderCancelResult(orderCancelResult: OrderCancelResultDTO) throws
-    func cleanUpDropIn() throws
+  func showDropInSession(dropInConfigurationDTO: DropInConfigurationDTO) throws
+  func showDropInAdvanced(dropInConfigurationDTO: DropInConfigurationDTO, paymentMethodsResponse: String) throws
+  func stopDropIn() throws
+  func onPaymentsResult(paymentsResult: PaymentEventDTO) throws
+  func onPaymentsDetailsResult(paymentsDetailsResult: PaymentEventDTO) throws
+  func onDeleteStoredPaymentMethodResult(deleteStoredPaymentMethodResultDTO: DeletedStoredPaymentMethodResultDTO) throws
+  func onBalanceCheckResult(balanceCheckResponse: String) throws
+  func onOrderRequestResult(orderRequestResponse: String) throws
+  func onOrderCancelResult(orderCancelResult: OrderCancelResultDTO) throws
+  func cleanUpDropIn() throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
 class DropInPlatformInterfaceSetup {
-    static var codec: FlutterStandardMessageCodec {
-        PlatformApiPigeonCodec.shared
+  static var codec: FlutterStandardMessageCodec { PlatformApiPigeonCodec.shared }
+  /// Sets up an instance of `DropInPlatformInterface` to handle messages through the `binaryMessenger`.
+  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: DropInPlatformInterface?, messageChannelSuffix: String = "") {
+    let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
+    let showDropInSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.showDropInSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      showDropInSessionChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let dropInConfigurationDTOArg = args[0] as! DropInConfigurationDTO
+        do {
+          try api.showDropInSession(dropInConfigurationDTO: dropInConfigurationDTOArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      showDropInSessionChannel.setMessageHandler(nil)
     }
-
-    /// Sets up an instance of `DropInPlatformInterface` to handle messages through the `binaryMessenger`.
-    static func setUp(binaryMessenger: FlutterBinaryMessenger, api: DropInPlatformInterface?, messageChannelSuffix: String = "") {
-        let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-        let showDropInSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.showDropInSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            showDropInSessionChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let dropInConfigurationDTOArg = args[0] as! DropInConfigurationDTO
-                do {
-                    try api.showDropInSession(dropInConfigurationDTO: dropInConfigurationDTOArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            showDropInSessionChannel.setMessageHandler(nil)
+    let showDropInAdvancedChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.showDropInAdvanced\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      showDropInAdvancedChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let dropInConfigurationDTOArg = args[0] as! DropInConfigurationDTO
+        let paymentMethodsResponseArg = args[1] as! String
+        do {
+          try api.showDropInAdvanced(dropInConfigurationDTO: dropInConfigurationDTOArg, paymentMethodsResponse: paymentMethodsResponseArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
         }
-        let showDropInAdvancedChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.showDropInAdvanced\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            showDropInAdvancedChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let dropInConfigurationDTOArg = args[0] as! DropInConfigurationDTO
-                let paymentMethodsResponseArg = args[1] as! String
-                do {
-                    try api.showDropInAdvanced(dropInConfigurationDTO: dropInConfigurationDTOArg, paymentMethodsResponse: paymentMethodsResponseArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            showDropInAdvancedChannel.setMessageHandler(nil)
-        }
-        let stopDropInChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.stopDropIn\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            stopDropInChannel.setMessageHandler { _, reply in
-                do {
-                    try api.stopDropIn()
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            stopDropInChannel.setMessageHandler(nil)
-        }
-        let onPaymentsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onPaymentsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            onPaymentsResultChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let paymentsResultArg = args[0] as! PaymentEventDTO
-                do {
-                    try api.onPaymentsResult(paymentsResult: paymentsResultArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            onPaymentsResultChannel.setMessageHandler(nil)
-        }
-        let onPaymentsDetailsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onPaymentsDetailsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            onPaymentsDetailsResultChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let paymentsDetailsResultArg = args[0] as! PaymentEventDTO
-                do {
-                    try api.onPaymentsDetailsResult(paymentsDetailsResult: paymentsDetailsResultArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            onPaymentsDetailsResultChannel.setMessageHandler(nil)
-        }
-        let onDeleteStoredPaymentMethodResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onDeleteStoredPaymentMethodResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            onDeleteStoredPaymentMethodResultChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let deleteStoredPaymentMethodResultDTOArg = args[0] as! DeletedStoredPaymentMethodResultDTO
-                do {
-                    try api.onDeleteStoredPaymentMethodResult(deleteStoredPaymentMethodResultDTO: deleteStoredPaymentMethodResultDTOArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            onDeleteStoredPaymentMethodResultChannel.setMessageHandler(nil)
-        }
-        let onBalanceCheckResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onBalanceCheckResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            onBalanceCheckResultChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let balanceCheckResponseArg = args[0] as! String
-                do {
-                    try api.onBalanceCheckResult(balanceCheckResponse: balanceCheckResponseArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            onBalanceCheckResultChannel.setMessageHandler(nil)
-        }
-        let onOrderRequestResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onOrderRequestResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            onOrderRequestResultChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let orderRequestResponseArg = args[0] as! String
-                do {
-                    try api.onOrderRequestResult(orderRequestResponse: orderRequestResponseArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            onOrderRequestResultChannel.setMessageHandler(nil)
-        }
-        let onOrderCancelResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onOrderCancelResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            onOrderCancelResultChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let orderCancelResultArg = args[0] as! OrderCancelResultDTO
-                do {
-                    try api.onOrderCancelResult(orderCancelResult: orderCancelResultArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            onOrderCancelResultChannel.setMessageHandler(nil)
-        }
-        let cleanUpDropInChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.cleanUpDropIn\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            cleanUpDropInChannel.setMessageHandler { _, reply in
-                do {
-                    try api.cleanUpDropIn()
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            cleanUpDropInChannel.setMessageHandler(nil)
-        }
+      }
+    } else {
+      showDropInAdvancedChannel.setMessageHandler(nil)
     }
+    let stopDropInChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.stopDropIn\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      stopDropInChannel.setMessageHandler { _, reply in
+        do {
+          try api.stopDropIn()
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      stopDropInChannel.setMessageHandler(nil)
+    }
+    let onPaymentsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onPaymentsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      onPaymentsResultChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let paymentsResultArg = args[0] as! PaymentEventDTO
+        do {
+          try api.onPaymentsResult(paymentsResult: paymentsResultArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      onPaymentsResultChannel.setMessageHandler(nil)
+    }
+    let onPaymentsDetailsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onPaymentsDetailsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      onPaymentsDetailsResultChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let paymentsDetailsResultArg = args[0] as! PaymentEventDTO
+        do {
+          try api.onPaymentsDetailsResult(paymentsDetailsResult: paymentsDetailsResultArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      onPaymentsDetailsResultChannel.setMessageHandler(nil)
+    }
+    let onDeleteStoredPaymentMethodResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onDeleteStoredPaymentMethodResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      onDeleteStoredPaymentMethodResultChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let deleteStoredPaymentMethodResultDTOArg = args[0] as! DeletedStoredPaymentMethodResultDTO
+        do {
+          try api.onDeleteStoredPaymentMethodResult(deleteStoredPaymentMethodResultDTO: deleteStoredPaymentMethodResultDTOArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      onDeleteStoredPaymentMethodResultChannel.setMessageHandler(nil)
+    }
+    let onBalanceCheckResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onBalanceCheckResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      onBalanceCheckResultChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let balanceCheckResponseArg = args[0] as! String
+        do {
+          try api.onBalanceCheckResult(balanceCheckResponse: balanceCheckResponseArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      onBalanceCheckResultChannel.setMessageHandler(nil)
+    }
+    let onOrderRequestResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onOrderRequestResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      onOrderRequestResultChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let orderRequestResponseArg = args[0] as! String
+        do {
+          try api.onOrderRequestResult(orderRequestResponse: orderRequestResponseArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      onOrderRequestResultChannel.setMessageHandler(nil)
+    }
+    let onOrderCancelResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onOrderCancelResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      onOrderCancelResultChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let orderCancelResultArg = args[0] as! OrderCancelResultDTO
+        do {
+          try api.onOrderCancelResult(orderCancelResult: orderCancelResultArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      onOrderCancelResultChannel.setMessageHandler(nil)
+    }
+    let cleanUpDropInChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.cleanUpDropIn\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      cleanUpDropInChannel.setMessageHandler { _, reply in
+        do {
+          try api.cleanUpDropIn()
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      cleanUpDropInChannel.setMessageHandler(nil)
+    }
+  }
 }
-
 /// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
 protocol CheckoutFlutterInterfaceProtocol {
-    func send(event eventArg: CheckoutEvent, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void)
+  func send(event eventArg: CheckoutEvent, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void)
 }
-
 class CheckoutFlutterInterface: CheckoutFlutterInterfaceProtocol {
-    private let binaryMessenger: FlutterBinaryMessenger
-    private let messageChannelSuffix: String
-    init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
-        self.binaryMessenger = binaryMessenger
-        self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
+  private let binaryMessenger: FlutterBinaryMessenger
+  private let messageChannelSuffix: String
+  init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
+    self.binaryMessenger = binaryMessenger
+    self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
+  }
+  var codec: PlatformApiPigeonCodec {
+    return PlatformApiPigeonCodec.shared
+  }
+  func send(event eventArg: CheckoutEvent, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.adyen_checkout.CheckoutFlutterInterface.send\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([eventArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(AdyenPigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(Void()))
+      }
     }
-
-    var codec: PlatformApiPigeonCodec {
-        PlatformApiPigeonCodec.shared
-    }
-
-    func send(event eventArg: CheckoutEvent, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void) {
-        let channelName = "dev.flutter.pigeon.adyen_checkout.CheckoutFlutterInterface.send\(messageChannelSuffix)"
-        let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-        channel.sendMessage([eventArg] as [Any?]) { response in
-            guard let listResponse = response as? [Any?] else {
-                completion(.failure(createConnectionError(withChannelName: channelName)))
-                return
-            }
-            if listResponse.count > 1 {
-                let code: String = listResponse[0] as! String
-                let message: String? = nilOrValue(listResponse[1])
-                let details: String? = nilOrValue(listResponse[2])
-                completion(.failure(AdyenPigeonError(code: code, message: message, details: details)))
-            } else {
-                completion(.success(()))
-            }
-        }
-    }
+  }
 }
-
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol ComponentPlatformInterface {
-    func updateViewHeight(viewId: Int64) throws
-    func onPaymentsResult(componentId: String, paymentsResult: PaymentEventDTO) throws
-    func onPaymentsDetailsResult(componentId: String, paymentsDetailsResult: PaymentEventDTO) throws
-    func isInstantPaymentSupportedByPlatform(instantPaymentConfigurationDTO: InstantPaymentConfigurationDTO, paymentMethodResponse: String, componentId: String, completion: @escaping (Result<InstantPaymentSetupResultDTO, Error>) -> Void)
-    func onInstantPaymentPressed(instantPaymentConfigurationDTO: InstantPaymentConfigurationDTO, encodedPaymentMethod: String, componentId: String) throws
-    func handleAction(actionComponentConfiguration: ActionComponentConfigurationDTO, componentId: String, actionResponse: [String?: Any?]?) throws
-    func onDispose(componentId: String) throws
+  func updateViewHeight(viewId: Int64) throws
+  func onPaymentsResult(componentId: String, paymentsResult: PaymentEventDTO) throws
+  func onPaymentsDetailsResult(componentId: String, paymentsDetailsResult: PaymentEventDTO) throws
+  func isInstantPaymentSupportedByPlatform(instantPaymentConfigurationDTO: InstantPaymentConfigurationDTO, paymentMethodResponse: String, componentId: String, completion: @escaping (Result<InstantPaymentSetupResultDTO, Error>) -> Void)
+  func onInstantPaymentPressed(instantPaymentConfigurationDTO: InstantPaymentConfigurationDTO, encodedPaymentMethod: String, componentId: String) throws
+  func handleAction(actionComponentConfiguration: ActionComponentConfigurationDTO, componentId: String, actionResponse: [String?: Any?]?) throws
+  func onDispose(componentId: String) throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
 class ComponentPlatformInterfaceSetup {
-    static var codec: FlutterStandardMessageCodec {
-        PlatformApiPigeonCodec.shared
+  static var codec: FlutterStandardMessageCodec { PlatformApiPigeonCodec.shared }
+  /// Sets up an instance of `ComponentPlatformInterface` to handle messages through the `binaryMessenger`.
+  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: ComponentPlatformInterface?, messageChannelSuffix: String = "") {
+    let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
+    let updateViewHeightChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.updateViewHeight\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      updateViewHeightChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let viewIdArg = args[0] is Int64 ? args[0] as! Int64 : Int64(args[0] as! Int32)
+        do {
+          try api.updateViewHeight(viewId: viewIdArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      updateViewHeightChannel.setMessageHandler(nil)
     }
-
-    /// Sets up an instance of `ComponentPlatformInterface` to handle messages through the `binaryMessenger`.
-    static func setUp(binaryMessenger: FlutterBinaryMessenger, api: ComponentPlatformInterface?, messageChannelSuffix: String = "") {
-        let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-        let updateViewHeightChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.updateViewHeight\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            updateViewHeightChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let viewIdArg = args[0] is Int64 ? args[0] as! Int64 : Int64(args[0] as! Int32)
-                do {
-                    try api.updateViewHeight(viewId: viewIdArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            updateViewHeightChannel.setMessageHandler(nil)
+    let onPaymentsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onPaymentsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      onPaymentsResultChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let componentIdArg = args[0] as! String
+        let paymentsResultArg = args[1] as! PaymentEventDTO
+        do {
+          try api.onPaymentsResult(componentId: componentIdArg, paymentsResult: paymentsResultArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
         }
-        let onPaymentsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onPaymentsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            onPaymentsResultChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let componentIdArg = args[0] as! String
-                let paymentsResultArg = args[1] as! PaymentEventDTO
-                do {
-                    try api.onPaymentsResult(componentId: componentIdArg, paymentsResult: paymentsResultArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            onPaymentsResultChannel.setMessageHandler(nil)
-        }
-        let onPaymentsDetailsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onPaymentsDetailsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            onPaymentsDetailsResultChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let componentIdArg = args[0] as! String
-                let paymentsDetailsResultArg = args[1] as! PaymentEventDTO
-                do {
-                    try api.onPaymentsDetailsResult(componentId: componentIdArg, paymentsDetailsResult: paymentsDetailsResultArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            onPaymentsDetailsResultChannel.setMessageHandler(nil)
-        }
-        let isInstantPaymentSupportedByPlatformChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.isInstantPaymentSupportedByPlatform\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            isInstantPaymentSupportedByPlatformChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let instantPaymentConfigurationDTOArg = args[0] as! InstantPaymentConfigurationDTO
-                let paymentMethodResponseArg = args[1] as! String
-                let componentIdArg = args[2] as! String
-                api.isInstantPaymentSupportedByPlatform(instantPaymentConfigurationDTO: instantPaymentConfigurationDTOArg, paymentMethodResponse: paymentMethodResponseArg, componentId: componentIdArg) { result in
-                    switch result {
-                    case let .success(res):
-                        reply(wrapResult(res))
-                    case let .failure(error):
-                        reply(wrapError(error))
-                    }
-                }
-            }
-        } else {
-            isInstantPaymentSupportedByPlatformChannel.setMessageHandler(nil)
-        }
-        let onInstantPaymentPressedChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onInstantPaymentPressed\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            onInstantPaymentPressedChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let instantPaymentConfigurationDTOArg = args[0] as! InstantPaymentConfigurationDTO
-                let encodedPaymentMethodArg = args[1] as! String
-                let componentIdArg = args[2] as! String
-                do {
-                    try api.onInstantPaymentPressed(instantPaymentConfigurationDTO: instantPaymentConfigurationDTOArg, encodedPaymentMethod: encodedPaymentMethodArg, componentId: componentIdArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            onInstantPaymentPressedChannel.setMessageHandler(nil)
-        }
-        let handleActionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.handleAction\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            handleActionChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let actionComponentConfigurationArg = args[0] as! ActionComponentConfigurationDTO
-                let componentIdArg = args[1] as! String
-                let actionResponseArg: [String?: Any?]? = nilOrValue(args[2])
-                do {
-                    try api.handleAction(actionComponentConfiguration: actionComponentConfigurationArg, componentId: componentIdArg, actionResponse: actionResponseArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            handleActionChannel.setMessageHandler(nil)
-        }
-        let onDisposeChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onDispose\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-        if let api {
-            onDisposeChannel.setMessageHandler { message, reply in
-                let args = message as! [Any?]
-                let componentIdArg = args[0] as! String
-                do {
-                    try api.onDispose(componentId: componentIdArg)
-                    reply(wrapResult(nil))
-                } catch {
-                    reply(wrapError(error))
-                }
-            }
-        } else {
-            onDisposeChannel.setMessageHandler(nil)
-        }
+      }
+    } else {
+      onPaymentsResultChannel.setMessageHandler(nil)
     }
+    let onPaymentsDetailsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onPaymentsDetailsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      onPaymentsDetailsResultChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let componentIdArg = args[0] as! String
+        let paymentsDetailsResultArg = args[1] as! PaymentEventDTO
+        do {
+          try api.onPaymentsDetailsResult(componentId: componentIdArg, paymentsDetailsResult: paymentsDetailsResultArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      onPaymentsDetailsResultChannel.setMessageHandler(nil)
+    }
+    let isInstantPaymentSupportedByPlatformChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.isInstantPaymentSupportedByPlatform\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      isInstantPaymentSupportedByPlatformChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let instantPaymentConfigurationDTOArg = args[0] as! InstantPaymentConfigurationDTO
+        let paymentMethodResponseArg = args[1] as! String
+        let componentIdArg = args[2] as! String
+        api.isInstantPaymentSupportedByPlatform(instantPaymentConfigurationDTO: instantPaymentConfigurationDTOArg, paymentMethodResponse: paymentMethodResponseArg, componentId: componentIdArg) { result in
+          switch result {
+          case .success(let res):
+            reply(wrapResult(res))
+          case .failure(let error):
+            reply(wrapError(error))
+          }
+        }
+      }
+    } else {
+      isInstantPaymentSupportedByPlatformChannel.setMessageHandler(nil)
+    }
+    let onInstantPaymentPressedChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onInstantPaymentPressed\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      onInstantPaymentPressedChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let instantPaymentConfigurationDTOArg = args[0] as! InstantPaymentConfigurationDTO
+        let encodedPaymentMethodArg = args[1] as! String
+        let componentIdArg = args[2] as! String
+        do {
+          try api.onInstantPaymentPressed(instantPaymentConfigurationDTO: instantPaymentConfigurationDTOArg, encodedPaymentMethod: encodedPaymentMethodArg, componentId: componentIdArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      onInstantPaymentPressedChannel.setMessageHandler(nil)
+    }
+    let handleActionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.handleAction\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      handleActionChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let actionComponentConfigurationArg = args[0] as! ActionComponentConfigurationDTO
+        let componentIdArg = args[1] as! String
+        let actionResponseArg: [String?: Any?]? = nilOrValue(args[2])
+        do {
+          try api.handleAction(actionComponentConfiguration: actionComponentConfigurationArg, componentId: componentIdArg, actionResponse: actionResponseArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      handleActionChannel.setMessageHandler(nil)
+    }
+    let onDisposeChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onDispose\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+    if let api = api {
+      onDisposeChannel.setMessageHandler { message, reply in
+        let args = message as! [Any?]
+        let componentIdArg = args[0] as! String
+        do {
+          try api.onDispose(componentId: componentIdArg)
+          reply(wrapResult(nil))
+        } catch {
+          reply(wrapError(error))
+        }
+      }
+    } else {
+      onDisposeChannel.setMessageHandler(nil)
+    }
+  }
 }
-
 /// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
 protocol ComponentFlutterInterfaceProtocol {
-    func _generateCodecForDTOs(cardComponentConfigurationDTO cardComponentConfigurationDTOArg: CardComponentConfigurationDTO, blikComponentConfigurationDTO blikComponentConfigurationDTOArg: BlikComponentConfigurationDTO, sessionDTO sessionDTOArg: SessionDTO, binLookupDataDTO binLookupDataDTOArg: BinLookupDataDTO, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void)
-    func onComponentCommunication(componentCommunicationModel componentCommunicationModelArg: ComponentCommunicationModel, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void)
+  func _generateCodecForDTOs(cardComponentConfigurationDTO cardComponentConfigurationDTOArg: CardComponentConfigurationDTO, blikComponentConfigurationDTO blikComponentConfigurationDTOArg: BlikComponentConfigurationDTO, sessionDTO sessionDTOArg: SessionDTO, binLookupDataDTO binLookupDataDTOArg: BinLookupDataDTO, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void)
+  func onComponentCommunication(componentCommunicationModel componentCommunicationModelArg: ComponentCommunicationModel, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void)
 }
-
 class ComponentFlutterInterface: ComponentFlutterInterfaceProtocol {
-    private let binaryMessenger: FlutterBinaryMessenger
-    private let messageChannelSuffix: String
-    init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
-        self.binaryMessenger = binaryMessenger
-        self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
+  private let binaryMessenger: FlutterBinaryMessenger
+  private let messageChannelSuffix: String
+  init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
+    self.binaryMessenger = binaryMessenger
+    self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
+  }
+  var codec: PlatformApiPigeonCodec {
+    return PlatformApiPigeonCodec.shared
+  }
+  func _generateCodecForDTOs(cardComponentConfigurationDTO cardComponentConfigurationDTOArg: CardComponentConfigurationDTO, blikComponentConfigurationDTO blikComponentConfigurationDTOArg: BlikComponentConfigurationDTO, sessionDTO sessionDTOArg: SessionDTO, binLookupDataDTO binLookupDataDTOArg: BinLookupDataDTO, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.adyen_checkout.ComponentFlutterInterface._generateCodecForDTOs\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([cardComponentConfigurationDTOArg, blikComponentConfigurationDTOArg, sessionDTOArg, binLookupDataDTOArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(AdyenPigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(Void()))
+      }
     }
-
-    var codec: PlatformApiPigeonCodec {
-        PlatformApiPigeonCodec.shared
+  }
+  func onComponentCommunication(componentCommunicationModel componentCommunicationModelArg: ComponentCommunicationModel, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void) {
+    let channelName: String = "dev.flutter.pigeon.adyen_checkout.ComponentFlutterInterface.onComponentCommunication\(messageChannelSuffix)"
+    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+    channel.sendMessage([componentCommunicationModelArg] as [Any?]) { response in
+      guard let listResponse = response as? [Any?] else {
+        completion(.failure(createConnectionError(withChannelName: channelName)))
+        return
+      }
+      if listResponse.count > 1 {
+        let code: String = listResponse[0] as! String
+        let message: String? = nilOrValue(listResponse[1])
+        let details: String? = nilOrValue(listResponse[2])
+        completion(.failure(AdyenPigeonError(code: code, message: message, details: details)))
+      } else {
+        completion(.success(Void()))
+      }
     }
-
-    func _generateCodecForDTOs(cardComponentConfigurationDTO cardComponentConfigurationDTOArg: CardComponentConfigurationDTO, blikComponentConfigurationDTO blikComponentConfigurationDTOArg: BlikComponentConfigurationDTO, sessionDTO sessionDTOArg: SessionDTO, binLookupDataDTO binLookupDataDTOArg: BinLookupDataDTO, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void) {
-        let channelName = "dev.flutter.pigeon.adyen_checkout.ComponentFlutterInterface._generateCodecForDTOs\(messageChannelSuffix)"
-        let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-        channel.sendMessage([cardComponentConfigurationDTOArg, blikComponentConfigurationDTOArg, sessionDTOArg, binLookupDataDTOArg] as [Any?]) { response in
-            guard let listResponse = response as? [Any?] else {
-                completion(.failure(createConnectionError(withChannelName: channelName)))
-                return
-            }
-            if listResponse.count > 1 {
-                let code: String = listResponse[0] as! String
-                let message: String? = nilOrValue(listResponse[1])
-                let details: String? = nilOrValue(listResponse[2])
-                completion(.failure(AdyenPigeonError(code: code, message: message, details: details)))
-            } else {
-                completion(.success(()))
-            }
-        }
-    }
-
-    func onComponentCommunication(componentCommunicationModel componentCommunicationModelArg: ComponentCommunicationModel, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void) {
-        let channelName = "dev.flutter.pigeon.adyen_checkout.ComponentFlutterInterface.onComponentCommunication\(messageChannelSuffix)"
-        let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-        channel.sendMessage([componentCommunicationModelArg] as [Any?]) { response in
-            guard let listResponse = response as? [Any?] else {
-                completion(.failure(createConnectionError(withChannelName: channelName)))
-                return
-            }
-            if listResponse.count > 1 {
-                let code: String = listResponse[0] as! String
-                let message: String? = nilOrValue(listResponse[1])
-                let details: String? = nilOrValue(listResponse[2])
-                completion(.failure(AdyenPigeonError(code: code, message: message, details: details)))
-            } else {
-                completion(.success(()))
-            }
-        }
-    }
+  }
 }

--- a/ios/adyen_checkout/Sources/adyen_checkout/generated/PlatformApi.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/generated/PlatformApi.swift
@@ -4,2654 +4,2716 @@
 import Foundation
 
 #if os(iOS)
-  import Flutter
+    import Flutter
 #elseif os(macOS)
-  import FlutterMacOS
+    import FlutterMacOS
 #else
-  #error("Unsupported platform.")
+    #error("Unsupported platform.")
 #endif
 
 /// Error class for passing custom error details to Dart side.
 final class AdyenPigeonError: Error {
-  let code: String
-  let message: String?
-  let details: Any?
+    let code: String
+    let message: String?
+    let details: Any?
 
-  init(code: String, message: String?, details: Any?) {
-    self.code = code
-    self.message = message
-    self.details = details
-  }
+    init(code: String, message: String?, details: Any?) {
+        self.code = code
+        self.message = message
+        self.details = details
+    }
 
-  var localizedDescription: String {
-    return
-      "AdyenPigeonError(code: \(code), message: \(message ?? "<nil>"), details: \(details ?? "<nil>")"
-      }
+    var localizedDescription: String {
+        "AdyenPigeonError(code: \(code), message: \(message ?? "<nil>"), details: \(details ?? "<nil>")"
+    }
 }
 
 private func wrapResult(_ result: Any?) -> [Any?] {
-  return [result]
+    [result]
 }
 
 private func wrapError(_ error: Any) -> [Any?] {
-  if let pigeonError = error as? AdyenPigeonError {
+    if let pigeonError = error as? AdyenPigeonError {
+        return [
+            pigeonError.code,
+            pigeonError.message,
+            pigeonError.details
+        ]
+    }
+    if let flutterError = error as? FlutterError {
+        return [
+            flutterError.code,
+            flutterError.message,
+            flutterError.details
+        ]
+    }
     return [
-      pigeonError.code,
-      pigeonError.message,
-      pigeonError.details,
+        "\(error)",
+        "\(type(of: error))",
+        "Stacktrace: \(Thread.callStackSymbols)"
     ]
-  }
-  if let flutterError = error as? FlutterError {
-    return [
-      flutterError.code,
-      flutterError.message,
-      flutterError.details,
-    ]
-  }
-  return [
-    "\(error)",
-    "\(type(of: error))",
-    "Stacktrace: \(Thread.callStackSymbols)",
-  ]
 }
 
 private func createConnectionError(withChannelName channelName: String) -> AdyenPigeonError {
-  return AdyenPigeonError(code: "channel-error", message: "Unable to establish connection on channel: '\(channelName)'.", details: "")
+    AdyenPigeonError(code: "channel-error", message: "Unable to establish connection on channel: '\(channelName)'.", details: "")
 }
 
 private func isNullish(_ value: Any?) -> Bool {
-  return value is NSNull || value == nil
+    value is NSNull || value == nil
 }
 
 private func nilOrValue<T>(_ value: Any?) -> T? {
-  if value is NSNull { return nil }
-  return value as! T?
+    if value is NSNull { return nil }
+    return value as! T?
 }
 
 enum Environment: Int {
-  case test = 0
-  case europe = 1
-  case unitedStates = 2
-  case australia = 3
-  case india = 4
-  case apse = 5
-  case nea = 6
+    case test = 0
+    case europe = 1
+    case unitedStates = 2
+    case australia = 3
+    case india = 4
+    case apse = 5
+    case nea = 6
 }
 
 enum AddressMode: Int {
-  case full = 0
-  case postalCode = 1
-  case none = 2
+    case full = 0
+    case postalCode = 1
+    case none = 2
 }
 
 enum CardAuthMethod: Int {
-  case panOnly = 0
-  case cryptogram3DS = 1
+    case panOnly = 0
+    case cryptogram3DS = 1
 }
 
 enum TotalPriceStatus: Int {
-  case notCurrentlyKnown = 0
-  case estimated = 1
-  case finalPrice = 2
+    case notCurrentlyKnown = 0
+    case estimated = 1
+    case finalPrice = 2
 }
 
 enum GooglePayEnvironment: Int {
-  case test = 0
-  case production = 1
+    case test = 0
+    case production = 1
 }
 
 enum CashAppPayEnvironment: Int {
-  case sandbox = 0
-  case production = 1
+    case sandbox = 0
+    case production = 1
 }
 
 enum PaymentResultEnum: Int {
-  case cancelledByUser = 0
-  case error = 1
-  case finished = 2
+    case cancelledByUser = 0
+    case error = 1
+    case finished = 2
 }
 
 enum CheckoutEventType: Int {
-  case submit = 0
-  case additionalDetails = 1
-  case result = 2
-  case deleteStoredPaymentMethod = 3
-  case balanceCheck = 4
-  case requestOrder = 5
-  case cancelOrder = 6
-  case binLookup = 7
-  case binValue = 8
+    case submit = 0
+    case additionalDetails = 1
+    case result = 2
+    case deleteStoredPaymentMethod = 3
+    case balanceCheck = 4
+    case requestOrder = 5
+    case cancelOrder = 6
+    case binLookup = 7
+    case binValue = 8
 }
 
 enum ComponentCommunicationType: Int {
-  case onSubmit = 0
-  case additionalDetails = 1
-  case loading = 2
-  case result = 3
-  case resize = 4
-  case binLookup = 5
-  case binValue = 6
-  case availability = 7
+    case onSubmit = 0
+    case additionalDetails = 1
+    case loading = 2
+    case result = 3
+    case resize = 4
+    case binLookup = 5
+    case binValue = 6
+    case availability = 7
 }
 
 enum PaymentEventType: Int {
-  case finished = 0
-  case action = 1
-  case error = 2
-  case update = 3
+    case finished = 0
+    case action = 1
+    case error = 2
+    case update = 3
 }
 
 enum FieldVisibility: Int {
-  case show = 0
-  case hide = 1
+    case show = 0
+    case hide = 1
 }
 
 enum InstantPaymentType: Int {
-  case googlePay = 0
-  case applePay = 1
-  case instant = 2
+    case googlePay = 0
+    case applePay = 1
+    case instant = 2
 }
 
 enum ApplePayShippingType: Int {
-  case shipping = 0
-  case delivery = 1
-  case storePickup = 2
-  case servicePickup = 3
+    case shipping = 0
+    case delivery = 1
+    case storePickup = 2
+    case servicePickup = 3
 }
 
 enum ApplePayMerchantCapability: Int {
-  case debit = 0
-  case credit = 1
+    case debit = 0
+    case credit = 1
 }
 
 enum ApplePaySummaryItemType: Int {
-  case pending = 0
-  case definite = 1
+    case pending = 0
+    case definite = 1
 }
 
 enum CardNumberValidationResultDTO: Int {
-  case valid = 0
-  case invalidIllegalCharacters = 1
-  case invalidLuhnCheck = 2
-  case invalidTooShort = 3
-  case invalidTooLong = 4
-  case invalidOtherReason = 5
+    case valid = 0
+    case invalidIllegalCharacters = 1
+    case invalidLuhnCheck = 2
+    case invalidTooShort = 3
+    case invalidTooLong = 4
+    case invalidOtherReason = 5
 }
 
 enum CardExpiryDateValidationResultDTO: Int {
-  case valid = 0
-  case invalidTooFarInTheFuture = 1
-  case invalidTooOld = 2
-  case nonParseableDate = 3
-  case invalidOtherReason = 4
+    case valid = 0
+    case invalidTooFarInTheFuture = 1
+    case invalidTooOld = 2
+    case nonParseableDate = 3
+    case invalidOtherReason = 4
 }
 
 enum CardSecurityCodeValidationResultDTO: Int {
-  case valid = 0
-  case invalid = 1
+    case valid = 0
+    case invalid = 1
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct SessionDTO {
-  var id: String
-  var sessionData: String
-  var paymentMethodsJson: String
+    var id: String
+    var sessionData: String
+    var paymentMethodsJson: String
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> SessionDTO? {
-    let id = __pigeon_list[0] as! String
-    let sessionData = __pigeon_list[1] as! String
-    let paymentMethodsJson = __pigeon_list[2] as! String
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> SessionDTO? {
+        let id = __pigeon_list[0] as! String
+        let sessionData = __pigeon_list[1] as! String
+        let paymentMethodsJson = __pigeon_list[2] as! String
 
-    return SessionDTO(
-      id: id,
-      sessionData: sessionData,
-      paymentMethodsJson: paymentMethodsJson
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      id,
-      sessionData,
-      paymentMethodsJson,
-    ]
-  }
+        return SessionDTO(
+            id: id,
+            sessionData: sessionData,
+            paymentMethodsJson: paymentMethodsJson
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            id,
+            sessionData,
+            paymentMethodsJson
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct AmountDTO {
-  var currency: String
-  var value: Int64
+    var currency: String
+    var value: Int64
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> AmountDTO? {
-    let currency = __pigeon_list[0] as! String
-    let value = __pigeon_list[1] is Int64 ? __pigeon_list[1] as! Int64 : Int64(__pigeon_list[1] as! Int32)
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> AmountDTO? {
+        let currency = __pigeon_list[0] as! String
+        let value = __pigeon_list[1] is Int64 ? __pigeon_list[1] as! Int64 : Int64(__pigeon_list[1] as! Int32)
 
-    return AmountDTO(
-      currency: currency,
-      value: value
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      currency,
-      value,
-    ]
-  }
+        return AmountDTO(
+            currency: currency,
+            value: value
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            currency,
+            value
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct AnalyticsOptionsDTO {
-  var enabled: Bool
-  var version: String
+    var enabled: Bool
+    var version: String
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> AnalyticsOptionsDTO? {
-    let enabled = __pigeon_list[0] as! Bool
-    let version = __pigeon_list[1] as! String
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> AnalyticsOptionsDTO? {
+        let enabled = __pigeon_list[0] as! Bool
+        let version = __pigeon_list[1] as! String
 
-    return AnalyticsOptionsDTO(
-      enabled: enabled,
-      version: version
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      enabled,
-      version,
-    ]
-  }
+        return AnalyticsOptionsDTO(
+            enabled: enabled,
+            version: version
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            enabled,
+            version
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2UICustomizationDTO {
-  var screenCustomization: ThreeDS2ScreenCustomizationDTO? = nil
-  var headingCustomization: ThreeDS2ToolbarCustomizationDTO? = nil
-  var labelCustomization: ThreeDS2LabelCustomizationDTO? = nil
-  var inputCustomization: ThreeDS2InputCustomizationDTO? = nil
-  var selectionItemCustomization: ThreeDS2SelectionItemCustomizationDTO? = nil
-  var primaryButtonCustomization: ThreeDS2ButtonCustomizationDTO? = nil
-  var secondaryButtonCustomization: ThreeDS2ButtonCustomizationDTO? = nil
+    var screenCustomization: ThreeDS2ScreenCustomizationDTO?
+    var headingCustomization: ThreeDS2ToolbarCustomizationDTO?
+    var labelCustomization: ThreeDS2LabelCustomizationDTO?
+    var inputCustomization: ThreeDS2InputCustomizationDTO?
+    var selectionItemCustomization: ThreeDS2SelectionItemCustomizationDTO?
+    var primaryButtonCustomization: ThreeDS2ButtonCustomizationDTO?
+    var secondaryButtonCustomization: ThreeDS2ButtonCustomizationDTO?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2UICustomizationDTO? {
-    let screenCustomization: ThreeDS2ScreenCustomizationDTO? = nilOrValue(__pigeon_list[0])
-    let headingCustomization: ThreeDS2ToolbarCustomizationDTO? = nilOrValue(__pigeon_list[1])
-    let labelCustomization: ThreeDS2LabelCustomizationDTO? = nilOrValue(__pigeon_list[2])
-    let inputCustomization: ThreeDS2InputCustomizationDTO? = nilOrValue(__pigeon_list[3])
-    let selectionItemCustomization: ThreeDS2SelectionItemCustomizationDTO? = nilOrValue(__pigeon_list[4])
-    let primaryButtonCustomization: ThreeDS2ButtonCustomizationDTO? = nilOrValue(__pigeon_list[5])
-    let secondaryButtonCustomization: ThreeDS2ButtonCustomizationDTO? = nilOrValue(__pigeon_list[6])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2UICustomizationDTO? {
+        let screenCustomization: ThreeDS2ScreenCustomizationDTO? = nilOrValue(__pigeon_list[0])
+        let headingCustomization: ThreeDS2ToolbarCustomizationDTO? = nilOrValue(__pigeon_list[1])
+        let labelCustomization: ThreeDS2LabelCustomizationDTO? = nilOrValue(__pigeon_list[2])
+        let inputCustomization: ThreeDS2InputCustomizationDTO? = nilOrValue(__pigeon_list[3])
+        let selectionItemCustomization: ThreeDS2SelectionItemCustomizationDTO? = nilOrValue(__pigeon_list[4])
+        let primaryButtonCustomization: ThreeDS2ButtonCustomizationDTO? = nilOrValue(__pigeon_list[5])
+        let secondaryButtonCustomization: ThreeDS2ButtonCustomizationDTO? = nilOrValue(__pigeon_list[6])
 
-    return ThreeDS2UICustomizationDTO(
-      screenCustomization: screenCustomization,
-      headingCustomization: headingCustomization,
-      labelCustomization: labelCustomization,
-      inputCustomization: inputCustomization,
-      selectionItemCustomization: selectionItemCustomization,
-      primaryButtonCustomization: primaryButtonCustomization,
-      secondaryButtonCustomization: secondaryButtonCustomization
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      screenCustomization,
-      headingCustomization,
-      labelCustomization,
-      inputCustomization,
-      selectionItemCustomization,
-      primaryButtonCustomization,
-      secondaryButtonCustomization,
-    ]
-  }
+        return ThreeDS2UICustomizationDTO(
+            screenCustomization: screenCustomization,
+            headingCustomization: headingCustomization,
+            labelCustomization: labelCustomization,
+            inputCustomization: inputCustomization,
+            selectionItemCustomization: selectionItemCustomization,
+            primaryButtonCustomization: primaryButtonCustomization,
+            secondaryButtonCustomization: secondaryButtonCustomization
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            screenCustomization,
+            headingCustomization,
+            labelCustomization,
+            inputCustomization,
+            selectionItemCustomization,
+            primaryButtonCustomization,
+            secondaryButtonCustomization
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2ScreenCustomizationDTO {
-  var backgroundColor: String? = nil
-  var textColor: String? = nil
+    var backgroundColor: String?
+    var textColor: String?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ScreenCustomizationDTO? {
-    let backgroundColor: String? = nilOrValue(__pigeon_list[0])
-    let textColor: String? = nilOrValue(__pigeon_list[1])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ScreenCustomizationDTO? {
+        let backgroundColor: String? = nilOrValue(__pigeon_list[0])
+        let textColor: String? = nilOrValue(__pigeon_list[1])
 
-    return ThreeDS2ScreenCustomizationDTO(
-      backgroundColor: backgroundColor,
-      textColor: textColor
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      backgroundColor,
-      textColor,
-    ]
-  }
+        return ThreeDS2ScreenCustomizationDTO(
+            backgroundColor: backgroundColor,
+            textColor: textColor
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            backgroundColor,
+            textColor
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2ButtonCustomizationDTO {
-  var backgroundColor: String? = nil
-  var textColor: String? = nil
-  var cornerRadius: Int64? = nil
-  var textFontSize: Int64? = nil
+    var backgroundColor: String?
+    var textColor: String?
+    var cornerRadius: Int64?
+    var textFontSize: Int64?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ButtonCustomizationDTO? {
-    let backgroundColor: String? = nilOrValue(__pigeon_list[0])
-    let textColor: String? = nilOrValue(__pigeon_list[1])
-    let cornerRadius: Int64? = isNullish(__pigeon_list[2]) ? nil : (__pigeon_list[2] is Int64? ? __pigeon_list[2] as! Int64? : Int64(__pigeon_list[2] as! Int32))
-    let textFontSize: Int64? = isNullish(__pigeon_list[3]) ? nil : (__pigeon_list[3] is Int64? ? __pigeon_list[3] as! Int64? : Int64(__pigeon_list[3] as! Int32))
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ButtonCustomizationDTO? {
+        let backgroundColor: String? = nilOrValue(__pigeon_list[0])
+        let textColor: String? = nilOrValue(__pigeon_list[1])
+        let cornerRadius: Int64? = isNullish(__pigeon_list[2]) ? nil : (__pigeon_list[2] is Int64? ? __pigeon_list[2] as! Int64? : Int64(__pigeon_list[2] as! Int32))
+        let textFontSize: Int64? = isNullish(__pigeon_list[3]) ? nil : (__pigeon_list[3] is Int64? ? __pigeon_list[3] as! Int64? : Int64(__pigeon_list[3] as! Int32))
 
-    return ThreeDS2ButtonCustomizationDTO(
-      backgroundColor: backgroundColor,
-      textColor: textColor,
-      cornerRadius: cornerRadius,
-      textFontSize: textFontSize
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      backgroundColor,
-      textColor,
-      cornerRadius,
-      textFontSize,
-    ]
-  }
+        return ThreeDS2ButtonCustomizationDTO(
+            backgroundColor: backgroundColor,
+            textColor: textColor,
+            cornerRadius: cornerRadius,
+            textFontSize: textFontSize
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            backgroundColor,
+            textColor,
+            cornerRadius,
+            textFontSize
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2SelectionItemCustomizationDTO {
-  var selectionIndicatorTintColor: String? = nil
-  var highlightedBackgroundColor: String? = nil
-  var textColor: String? = nil
+    var selectionIndicatorTintColor: String?
+    var highlightedBackgroundColor: String?
+    var textColor: String?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2SelectionItemCustomizationDTO? {
-    let selectionIndicatorTintColor: String? = nilOrValue(__pigeon_list[0])
-    let highlightedBackgroundColor: String? = nilOrValue(__pigeon_list[1])
-    let textColor: String? = nilOrValue(__pigeon_list[2])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2SelectionItemCustomizationDTO? {
+        let selectionIndicatorTintColor: String? = nilOrValue(__pigeon_list[0])
+        let highlightedBackgroundColor: String? = nilOrValue(__pigeon_list[1])
+        let textColor: String? = nilOrValue(__pigeon_list[2])
 
-    return ThreeDS2SelectionItemCustomizationDTO(
-      selectionIndicatorTintColor: selectionIndicatorTintColor,
-      highlightedBackgroundColor: highlightedBackgroundColor,
-      textColor: textColor
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      selectionIndicatorTintColor,
-      highlightedBackgroundColor,
-      textColor,
-    ]
-  }
+        return ThreeDS2SelectionItemCustomizationDTO(
+            selectionIndicatorTintColor: selectionIndicatorTintColor,
+            highlightedBackgroundColor: highlightedBackgroundColor,
+            textColor: textColor
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            selectionIndicatorTintColor,
+            highlightedBackgroundColor,
+            textColor
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2LabelCustomizationDTO {
-  var headingTextColor: String? = nil
-  var headingTextFontSize: Int64? = nil
-  var inputLabelTextColor: String? = nil
-  var inputLabelFontSize: Int64? = nil
-  var textColor: String? = nil
-  var textFontSize: Int64? = nil
+    var headingTextColor: String?
+    var headingTextFontSize: Int64?
+    var inputLabelTextColor: String?
+    var inputLabelFontSize: Int64?
+    var textColor: String?
+    var textFontSize: Int64?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2LabelCustomizationDTO? {
-    let headingTextColor: String? = nilOrValue(__pigeon_list[0])
-    let headingTextFontSize: Int64? = isNullish(__pigeon_list[1]) ? nil : (__pigeon_list[1] is Int64? ? __pigeon_list[1] as! Int64? : Int64(__pigeon_list[1] as! Int32))
-    let inputLabelTextColor: String? = nilOrValue(__pigeon_list[2])
-    let inputLabelFontSize: Int64? = isNullish(__pigeon_list[3]) ? nil : (__pigeon_list[3] is Int64? ? __pigeon_list[3] as! Int64? : Int64(__pigeon_list[3] as! Int32))
-    let textColor: String? = nilOrValue(__pigeon_list[4])
-    let textFontSize: Int64? = isNullish(__pigeon_list[5]) ? nil : (__pigeon_list[5] is Int64? ? __pigeon_list[5] as! Int64? : Int64(__pigeon_list[5] as! Int32))
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2LabelCustomizationDTO? {
+        let headingTextColor: String? = nilOrValue(__pigeon_list[0])
+        let headingTextFontSize: Int64? = isNullish(__pigeon_list[1]) ? nil : (__pigeon_list[1] is Int64? ? __pigeon_list[1] as! Int64? : Int64(__pigeon_list[1] as! Int32))
+        let inputLabelTextColor: String? = nilOrValue(__pigeon_list[2])
+        let inputLabelFontSize: Int64? = isNullish(__pigeon_list[3]) ? nil : (__pigeon_list[3] is Int64? ? __pigeon_list[3] as! Int64? : Int64(__pigeon_list[3] as! Int32))
+        let textColor: String? = nilOrValue(__pigeon_list[4])
+        let textFontSize: Int64? = isNullish(__pigeon_list[5]) ? nil : (__pigeon_list[5] is Int64? ? __pigeon_list[5] as! Int64? : Int64(__pigeon_list[5] as! Int32))
 
-    return ThreeDS2LabelCustomizationDTO(
-      headingTextColor: headingTextColor,
-      headingTextFontSize: headingTextFontSize,
-      inputLabelTextColor: inputLabelTextColor,
-      inputLabelFontSize: inputLabelFontSize,
-      textColor: textColor,
-      textFontSize: textFontSize
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      headingTextColor,
-      headingTextFontSize,
-      inputLabelTextColor,
-      inputLabelFontSize,
-      textColor,
-      textFontSize,
-    ]
-  }
+        return ThreeDS2LabelCustomizationDTO(
+            headingTextColor: headingTextColor,
+            headingTextFontSize: headingTextFontSize,
+            inputLabelTextColor: inputLabelTextColor,
+            inputLabelFontSize: inputLabelFontSize,
+            textColor: textColor,
+            textFontSize: textFontSize
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            headingTextColor,
+            headingTextFontSize,
+            inputLabelTextColor,
+            inputLabelFontSize,
+            textColor,
+            textFontSize
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2InputCustomizationDTO {
-  var borderColor: String? = nil
-  var borderWidth: Int64? = nil
-  var cornerRadius: Int64? = nil
-  var textColor: String? = nil
+    var borderColor: String?
+    var borderWidth: Int64?
+    var cornerRadius: Int64?
+    var textColor: String?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2InputCustomizationDTO? {
-    let borderColor: String? = nilOrValue(__pigeon_list[0])
-    let borderWidth: Int64? = isNullish(__pigeon_list[1]) ? nil : (__pigeon_list[1] is Int64? ? __pigeon_list[1] as! Int64? : Int64(__pigeon_list[1] as! Int32))
-    let cornerRadius: Int64? = isNullish(__pigeon_list[2]) ? nil : (__pigeon_list[2] is Int64? ? __pigeon_list[2] as! Int64? : Int64(__pigeon_list[2] as! Int32))
-    let textColor: String? = nilOrValue(__pigeon_list[3])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2InputCustomizationDTO? {
+        let borderColor: String? = nilOrValue(__pigeon_list[0])
+        let borderWidth: Int64? = isNullish(__pigeon_list[1]) ? nil : (__pigeon_list[1] is Int64? ? __pigeon_list[1] as! Int64? : Int64(__pigeon_list[1] as! Int32))
+        let cornerRadius: Int64? = isNullish(__pigeon_list[2]) ? nil : (__pigeon_list[2] is Int64? ? __pigeon_list[2] as! Int64? : Int64(__pigeon_list[2] as! Int32))
+        let textColor: String? = nilOrValue(__pigeon_list[3])
 
-    return ThreeDS2InputCustomizationDTO(
-      borderColor: borderColor,
-      borderWidth: borderWidth,
-      cornerRadius: cornerRadius,
-      textColor: textColor
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      borderColor,
-      borderWidth,
-      cornerRadius,
-      textColor,
-    ]
-  }
+        return ThreeDS2InputCustomizationDTO(
+            borderColor: borderColor,
+            borderWidth: borderWidth,
+            cornerRadius: cornerRadius,
+            textColor: textColor
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            borderColor,
+            borderWidth,
+            cornerRadius,
+            textColor
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2ToolbarCustomizationDTO {
-  var headerText: String? = nil
-  var textColor: String? = nil
-  var backgroundColor: String? = nil
-  var cancelButtonColor: String? = nil
+    var headerText: String?
+    var textColor: String?
+    var backgroundColor: String?
+    var cancelButtonColor: String?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ToolbarCustomizationDTO? {
-    let headerText: String? = nilOrValue(__pigeon_list[0])
-    let textColor: String? = nilOrValue(__pigeon_list[1])
-    let backgroundColor: String? = nilOrValue(__pigeon_list[2])
-    let cancelButtonColor: String? = nilOrValue(__pigeon_list[3])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ToolbarCustomizationDTO? {
+        let headerText: String? = nilOrValue(__pigeon_list[0])
+        let textColor: String? = nilOrValue(__pigeon_list[1])
+        let backgroundColor: String? = nilOrValue(__pigeon_list[2])
+        let cancelButtonColor: String? = nilOrValue(__pigeon_list[3])
 
-    return ThreeDS2ToolbarCustomizationDTO(
-      headerText: headerText,
-      textColor: textColor,
-      backgroundColor: backgroundColor,
-      cancelButtonColor: cancelButtonColor
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      headerText,
-      textColor,
-      backgroundColor,
-      cancelButtonColor,
-    ]
-  }
+        return ThreeDS2ToolbarCustomizationDTO(
+            headerText: headerText,
+            textColor: textColor,
+            backgroundColor: backgroundColor,
+            cancelButtonColor: cancelButtonColor
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            headerText,
+            textColor,
+            backgroundColor,
+            cancelButtonColor
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ThreeDS2ConfigurationDTO {
-  var requestorAppURL: String? = nil
-  var uiCustomization: ThreeDS2UICustomizationDTO? = nil
+    var requestorAppURL: String?
+    var uiCustomization: ThreeDS2UICustomizationDTO?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ConfigurationDTO? {
-    let requestorAppURL: String? = nilOrValue(__pigeon_list[0])
-    let uiCustomization: ThreeDS2UICustomizationDTO? = nilOrValue(__pigeon_list[1])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ThreeDS2ConfigurationDTO? {
+        let requestorAppURL: String? = nilOrValue(__pigeon_list[0])
+        let uiCustomization: ThreeDS2UICustomizationDTO? = nilOrValue(__pigeon_list[1])
 
-    return ThreeDS2ConfigurationDTO(
-      requestorAppURL: requestorAppURL,
-      uiCustomization: uiCustomization
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      requestorAppURL,
-      uiCustomization,
-    ]
-  }
+        return ThreeDS2ConfigurationDTO(
+            requestorAppURL: requestorAppURL,
+            uiCustomization: uiCustomization
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            requestorAppURL,
+            uiCustomization
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct DefaultInstallmentOptionsDTO {
-  var values: [Int64?]
-  var includesRevolving: Bool
+    var values: [Int64?]
+    var includesRevolving: Bool
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> DefaultInstallmentOptionsDTO? {
-    let values = __pigeon_list[0] as! [Int64?]
-    let includesRevolving = __pigeon_list[1] as! Bool
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> DefaultInstallmentOptionsDTO? {
+        let values = __pigeon_list[0] as! [Int64?]
+        let includesRevolving = __pigeon_list[1] as! Bool
 
-    return DefaultInstallmentOptionsDTO(
-      values: values,
-      includesRevolving: includesRevolving
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      values,
-      includesRevolving,
-    ]
-  }
+        return DefaultInstallmentOptionsDTO(
+            values: values,
+            includesRevolving: includesRevolving
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            values,
+            includesRevolving
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct CardBasedInstallmentOptionsDTO {
-  var values: [Int64?]
-  var includesRevolving: Bool
-  var cardBrand: String
+    var values: [Int64?]
+    var includesRevolving: Bool
+    var cardBrand: String
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> CardBasedInstallmentOptionsDTO? {
-    let values = __pigeon_list[0] as! [Int64?]
-    let includesRevolving = __pigeon_list[1] as! Bool
-    let cardBrand = __pigeon_list[2] as! String
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> CardBasedInstallmentOptionsDTO? {
+        let values = __pigeon_list[0] as! [Int64?]
+        let includesRevolving = __pigeon_list[1] as! Bool
+        let cardBrand = __pigeon_list[2] as! String
 
-    return CardBasedInstallmentOptionsDTO(
-      values: values,
-      includesRevolving: includesRevolving,
-      cardBrand: cardBrand
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      values,
-      includesRevolving,
-      cardBrand,
-    ]
-  }
+        return CardBasedInstallmentOptionsDTO(
+            values: values,
+            includesRevolving: includesRevolving,
+            cardBrand: cardBrand
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            values,
+            includesRevolving,
+            cardBrand
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct InstallmentConfigurationDTO {
-  var defaultOptions: DefaultInstallmentOptionsDTO? = nil
-  var cardBasedOptions: [CardBasedInstallmentOptionsDTO?]? = nil
-  var showInstallmentAmount: Bool
+    var defaultOptions: DefaultInstallmentOptionsDTO?
+    var cardBasedOptions: [CardBasedInstallmentOptionsDTO?]?
+    var showInstallmentAmount: Bool
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> InstallmentConfigurationDTO? {
-    let defaultOptions: DefaultInstallmentOptionsDTO? = nilOrValue(__pigeon_list[0])
-    let cardBasedOptions: [CardBasedInstallmentOptionsDTO?]? = nilOrValue(__pigeon_list[1])
-    let showInstallmentAmount = __pigeon_list[2] as! Bool
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> InstallmentConfigurationDTO? {
+        let defaultOptions: DefaultInstallmentOptionsDTO? = nilOrValue(__pigeon_list[0])
+        let cardBasedOptions: [CardBasedInstallmentOptionsDTO?]? = nilOrValue(__pigeon_list[1])
+        let showInstallmentAmount = __pigeon_list[2] as! Bool
 
-    return InstallmentConfigurationDTO(
-      defaultOptions: defaultOptions,
-      cardBasedOptions: cardBasedOptions,
-      showInstallmentAmount: showInstallmentAmount
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      defaultOptions,
-      cardBasedOptions,
-      showInstallmentAmount,
-    ]
-  }
+        return InstallmentConfigurationDTO(
+            defaultOptions: defaultOptions,
+            cardBasedOptions: cardBasedOptions,
+            showInstallmentAmount: showInstallmentAmount
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            defaultOptions,
+            cardBasedOptions,
+            showInstallmentAmount
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct DropInConfigurationDTO {
-  var environment: Environment
-  var clientKey: String
-  var countryCode: String
-  var amount: AmountDTO? = nil
-  var shopperLocale: String? = nil
-  var cardConfigurationDTO: CardConfigurationDTO? = nil
-  var applePayConfigurationDTO: ApplePayConfigurationDTO? = nil
-  var googlePayConfigurationDTO: GooglePayConfigurationDTO? = nil
-  var cashAppPayConfigurationDTO: CashAppPayConfigurationDTO? = nil
-  var twintConfigurationDTO: TwintConfigurationDTO? = nil
-  var threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil
-  var analyticsOptionsDTO: AnalyticsOptionsDTO
-  var showPreselectedStoredPaymentMethod: Bool
-  var skipListWhenSinglePaymentMethod: Bool
-  var isRemoveStoredPaymentMethodEnabled: Bool
-  var preselectedPaymentMethodTitle: String? = nil
-  var paymentMethodNames: [String?: String?]? = nil
-  var isPartialPaymentSupported: Bool
+    var environment: Environment
+    var clientKey: String
+    var countryCode: String
+    var amount: AmountDTO?
+    var shopperLocale: String?
+    var cardConfigurationDTO: CardConfigurationDTO?
+    var applePayConfigurationDTO: ApplePayConfigurationDTO?
+    var googlePayConfigurationDTO: GooglePayConfigurationDTO?
+    var cashAppPayConfigurationDTO: CashAppPayConfigurationDTO?
+    var twintConfigurationDTO: TwintConfigurationDTO?
+    var threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO?
+    var analyticsOptionsDTO: AnalyticsOptionsDTO
+    var showPreselectedStoredPaymentMethod: Bool
+    var skipListWhenSinglePaymentMethod: Bool
+    var isRemoveStoredPaymentMethodEnabled: Bool
+    var preselectedPaymentMethodTitle: String?
+    var paymentMethodNames: [String?: String?]?
+    var isPartialPaymentSupported: Bool
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> DropInConfigurationDTO? {
-    let environment = __pigeon_list[0] as! Environment
-    let clientKey = __pigeon_list[1] as! String
-    let countryCode = __pigeon_list[2] as! String
-    let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
-    let shopperLocale: String? = nilOrValue(__pigeon_list[4])
-    let cardConfigurationDTO: CardConfigurationDTO? = nilOrValue(__pigeon_list[5])
-    let applePayConfigurationDTO: ApplePayConfigurationDTO? = nilOrValue(__pigeon_list[6])
-    let googlePayConfigurationDTO: GooglePayConfigurationDTO? = nilOrValue(__pigeon_list[7])
-    let cashAppPayConfigurationDTO: CashAppPayConfigurationDTO? = nilOrValue(__pigeon_list[8])
-    let twintConfigurationDTO: TwintConfigurationDTO? = nilOrValue(__pigeon_list[9])
-    let threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nilOrValue(__pigeon_list[10])
-    let analyticsOptionsDTO = __pigeon_list[11] as! AnalyticsOptionsDTO
-    let showPreselectedStoredPaymentMethod = __pigeon_list[12] as! Bool
-    let skipListWhenSinglePaymentMethod = __pigeon_list[13] as! Bool
-    let isRemoveStoredPaymentMethodEnabled = __pigeon_list[14] as! Bool
-    let preselectedPaymentMethodTitle: String? = nilOrValue(__pigeon_list[15])
-    let paymentMethodNames: [String?: String?]? = nilOrValue(__pigeon_list[16])
-    let isPartialPaymentSupported = __pigeon_list[17] as! Bool
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> DropInConfigurationDTO? {
+        let environment = __pigeon_list[0] as! Environment
+        let clientKey = __pigeon_list[1] as! String
+        let countryCode = __pigeon_list[2] as! String
+        let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
+        let shopperLocale: String? = nilOrValue(__pigeon_list[4])
+        let cardConfigurationDTO: CardConfigurationDTO? = nilOrValue(__pigeon_list[5])
+        let applePayConfigurationDTO: ApplePayConfigurationDTO? = nilOrValue(__pigeon_list[6])
+        let googlePayConfigurationDTO: GooglePayConfigurationDTO? = nilOrValue(__pigeon_list[7])
+        let cashAppPayConfigurationDTO: CashAppPayConfigurationDTO? = nilOrValue(__pigeon_list[8])
+        let twintConfigurationDTO: TwintConfigurationDTO? = nilOrValue(__pigeon_list[9])
+        let threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nilOrValue(__pigeon_list[10])
+        let analyticsOptionsDTO = __pigeon_list[11] as! AnalyticsOptionsDTO
+        let showPreselectedStoredPaymentMethod = __pigeon_list[12] as! Bool
+        let skipListWhenSinglePaymentMethod = __pigeon_list[13] as! Bool
+        let isRemoveStoredPaymentMethodEnabled = __pigeon_list[14] as! Bool
+        let preselectedPaymentMethodTitle: String? = nilOrValue(__pigeon_list[15])
+        let paymentMethodNames: [String?: String?]? = nilOrValue(__pigeon_list[16])
+        let isPartialPaymentSupported = __pigeon_list[17] as! Bool
 
-    return DropInConfigurationDTO(
-      environment: environment,
-      clientKey: clientKey,
-      countryCode: countryCode,
-      amount: amount,
-      shopperLocale: shopperLocale,
-      cardConfigurationDTO: cardConfigurationDTO,
-      applePayConfigurationDTO: applePayConfigurationDTO,
-      googlePayConfigurationDTO: googlePayConfigurationDTO,
-      cashAppPayConfigurationDTO: cashAppPayConfigurationDTO,
-      twintConfigurationDTO: twintConfigurationDTO,
-      threeDS2ConfigurationDTO: threeDS2ConfigurationDTO,
-      analyticsOptionsDTO: analyticsOptionsDTO,
-      showPreselectedStoredPaymentMethod: showPreselectedStoredPaymentMethod,
-      skipListWhenSinglePaymentMethod: skipListWhenSinglePaymentMethod,
-      isRemoveStoredPaymentMethodEnabled: isRemoveStoredPaymentMethodEnabled,
-      preselectedPaymentMethodTitle: preselectedPaymentMethodTitle,
-      paymentMethodNames: paymentMethodNames,
-      isPartialPaymentSupported: isPartialPaymentSupported
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      environment,
-      clientKey,
-      countryCode,
-      amount,
-      shopperLocale,
-      cardConfigurationDTO,
-      applePayConfigurationDTO,
-      googlePayConfigurationDTO,
-      cashAppPayConfigurationDTO,
-      twintConfigurationDTO,
-      threeDS2ConfigurationDTO,
-      analyticsOptionsDTO,
-      showPreselectedStoredPaymentMethod,
-      skipListWhenSinglePaymentMethod,
-      isRemoveStoredPaymentMethodEnabled,
-      preselectedPaymentMethodTitle,
-      paymentMethodNames,
-      isPartialPaymentSupported,
-    ]
-  }
+        return DropInConfigurationDTO(
+            environment: environment,
+            clientKey: clientKey,
+            countryCode: countryCode,
+            amount: amount,
+            shopperLocale: shopperLocale,
+            cardConfigurationDTO: cardConfigurationDTO,
+            applePayConfigurationDTO: applePayConfigurationDTO,
+            googlePayConfigurationDTO: googlePayConfigurationDTO,
+            cashAppPayConfigurationDTO: cashAppPayConfigurationDTO,
+            twintConfigurationDTO: twintConfigurationDTO,
+            threeDS2ConfigurationDTO: threeDS2ConfigurationDTO,
+            analyticsOptionsDTO: analyticsOptionsDTO,
+            showPreselectedStoredPaymentMethod: showPreselectedStoredPaymentMethod,
+            skipListWhenSinglePaymentMethod: skipListWhenSinglePaymentMethod,
+            isRemoveStoredPaymentMethodEnabled: isRemoveStoredPaymentMethodEnabled,
+            preselectedPaymentMethodTitle: preselectedPaymentMethodTitle,
+            paymentMethodNames: paymentMethodNames,
+            isPartialPaymentSupported: isPartialPaymentSupported
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            environment,
+            clientKey,
+            countryCode,
+            amount,
+            shopperLocale,
+            cardConfigurationDTO,
+            applePayConfigurationDTO,
+            googlePayConfigurationDTO,
+            cashAppPayConfigurationDTO,
+            twintConfigurationDTO,
+            threeDS2ConfigurationDTO,
+            analyticsOptionsDTO,
+            showPreselectedStoredPaymentMethod,
+            skipListWhenSinglePaymentMethod,
+            isRemoveStoredPaymentMethodEnabled,
+            preselectedPaymentMethodTitle,
+            paymentMethodNames,
+            isPartialPaymentSupported
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct CardConfigurationDTO {
-  var holderNameRequired: Bool
-  var addressMode: AddressMode
-  var showStorePaymentField: Bool
-  var showCvcForStoredCard: Bool
-  var showCvc: Bool
-  var kcpFieldVisibility: FieldVisibility
-  var socialSecurityNumberFieldVisibility: FieldVisibility
-  var supportedCardTypes: [String?]
-  var installmentConfiguration: InstallmentConfigurationDTO? = nil
+    var holderNameRequired: Bool
+    var addressMode: AddressMode
+    var showStorePaymentField: Bool
+    var showCvcForStoredCard: Bool
+    var showCvc: Bool
+    var kcpFieldVisibility: FieldVisibility
+    var socialSecurityNumberFieldVisibility: FieldVisibility
+    var supportedCardTypes: [String?]
+    var installmentConfiguration: InstallmentConfigurationDTO?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> CardConfigurationDTO? {
-    let holderNameRequired = __pigeon_list[0] as! Bool
-    let addressMode = __pigeon_list[1] as! AddressMode
-    let showStorePaymentField = __pigeon_list[2] as! Bool
-    let showCvcForStoredCard = __pigeon_list[3] as! Bool
-    let showCvc = __pigeon_list[4] as! Bool
-    let kcpFieldVisibility = __pigeon_list[5] as! FieldVisibility
-    let socialSecurityNumberFieldVisibility = __pigeon_list[6] as! FieldVisibility
-    let supportedCardTypes = __pigeon_list[7] as! [String?]
-    let installmentConfiguration: InstallmentConfigurationDTO? = nilOrValue(__pigeon_list[8])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> CardConfigurationDTO? {
+        let holderNameRequired = __pigeon_list[0] as! Bool
+        let addressMode = __pigeon_list[1] as! AddressMode
+        let showStorePaymentField = __pigeon_list[2] as! Bool
+        let showCvcForStoredCard = __pigeon_list[3] as! Bool
+        let showCvc = __pigeon_list[4] as! Bool
+        let kcpFieldVisibility = __pigeon_list[5] as! FieldVisibility
+        let socialSecurityNumberFieldVisibility = __pigeon_list[6] as! FieldVisibility
+        let supportedCardTypes = __pigeon_list[7] as! [String?]
+        let installmentConfiguration: InstallmentConfigurationDTO? = nilOrValue(__pigeon_list[8])
 
-    return CardConfigurationDTO(
-      holderNameRequired: holderNameRequired,
-      addressMode: addressMode,
-      showStorePaymentField: showStorePaymentField,
-      showCvcForStoredCard: showCvcForStoredCard,
-      showCvc: showCvc,
-      kcpFieldVisibility: kcpFieldVisibility,
-      socialSecurityNumberFieldVisibility: socialSecurityNumberFieldVisibility,
-      supportedCardTypes: supportedCardTypes,
-      installmentConfiguration: installmentConfiguration
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      holderNameRequired,
-      addressMode,
-      showStorePaymentField,
-      showCvcForStoredCard,
-      showCvc,
-      kcpFieldVisibility,
-      socialSecurityNumberFieldVisibility,
-      supportedCardTypes,
-      installmentConfiguration,
-    ]
-  }
+        return CardConfigurationDTO(
+            holderNameRequired: holderNameRequired,
+            addressMode: addressMode,
+            showStorePaymentField: showStorePaymentField,
+            showCvcForStoredCard: showCvcForStoredCard,
+            showCvc: showCvc,
+            kcpFieldVisibility: kcpFieldVisibility,
+            socialSecurityNumberFieldVisibility: socialSecurityNumberFieldVisibility,
+            supportedCardTypes: supportedCardTypes,
+            installmentConfiguration: installmentConfiguration
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            holderNameRequired,
+            addressMode,
+            showStorePaymentField,
+            showCvcForStoredCard,
+            showCvc,
+            kcpFieldVisibility,
+            socialSecurityNumberFieldVisibility,
+            supportedCardTypes,
+            installmentConfiguration
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ApplePayConfigurationDTO {
-  var merchantId: String
-  var merchantName: String
-  var allowOnboarding: Bool? = nil
-  var summaryItems: [ApplePaySummaryItemDTO?]? = nil
-  var requiredBillingContactFields: [String?]? = nil
-  var billingContact: ApplePayContactDTO? = nil
-  var requiredShippingContactFields: [String?]? = nil
-  var shippingContact: ApplePayContactDTO? = nil
-  var applePayShippingType: ApplePayShippingType? = nil
-  var allowShippingContactEditing: Bool? = nil
-  var shippingMethods: [ApplePayShippingMethodDTO?]? = nil
-  var applicationData: String? = nil
-  var supportedCountries: [String?]? = nil
-  var merchantCapability: ApplePayMerchantCapability? = nil
+    var merchantId: String
+    var merchantName: String
+    var allowOnboarding: Bool?
+    var summaryItems: [ApplePaySummaryItemDTO?]?
+    var requiredBillingContactFields: [String?]?
+    var billingContact: ApplePayContactDTO?
+    var requiredShippingContactFields: [String?]?
+    var shippingContact: ApplePayContactDTO?
+    var applePayShippingType: ApplePayShippingType?
+    var allowShippingContactEditing: Bool?
+    var shippingMethods: [ApplePayShippingMethodDTO?]?
+    var applicationData: String?
+    var supportedCountries: [String?]?
+    var merchantCapability: ApplePayMerchantCapability?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ApplePayConfigurationDTO? {
-    let merchantId = __pigeon_list[0] as! String
-    let merchantName = __pigeon_list[1] as! String
-    let allowOnboarding: Bool? = nilOrValue(__pigeon_list[2])
-    let summaryItems: [ApplePaySummaryItemDTO?]? = nilOrValue(__pigeon_list[3])
-    let requiredBillingContactFields: [String?]? = nilOrValue(__pigeon_list[4])
-    let billingContact: ApplePayContactDTO? = nilOrValue(__pigeon_list[5])
-    let requiredShippingContactFields: [String?]? = nilOrValue(__pigeon_list[6])
-    let shippingContact: ApplePayContactDTO? = nilOrValue(__pigeon_list[7])
-    let applePayShippingType: ApplePayShippingType? = nilOrValue(__pigeon_list[8])
-    let allowShippingContactEditing: Bool? = nilOrValue(__pigeon_list[9])
-    let shippingMethods: [ApplePayShippingMethodDTO?]? = nilOrValue(__pigeon_list[10])
-    let applicationData: String? = nilOrValue(__pigeon_list[11])
-    let supportedCountries: [String?]? = nilOrValue(__pigeon_list[12])
-    let merchantCapability: ApplePayMerchantCapability? = nilOrValue(__pigeon_list[13])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ApplePayConfigurationDTO? {
+        let merchantId = __pigeon_list[0] as! String
+        let merchantName = __pigeon_list[1] as! String
+        let allowOnboarding: Bool? = nilOrValue(__pigeon_list[2])
+        let summaryItems: [ApplePaySummaryItemDTO?]? = nilOrValue(__pigeon_list[3])
+        let requiredBillingContactFields: [String?]? = nilOrValue(__pigeon_list[4])
+        let billingContact: ApplePayContactDTO? = nilOrValue(__pigeon_list[5])
+        let requiredShippingContactFields: [String?]? = nilOrValue(__pigeon_list[6])
+        let shippingContact: ApplePayContactDTO? = nilOrValue(__pigeon_list[7])
+        let applePayShippingType: ApplePayShippingType? = nilOrValue(__pigeon_list[8])
+        let allowShippingContactEditing: Bool? = nilOrValue(__pigeon_list[9])
+        let shippingMethods: [ApplePayShippingMethodDTO?]? = nilOrValue(__pigeon_list[10])
+        let applicationData: String? = nilOrValue(__pigeon_list[11])
+        let supportedCountries: [String?]? = nilOrValue(__pigeon_list[12])
+        let merchantCapability: ApplePayMerchantCapability? = nilOrValue(__pigeon_list[13])
 
-    return ApplePayConfigurationDTO(
-      merchantId: merchantId,
-      merchantName: merchantName,
-      allowOnboarding: allowOnboarding,
-      summaryItems: summaryItems,
-      requiredBillingContactFields: requiredBillingContactFields,
-      billingContact: billingContact,
-      requiredShippingContactFields: requiredShippingContactFields,
-      shippingContact: shippingContact,
-      applePayShippingType: applePayShippingType,
-      allowShippingContactEditing: allowShippingContactEditing,
-      shippingMethods: shippingMethods,
-      applicationData: applicationData,
-      supportedCountries: supportedCountries,
-      merchantCapability: merchantCapability
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      merchantId,
-      merchantName,
-      allowOnboarding,
-      summaryItems,
-      requiredBillingContactFields,
-      billingContact,
-      requiredShippingContactFields,
-      shippingContact,
-      applePayShippingType,
-      allowShippingContactEditing,
-      shippingMethods,
-      applicationData,
-      supportedCountries,
-      merchantCapability,
-    ]
-  }
+        return ApplePayConfigurationDTO(
+            merchantId: merchantId,
+            merchantName: merchantName,
+            allowOnboarding: allowOnboarding,
+            summaryItems: summaryItems,
+            requiredBillingContactFields: requiredBillingContactFields,
+            billingContact: billingContact,
+            requiredShippingContactFields: requiredShippingContactFields,
+            shippingContact: shippingContact,
+            applePayShippingType: applePayShippingType,
+            allowShippingContactEditing: allowShippingContactEditing,
+            shippingMethods: shippingMethods,
+            applicationData: applicationData,
+            supportedCountries: supportedCountries,
+            merchantCapability: merchantCapability
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            merchantId,
+            merchantName,
+            allowOnboarding,
+            summaryItems,
+            requiredBillingContactFields,
+            billingContact,
+            requiredShippingContactFields,
+            shippingContact,
+            applePayShippingType,
+            allowShippingContactEditing,
+            shippingMethods,
+            applicationData,
+            supportedCountries,
+            merchantCapability
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ApplePayContactDTO {
-  var phoneNumber: String? = nil
-  var emailAddress: String? = nil
-  var givenName: String? = nil
-  var familyName: String? = nil
-  var phoneticGivenName: String? = nil
-  var phoneticFamilyName: String? = nil
-  var addressLines: [String?]? = nil
-  var subLocality: String? = nil
-  var city: String? = nil
-  var postalCode: String? = nil
-  var subAdministrativeArea: String? = nil
-  var administrativeArea: String? = nil
-  var country: String? = nil
-  var countryCode: String? = nil
+    var phoneNumber: String?
+    var emailAddress: String?
+    var givenName: String?
+    var familyName: String?
+    var phoneticGivenName: String?
+    var phoneticFamilyName: String?
+    var addressLines: [String?]?
+    var subLocality: String?
+    var city: String?
+    var postalCode: String?
+    var subAdministrativeArea: String?
+    var administrativeArea: String?
+    var country: String?
+    var countryCode: String?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ApplePayContactDTO? {
-    let phoneNumber: String? = nilOrValue(__pigeon_list[0])
-    let emailAddress: String? = nilOrValue(__pigeon_list[1])
-    let givenName: String? = nilOrValue(__pigeon_list[2])
-    let familyName: String? = nilOrValue(__pigeon_list[3])
-    let phoneticGivenName: String? = nilOrValue(__pigeon_list[4])
-    let phoneticFamilyName: String? = nilOrValue(__pigeon_list[5])
-    let addressLines: [String?]? = nilOrValue(__pigeon_list[6])
-    let subLocality: String? = nilOrValue(__pigeon_list[7])
-    let city: String? = nilOrValue(__pigeon_list[8])
-    let postalCode: String? = nilOrValue(__pigeon_list[9])
-    let subAdministrativeArea: String? = nilOrValue(__pigeon_list[10])
-    let administrativeArea: String? = nilOrValue(__pigeon_list[11])
-    let country: String? = nilOrValue(__pigeon_list[12])
-    let countryCode: String? = nilOrValue(__pigeon_list[13])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ApplePayContactDTO? {
+        let phoneNumber: String? = nilOrValue(__pigeon_list[0])
+        let emailAddress: String? = nilOrValue(__pigeon_list[1])
+        let givenName: String? = nilOrValue(__pigeon_list[2])
+        let familyName: String? = nilOrValue(__pigeon_list[3])
+        let phoneticGivenName: String? = nilOrValue(__pigeon_list[4])
+        let phoneticFamilyName: String? = nilOrValue(__pigeon_list[5])
+        let addressLines: [String?]? = nilOrValue(__pigeon_list[6])
+        let subLocality: String? = nilOrValue(__pigeon_list[7])
+        let city: String? = nilOrValue(__pigeon_list[8])
+        let postalCode: String? = nilOrValue(__pigeon_list[9])
+        let subAdministrativeArea: String? = nilOrValue(__pigeon_list[10])
+        let administrativeArea: String? = nilOrValue(__pigeon_list[11])
+        let country: String? = nilOrValue(__pigeon_list[12])
+        let countryCode: String? = nilOrValue(__pigeon_list[13])
 
-    return ApplePayContactDTO(
-      phoneNumber: phoneNumber,
-      emailAddress: emailAddress,
-      givenName: givenName,
-      familyName: familyName,
-      phoneticGivenName: phoneticGivenName,
-      phoneticFamilyName: phoneticFamilyName,
-      addressLines: addressLines,
-      subLocality: subLocality,
-      city: city,
-      postalCode: postalCode,
-      subAdministrativeArea: subAdministrativeArea,
-      administrativeArea: administrativeArea,
-      country: country,
-      countryCode: countryCode
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      phoneNumber,
-      emailAddress,
-      givenName,
-      familyName,
-      phoneticGivenName,
-      phoneticFamilyName,
-      addressLines,
-      subLocality,
-      city,
-      postalCode,
-      subAdministrativeArea,
-      administrativeArea,
-      country,
-      countryCode,
-    ]
-  }
+        return ApplePayContactDTO(
+            phoneNumber: phoneNumber,
+            emailAddress: emailAddress,
+            givenName: givenName,
+            familyName: familyName,
+            phoneticGivenName: phoneticGivenName,
+            phoneticFamilyName: phoneticFamilyName,
+            addressLines: addressLines,
+            subLocality: subLocality,
+            city: city,
+            postalCode: postalCode,
+            subAdministrativeArea: subAdministrativeArea,
+            administrativeArea: administrativeArea,
+            country: country,
+            countryCode: countryCode
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            phoneNumber,
+            emailAddress,
+            givenName,
+            familyName,
+            phoneticGivenName,
+            phoneticFamilyName,
+            addressLines,
+            subLocality,
+            city,
+            postalCode,
+            subAdministrativeArea,
+            administrativeArea,
+            country,
+            countryCode
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ApplePayShippingMethodDTO {
-  var label: String
-  var detail: String
-  var amount: AmountDTO
-  var identifier: String
-  var startDate: String? = nil
-  var endDate: String? = nil
+    var label: String
+    var detail: String
+    var amount: AmountDTO
+    var identifier: String
+    var startDate: String?
+    var endDate: String?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ApplePayShippingMethodDTO? {
-    let label = __pigeon_list[0] as! String
-    let detail = __pigeon_list[1] as! String
-    let amount = __pigeon_list[2] as! AmountDTO
-    let identifier = __pigeon_list[3] as! String
-    let startDate: String? = nilOrValue(__pigeon_list[4])
-    let endDate: String? = nilOrValue(__pigeon_list[5])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ApplePayShippingMethodDTO? {
+        let label = __pigeon_list[0] as! String
+        let detail = __pigeon_list[1] as! String
+        let amount = __pigeon_list[2] as! AmountDTO
+        let identifier = __pigeon_list[3] as! String
+        let startDate: String? = nilOrValue(__pigeon_list[4])
+        let endDate: String? = nilOrValue(__pigeon_list[5])
 
-    return ApplePayShippingMethodDTO(
-      label: label,
-      detail: detail,
-      amount: amount,
-      identifier: identifier,
-      startDate: startDate,
-      endDate: endDate
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      label,
-      detail,
-      amount,
-      identifier,
-      startDate,
-      endDate,
-    ]
-  }
+        return ApplePayShippingMethodDTO(
+            label: label,
+            detail: detail,
+            amount: amount,
+            identifier: identifier,
+            startDate: startDate,
+            endDate: endDate
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            label,
+            detail,
+            amount,
+            identifier,
+            startDate,
+            endDate
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ApplePaySummaryItemDTO {
-  var label: String
-  var amount: AmountDTO
-  var type: ApplePaySummaryItemType
+    var label: String
+    var amount: AmountDTO
+    var type: ApplePaySummaryItemType
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ApplePaySummaryItemDTO? {
-    let label = __pigeon_list[0] as! String
-    let amount = __pigeon_list[1] as! AmountDTO
-    let type = __pigeon_list[2] as! ApplePaySummaryItemType
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ApplePaySummaryItemDTO? {
+        let label = __pigeon_list[0] as! String
+        let amount = __pigeon_list[1] as! AmountDTO
+        let type = __pigeon_list[2] as! ApplePaySummaryItemType
 
-    return ApplePaySummaryItemDTO(
-      label: label,
-      amount: amount,
-      type: type
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      label,
-      amount,
-      type,
-    ]
-  }
+        return ApplePaySummaryItemDTO(
+            label: label,
+            amount: amount,
+            type: type
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            label,
+            amount,
+            type
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct GooglePayConfigurationDTO {
-  var googlePayEnvironment: GooglePayEnvironment
-  var merchantAccount: String? = nil
-  var merchantInfoDTO: MerchantInfoDTO? = nil
-  var totalPriceStatus: TotalPriceStatus? = nil
-  var allowedCardNetworks: [String?]? = nil
-  var allowedAuthMethods: [String?]? = nil
-  var allowPrepaidCards: Bool? = nil
-  var allowCreditCards: Bool? = nil
-  var assuranceDetailsRequired: Bool? = nil
-  var emailRequired: Bool? = nil
-  var existingPaymentMethodRequired: Bool? = nil
-  var shippingAddressRequired: Bool? = nil
-  var shippingAddressParametersDTO: ShippingAddressParametersDTO? = nil
-  var billingAddressRequired: Bool? = nil
-  var billingAddressParametersDTO: BillingAddressParametersDTO? = nil
+    var googlePayEnvironment: GooglePayEnvironment
+    var merchantAccount: String?
+    var merchantInfoDTO: MerchantInfoDTO?
+    var totalPriceStatus: TotalPriceStatus?
+    var allowedCardNetworks: [String?]?
+    var allowedAuthMethods: [String?]?
+    var allowPrepaidCards: Bool?
+    var allowCreditCards: Bool?
+    var assuranceDetailsRequired: Bool?
+    var emailRequired: Bool?
+    var existingPaymentMethodRequired: Bool?
+    var shippingAddressRequired: Bool?
+    var shippingAddressParametersDTO: ShippingAddressParametersDTO?
+    var billingAddressRequired: Bool?
+    var billingAddressParametersDTO: BillingAddressParametersDTO?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> GooglePayConfigurationDTO? {
-    let googlePayEnvironment = __pigeon_list[0] as! GooglePayEnvironment
-    let merchantAccount: String? = nilOrValue(__pigeon_list[1])
-    let merchantInfoDTO: MerchantInfoDTO? = nilOrValue(__pigeon_list[2])
-    let totalPriceStatus: TotalPriceStatus? = nilOrValue(__pigeon_list[3])
-    let allowedCardNetworks: [String?]? = nilOrValue(__pigeon_list[4])
-    let allowedAuthMethods: [String?]? = nilOrValue(__pigeon_list[5])
-    let allowPrepaidCards: Bool? = nilOrValue(__pigeon_list[6])
-    let allowCreditCards: Bool? = nilOrValue(__pigeon_list[7])
-    let assuranceDetailsRequired: Bool? = nilOrValue(__pigeon_list[8])
-    let emailRequired: Bool? = nilOrValue(__pigeon_list[9])
-    let existingPaymentMethodRequired: Bool? = nilOrValue(__pigeon_list[10])
-    let shippingAddressRequired: Bool? = nilOrValue(__pigeon_list[11])
-    let shippingAddressParametersDTO: ShippingAddressParametersDTO? = nilOrValue(__pigeon_list[12])
-    let billingAddressRequired: Bool? = nilOrValue(__pigeon_list[13])
-    let billingAddressParametersDTO: BillingAddressParametersDTO? = nilOrValue(__pigeon_list[14])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> GooglePayConfigurationDTO? {
+        let googlePayEnvironment = __pigeon_list[0] as! GooglePayEnvironment
+        let merchantAccount: String? = nilOrValue(__pigeon_list[1])
+        let merchantInfoDTO: MerchantInfoDTO? = nilOrValue(__pigeon_list[2])
+        let totalPriceStatus: TotalPriceStatus? = nilOrValue(__pigeon_list[3])
+        let allowedCardNetworks: [String?]? = nilOrValue(__pigeon_list[4])
+        let allowedAuthMethods: [String?]? = nilOrValue(__pigeon_list[5])
+        let allowPrepaidCards: Bool? = nilOrValue(__pigeon_list[6])
+        let allowCreditCards: Bool? = nilOrValue(__pigeon_list[7])
+        let assuranceDetailsRequired: Bool? = nilOrValue(__pigeon_list[8])
+        let emailRequired: Bool? = nilOrValue(__pigeon_list[9])
+        let existingPaymentMethodRequired: Bool? = nilOrValue(__pigeon_list[10])
+        let shippingAddressRequired: Bool? = nilOrValue(__pigeon_list[11])
+        let shippingAddressParametersDTO: ShippingAddressParametersDTO? = nilOrValue(__pigeon_list[12])
+        let billingAddressRequired: Bool? = nilOrValue(__pigeon_list[13])
+        let billingAddressParametersDTO: BillingAddressParametersDTO? = nilOrValue(__pigeon_list[14])
 
-    return GooglePayConfigurationDTO(
-      googlePayEnvironment: googlePayEnvironment,
-      merchantAccount: merchantAccount,
-      merchantInfoDTO: merchantInfoDTO,
-      totalPriceStatus: totalPriceStatus,
-      allowedCardNetworks: allowedCardNetworks,
-      allowedAuthMethods: allowedAuthMethods,
-      allowPrepaidCards: allowPrepaidCards,
-      allowCreditCards: allowCreditCards,
-      assuranceDetailsRequired: assuranceDetailsRequired,
-      emailRequired: emailRequired,
-      existingPaymentMethodRequired: existingPaymentMethodRequired,
-      shippingAddressRequired: shippingAddressRequired,
-      shippingAddressParametersDTO: shippingAddressParametersDTO,
-      billingAddressRequired: billingAddressRequired,
-      billingAddressParametersDTO: billingAddressParametersDTO
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      googlePayEnvironment,
-      merchantAccount,
-      merchantInfoDTO,
-      totalPriceStatus,
-      allowedCardNetworks,
-      allowedAuthMethods,
-      allowPrepaidCards,
-      allowCreditCards,
-      assuranceDetailsRequired,
-      emailRequired,
-      existingPaymentMethodRequired,
-      shippingAddressRequired,
-      shippingAddressParametersDTO,
-      billingAddressRequired,
-      billingAddressParametersDTO,
-    ]
-  }
+        return GooglePayConfigurationDTO(
+            googlePayEnvironment: googlePayEnvironment,
+            merchantAccount: merchantAccount,
+            merchantInfoDTO: merchantInfoDTO,
+            totalPriceStatus: totalPriceStatus,
+            allowedCardNetworks: allowedCardNetworks,
+            allowedAuthMethods: allowedAuthMethods,
+            allowPrepaidCards: allowPrepaidCards,
+            allowCreditCards: allowCreditCards,
+            assuranceDetailsRequired: assuranceDetailsRequired,
+            emailRequired: emailRequired,
+            existingPaymentMethodRequired: existingPaymentMethodRequired,
+            shippingAddressRequired: shippingAddressRequired,
+            shippingAddressParametersDTO: shippingAddressParametersDTO,
+            billingAddressRequired: billingAddressRequired,
+            billingAddressParametersDTO: billingAddressParametersDTO
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            googlePayEnvironment,
+            merchantAccount,
+            merchantInfoDTO,
+            totalPriceStatus,
+            allowedCardNetworks,
+            allowedAuthMethods,
+            allowPrepaidCards,
+            allowCreditCards,
+            assuranceDetailsRequired,
+            emailRequired,
+            existingPaymentMethodRequired,
+            shippingAddressRequired,
+            shippingAddressParametersDTO,
+            billingAddressRequired,
+            billingAddressParametersDTO
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct MerchantInfoDTO {
-  var merchantName: String? = nil
-  var merchantId: String? = nil
+    var merchantName: String?
+    var merchantId: String?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> MerchantInfoDTO? {
-    let merchantName: String? = nilOrValue(__pigeon_list[0])
-    let merchantId: String? = nilOrValue(__pigeon_list[1])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> MerchantInfoDTO? {
+        let merchantName: String? = nilOrValue(__pigeon_list[0])
+        let merchantId: String? = nilOrValue(__pigeon_list[1])
 
-    return MerchantInfoDTO(
-      merchantName: merchantName,
-      merchantId: merchantId
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      merchantName,
-      merchantId,
-    ]
-  }
+        return MerchantInfoDTO(
+            merchantName: merchantName,
+            merchantId: merchantId
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            merchantName,
+            merchantId
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ShippingAddressParametersDTO {
-  var allowedCountryCodes: [String?]? = nil
-  var isPhoneNumberRequired: Bool? = nil
+    var allowedCountryCodes: [String?]?
+    var isPhoneNumberRequired: Bool?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ShippingAddressParametersDTO? {
-    let allowedCountryCodes: [String?]? = nilOrValue(__pigeon_list[0])
-    let isPhoneNumberRequired: Bool? = nilOrValue(__pigeon_list[1])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ShippingAddressParametersDTO? {
+        let allowedCountryCodes: [String?]? = nilOrValue(__pigeon_list[0])
+        let isPhoneNumberRequired: Bool? = nilOrValue(__pigeon_list[1])
 
-    return ShippingAddressParametersDTO(
-      allowedCountryCodes: allowedCountryCodes,
-      isPhoneNumberRequired: isPhoneNumberRequired
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      allowedCountryCodes,
-      isPhoneNumberRequired,
-    ]
-  }
+        return ShippingAddressParametersDTO(
+            allowedCountryCodes: allowedCountryCodes,
+            isPhoneNumberRequired: isPhoneNumberRequired
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            allowedCountryCodes,
+            isPhoneNumberRequired
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct BillingAddressParametersDTO {
-  var format: String? = nil
-  var isPhoneNumberRequired: Bool? = nil
+    var format: String?
+    var isPhoneNumberRequired: Bool?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> BillingAddressParametersDTO? {
-    let format: String? = nilOrValue(__pigeon_list[0])
-    let isPhoneNumberRequired: Bool? = nilOrValue(__pigeon_list[1])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> BillingAddressParametersDTO? {
+        let format: String? = nilOrValue(__pigeon_list[0])
+        let isPhoneNumberRequired: Bool? = nilOrValue(__pigeon_list[1])
 
-    return BillingAddressParametersDTO(
-      format: format,
-      isPhoneNumberRequired: isPhoneNumberRequired
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      format,
-      isPhoneNumberRequired,
-    ]
-  }
+        return BillingAddressParametersDTO(
+            format: format,
+            isPhoneNumberRequired: isPhoneNumberRequired
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            format,
+            isPhoneNumberRequired
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct CashAppPayConfigurationDTO {
-  var cashAppPayEnvironment: CashAppPayEnvironment
-  var returnUrl: String
+    var cashAppPayEnvironment: CashAppPayEnvironment
+    var returnUrl: String
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> CashAppPayConfigurationDTO? {
-    let cashAppPayEnvironment = __pigeon_list[0] as! CashAppPayEnvironment
-    let returnUrl = __pigeon_list[1] as! String
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> CashAppPayConfigurationDTO? {
+        let cashAppPayEnvironment = __pigeon_list[0] as! CashAppPayEnvironment
+        let returnUrl = __pigeon_list[1] as! String
 
-    return CashAppPayConfigurationDTO(
-      cashAppPayEnvironment: cashAppPayEnvironment,
-      returnUrl: returnUrl
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      cashAppPayEnvironment,
-      returnUrl,
-    ]
-  }
+        return CashAppPayConfigurationDTO(
+            cashAppPayEnvironment: cashAppPayEnvironment,
+            returnUrl: returnUrl
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            cashAppPayEnvironment,
+            returnUrl
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct TwintConfigurationDTO {
-  var iosCallbackAppScheme: String
-  var showStorePaymentField: Bool
+    var iosCallbackAppScheme: String
+    var showStorePaymentField: Bool
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> TwintConfigurationDTO? {
-    let iosCallbackAppScheme = __pigeon_list[0] as! String
-    let showStorePaymentField = __pigeon_list[1] as! Bool
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> TwintConfigurationDTO? {
+        let iosCallbackAppScheme = __pigeon_list[0] as! String
+        let showStorePaymentField = __pigeon_list[1] as! Bool
 
-    return TwintConfigurationDTO(
-      iosCallbackAppScheme: iosCallbackAppScheme,
-      showStorePaymentField: showStorePaymentField
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      iosCallbackAppScheme,
-      showStorePaymentField,
-    ]
-  }
+        return TwintConfigurationDTO(
+            iosCallbackAppScheme: iosCallbackAppScheme,
+            showStorePaymentField: showStorePaymentField
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            iosCallbackAppScheme,
+            showStorePaymentField
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct PaymentResultDTO {
-  var type: PaymentResultEnum
-  var reason: String? = nil
-  var result: PaymentResultModelDTO? = nil
+    var type: PaymentResultEnum
+    var reason: String?
+    var result: PaymentResultModelDTO?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> PaymentResultDTO? {
-    let type = __pigeon_list[0] as! PaymentResultEnum
-    let reason: String? = nilOrValue(__pigeon_list[1])
-    let result: PaymentResultModelDTO? = nilOrValue(__pigeon_list[2])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> PaymentResultDTO? {
+        let type = __pigeon_list[0] as! PaymentResultEnum
+        let reason: String? = nilOrValue(__pigeon_list[1])
+        let result: PaymentResultModelDTO? = nilOrValue(__pigeon_list[2])
 
-    return PaymentResultDTO(
-      type: type,
-      reason: reason,
-      result: result
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      type,
-      reason,
-      result,
-    ]
-  }
+        return PaymentResultDTO(
+            type: type,
+            reason: reason,
+            result: result
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            type,
+            reason,
+            result
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct PaymentResultModelDTO {
-  var sessionId: String? = nil
-  var sessionData: String? = nil
-  var sessionResult: String? = nil
-  var resultCode: String? = nil
-  var order: OrderResponseDTO? = nil
+    var sessionId: String?
+    var sessionData: String?
+    var sessionResult: String?
+    var resultCode: String?
+    var order: OrderResponseDTO?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> PaymentResultModelDTO? {
-    let sessionId: String? = nilOrValue(__pigeon_list[0])
-    let sessionData: String? = nilOrValue(__pigeon_list[1])
-    let sessionResult: String? = nilOrValue(__pigeon_list[2])
-    let resultCode: String? = nilOrValue(__pigeon_list[3])
-    let order: OrderResponseDTO? = nilOrValue(__pigeon_list[4])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> PaymentResultModelDTO? {
+        let sessionId: String? = nilOrValue(__pigeon_list[0])
+        let sessionData: String? = nilOrValue(__pigeon_list[1])
+        let sessionResult: String? = nilOrValue(__pigeon_list[2])
+        let resultCode: String? = nilOrValue(__pigeon_list[3])
+        let order: OrderResponseDTO? = nilOrValue(__pigeon_list[4])
 
-    return PaymentResultModelDTO(
-      sessionId: sessionId,
-      sessionData: sessionData,
-      sessionResult: sessionResult,
-      resultCode: resultCode,
-      order: order
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      sessionId,
-      sessionData,
-      sessionResult,
-      resultCode,
-      order,
-    ]
-  }
+        return PaymentResultModelDTO(
+            sessionId: sessionId,
+            sessionData: sessionData,
+            sessionResult: sessionResult,
+            resultCode: resultCode,
+            order: order
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            sessionId,
+            sessionData,
+            sessionResult,
+            resultCode,
+            order
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct OrderResponseDTO {
-  var pspReference: String
-  var orderData: String
-  var amount: AmountDTO? = nil
-  var remainingAmount: AmountDTO? = nil
+    var pspReference: String
+    var orderData: String
+    var amount: AmountDTO?
+    var remainingAmount: AmountDTO?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> OrderResponseDTO? {
-    let pspReference = __pigeon_list[0] as! String
-    let orderData = __pigeon_list[1] as! String
-    let amount: AmountDTO? = nilOrValue(__pigeon_list[2])
-    let remainingAmount: AmountDTO? = nilOrValue(__pigeon_list[3])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> OrderResponseDTO? {
+        let pspReference = __pigeon_list[0] as! String
+        let orderData = __pigeon_list[1] as! String
+        let amount: AmountDTO? = nilOrValue(__pigeon_list[2])
+        let remainingAmount: AmountDTO? = nilOrValue(__pigeon_list[3])
 
-    return OrderResponseDTO(
-      pspReference: pspReference,
-      orderData: orderData,
-      amount: amount,
-      remainingAmount: remainingAmount
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      pspReference,
-      orderData,
-      amount,
-      remainingAmount,
-    ]
-  }
+        return OrderResponseDTO(
+            pspReference: pspReference,
+            orderData: orderData,
+            amount: amount,
+            remainingAmount: remainingAmount
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            pspReference,
+            orderData,
+            amount,
+            remainingAmount
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct CheckoutEvent {
-  var type: CheckoutEventType
-  var data: Any? = nil
+    var type: CheckoutEventType
+    var data: Any?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> CheckoutEvent? {
-    let type = __pigeon_list[0] as! CheckoutEventType
-    let data: Any? = __pigeon_list[1]
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> CheckoutEvent? {
+        let type = __pigeon_list[0] as! CheckoutEventType
+        let data: Any? = __pigeon_list[1]
 
-    return CheckoutEvent(
-      type: type,
-      data: data
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      type,
-      data,
-    ]
-  }
+        return CheckoutEvent(
+            type: type,
+            data: data
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            type,
+            data
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ComponentCommunicationModel {
-  var type: ComponentCommunicationType
-  var componentId: String
-  var data: Any? = nil
-  var paymentResult: PaymentResultDTO? = nil
+    var type: ComponentCommunicationType
+    var componentId: String
+    var data: Any?
+    var paymentResult: PaymentResultDTO?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ComponentCommunicationModel? {
-    let type = __pigeon_list[0] as! ComponentCommunicationType
-    let componentId = __pigeon_list[1] as! String
-    let data: Any? = __pigeon_list[2]
-    let paymentResult: PaymentResultDTO? = nilOrValue(__pigeon_list[3])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ComponentCommunicationModel? {
+        let type = __pigeon_list[0] as! ComponentCommunicationType
+        let componentId = __pigeon_list[1] as! String
+        let data: Any? = __pigeon_list[2]
+        let paymentResult: PaymentResultDTO? = nilOrValue(__pigeon_list[3])
 
-    return ComponentCommunicationModel(
-      type: type,
-      componentId: componentId,
-      data: data,
-      paymentResult: paymentResult
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      type,
-      componentId,
-      data,
-      paymentResult,
-    ]
-  }
+        return ComponentCommunicationModel(
+            type: type,
+            componentId: componentId,
+            data: data,
+            paymentResult: paymentResult
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            type,
+            componentId,
+            data,
+            paymentResult
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct PaymentEventDTO {
-  var paymentEventType: PaymentEventType
-  var result: String? = nil
-  var data: [String?: Any?]? = nil
-  var error: ErrorDTO? = nil
+    var paymentEventType: PaymentEventType
+    var result: String?
+    var data: [String?: Any?]?
+    var error: ErrorDTO?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> PaymentEventDTO? {
-    let paymentEventType = __pigeon_list[0] as! PaymentEventType
-    let result: String? = nilOrValue(__pigeon_list[1])
-    let data: [String?: Any?]? = nilOrValue(__pigeon_list[2])
-    let error: ErrorDTO? = nilOrValue(__pigeon_list[3])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> PaymentEventDTO? {
+        let paymentEventType = __pigeon_list[0] as! PaymentEventType
+        let result: String? = nilOrValue(__pigeon_list[1])
+        let data: [String?: Any?]? = nilOrValue(__pigeon_list[2])
+        let error: ErrorDTO? = nilOrValue(__pigeon_list[3])
 
-    return PaymentEventDTO(
-      paymentEventType: paymentEventType,
-      result: result,
-      data: data,
-      error: error
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      paymentEventType,
-      result,
-      data,
-      error,
-    ]
-  }
+        return PaymentEventDTO(
+            paymentEventType: paymentEventType,
+            result: result,
+            data: data,
+            error: error
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            paymentEventType,
+            result,
+            data,
+            error
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ErrorDTO {
-  var errorMessage: String? = nil
-  var reason: String? = nil
-  var dismissDropIn: Bool? = nil
+    var errorMessage: String?
+    var reason: String?
+    var dismissDropIn: Bool?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ErrorDTO? {
-    let errorMessage: String? = nilOrValue(__pigeon_list[0])
-    let reason: String? = nilOrValue(__pigeon_list[1])
-    let dismissDropIn: Bool? = nilOrValue(__pigeon_list[2])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ErrorDTO? {
+        let errorMessage: String? = nilOrValue(__pigeon_list[0])
+        let reason: String? = nilOrValue(__pigeon_list[1])
+        let dismissDropIn: Bool? = nilOrValue(__pigeon_list[2])
 
-    return ErrorDTO(
-      errorMessage: errorMessage,
-      reason: reason,
-      dismissDropIn: dismissDropIn
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      errorMessage,
-      reason,
-      dismissDropIn,
-    ]
-  }
+        return ErrorDTO(
+            errorMessage: errorMessage,
+            reason: reason,
+            dismissDropIn: dismissDropIn
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            errorMessage,
+            reason,
+            dismissDropIn
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct DeletedStoredPaymentMethodResultDTO {
-  var storedPaymentMethodId: String
-  var isSuccessfullyRemoved: Bool
+    var storedPaymentMethodId: String
+    var isSuccessfullyRemoved: Bool
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> DeletedStoredPaymentMethodResultDTO? {
-    let storedPaymentMethodId = __pigeon_list[0] as! String
-    let isSuccessfullyRemoved = __pigeon_list[1] as! Bool
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> DeletedStoredPaymentMethodResultDTO? {
+        let storedPaymentMethodId = __pigeon_list[0] as! String
+        let isSuccessfullyRemoved = __pigeon_list[1] as! Bool
 
-    return DeletedStoredPaymentMethodResultDTO(
-      storedPaymentMethodId: storedPaymentMethodId,
-      isSuccessfullyRemoved: isSuccessfullyRemoved
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      storedPaymentMethodId,
-      isSuccessfullyRemoved,
-    ]
-  }
+        return DeletedStoredPaymentMethodResultDTO(
+            storedPaymentMethodId: storedPaymentMethodId,
+            isSuccessfullyRemoved: isSuccessfullyRemoved
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            storedPaymentMethodId,
+            isSuccessfullyRemoved
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct CardComponentConfigurationDTO {
-  var environment: Environment
-  var clientKey: String
-  var countryCode: String
-  var amount: AmountDTO? = nil
-  var shopperLocale: String? = nil
-  var cardConfiguration: CardConfigurationDTO
-  var threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil
-  var analyticsOptionsDTO: AnalyticsOptionsDTO
+    var environment: Environment
+    var clientKey: String
+    var countryCode: String
+    var amount: AmountDTO?
+    var shopperLocale: String?
+    var cardConfiguration: CardConfigurationDTO
+    var threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO?
+    var analyticsOptionsDTO: AnalyticsOptionsDTO
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> CardComponentConfigurationDTO? {
-    let environment = __pigeon_list[0] as! Environment
-    let clientKey = __pigeon_list[1] as! String
-    let countryCode = __pigeon_list[2] as! String
-    let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
-    let shopperLocale: String? = nilOrValue(__pigeon_list[4])
-    let cardConfiguration = __pigeon_list[5] as! CardConfigurationDTO
-    let threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nilOrValue(__pigeon_list[6])
-    let analyticsOptionsDTO = __pigeon_list[7] as! AnalyticsOptionsDTO
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> CardComponentConfigurationDTO? {
+        let environment = __pigeon_list[0] as! Environment
+        let clientKey = __pigeon_list[1] as! String
+        let countryCode = __pigeon_list[2] as! String
+        let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
+        let shopperLocale: String? = nilOrValue(__pigeon_list[4])
+        let cardConfiguration = __pigeon_list[5] as! CardConfigurationDTO
+        let threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nilOrValue(__pigeon_list[6])
+        let analyticsOptionsDTO = __pigeon_list[7] as! AnalyticsOptionsDTO
 
-    return CardComponentConfigurationDTO(
-      environment: environment,
-      clientKey: clientKey,
-      countryCode: countryCode,
-      amount: amount,
-      shopperLocale: shopperLocale,
-      cardConfiguration: cardConfiguration,
-      threeDS2ConfigurationDTO: threeDS2ConfigurationDTO,
-      analyticsOptionsDTO: analyticsOptionsDTO
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      environment,
-      clientKey,
-      countryCode,
-      amount,
-      shopperLocale,
-      cardConfiguration,
-      threeDS2ConfigurationDTO,
-      analyticsOptionsDTO,
-    ]
-  }
+        return CardComponentConfigurationDTO(
+            environment: environment,
+            clientKey: clientKey,
+            countryCode: countryCode,
+            amount: amount,
+            shopperLocale: shopperLocale,
+            cardConfiguration: cardConfiguration,
+            threeDS2ConfigurationDTO: threeDS2ConfigurationDTO,
+            analyticsOptionsDTO: analyticsOptionsDTO
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            environment,
+            clientKey,
+            countryCode,
+            amount,
+            shopperLocale,
+            cardConfiguration,
+            threeDS2ConfigurationDTO,
+            analyticsOptionsDTO
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct BlikComponentConfigurationDTO {
-  var environment: Environment
-  var clientKey: String
-  var countryCode: String
-  var amount: AmountDTO? = nil
-  var shopperLocale: String? = nil
-  var analyticsOptionsDTO: AnalyticsOptionsDTO
+    var environment: Environment
+    var clientKey: String
+    var countryCode: String
+    var amount: AmountDTO?
+    var shopperLocale: String?
+    var analyticsOptionsDTO: AnalyticsOptionsDTO
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> BlikComponentConfigurationDTO? {
-    let environment = __pigeon_list[0] as! Environment
-    let clientKey = __pigeon_list[1] as! String
-    let countryCode = __pigeon_list[2] as! String
-    let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
-    let shopperLocale: String? = nilOrValue(__pigeon_list[4])
-    let analyticsOptionsDTO = __pigeon_list[5] as! AnalyticsOptionsDTO
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> BlikComponentConfigurationDTO? {
+        let environment = __pigeon_list[0] as! Environment
+        let clientKey = __pigeon_list[1] as! String
+        let countryCode = __pigeon_list[2] as! String
+        let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
+        let shopperLocale: String? = nilOrValue(__pigeon_list[4])
+        let analyticsOptionsDTO = __pigeon_list[5] as! AnalyticsOptionsDTO
 
-    return BlikComponentConfigurationDTO(
-      environment: environment,
-      clientKey: clientKey,
-      countryCode: countryCode,
-      amount: amount,
-      shopperLocale: shopperLocale,
-      analyticsOptionsDTO: analyticsOptionsDTO
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      environment,
-      clientKey,
-      countryCode,
-      amount,
-      shopperLocale,
-      analyticsOptionsDTO,
-    ]
-  }
+        return BlikComponentConfigurationDTO(
+            environment: environment,
+            clientKey: clientKey,
+            countryCode: countryCode,
+            amount: amount,
+            shopperLocale: shopperLocale,
+            analyticsOptionsDTO: analyticsOptionsDTO
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            environment,
+            clientKey,
+            countryCode,
+            amount,
+            shopperLocale,
+            analyticsOptionsDTO
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct InstantPaymentConfigurationDTO {
-  var instantPaymentType: InstantPaymentType
-  var environment: Environment
-  var clientKey: String
-  var countryCode: String
-  var amount: AmountDTO? = nil
-  var shopperLocale: String? = nil
-  var analyticsOptionsDTO: AnalyticsOptionsDTO
-  var googlePayConfigurationDTO: GooglePayConfigurationDTO? = nil
-  var applePayConfigurationDTO: ApplePayConfigurationDTO? = nil
+    var instantPaymentType: InstantPaymentType
+    var environment: Environment
+    var clientKey: String
+    var countryCode: String
+    var amount: AmountDTO?
+    var shopperLocale: String?
+    var analyticsOptionsDTO: AnalyticsOptionsDTO
+    var googlePayConfigurationDTO: GooglePayConfigurationDTO?
+    var applePayConfigurationDTO: ApplePayConfigurationDTO?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> InstantPaymentConfigurationDTO? {
-    let instantPaymentType = __pigeon_list[0] as! InstantPaymentType
-    let environment = __pigeon_list[1] as! Environment
-    let clientKey = __pigeon_list[2] as! String
-    let countryCode = __pigeon_list[3] as! String
-    let amount: AmountDTO? = nilOrValue(__pigeon_list[4])
-    let shopperLocale: String? = nilOrValue(__pigeon_list[5])
-    let analyticsOptionsDTO = __pigeon_list[6] as! AnalyticsOptionsDTO
-    let googlePayConfigurationDTO: GooglePayConfigurationDTO? = nilOrValue(__pigeon_list[7])
-    let applePayConfigurationDTO: ApplePayConfigurationDTO? = nilOrValue(__pigeon_list[8])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> InstantPaymentConfigurationDTO? {
+        let instantPaymentType = __pigeon_list[0] as! InstantPaymentType
+        let environment = __pigeon_list[1] as! Environment
+        let clientKey = __pigeon_list[2] as! String
+        let countryCode = __pigeon_list[3] as! String
+        let amount: AmountDTO? = nilOrValue(__pigeon_list[4])
+        let shopperLocale: String? = nilOrValue(__pigeon_list[5])
+        let analyticsOptionsDTO = __pigeon_list[6] as! AnalyticsOptionsDTO
+        let googlePayConfigurationDTO: GooglePayConfigurationDTO? = nilOrValue(__pigeon_list[7])
+        let applePayConfigurationDTO: ApplePayConfigurationDTO? = nilOrValue(__pigeon_list[8])
 
-    return InstantPaymentConfigurationDTO(
-      instantPaymentType: instantPaymentType,
-      environment: environment,
-      clientKey: clientKey,
-      countryCode: countryCode,
-      amount: amount,
-      shopperLocale: shopperLocale,
-      analyticsOptionsDTO: analyticsOptionsDTO,
-      googlePayConfigurationDTO: googlePayConfigurationDTO,
-      applePayConfigurationDTO: applePayConfigurationDTO
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      instantPaymentType,
-      environment,
-      clientKey,
-      countryCode,
-      amount,
-      shopperLocale,
-      analyticsOptionsDTO,
-      googlePayConfigurationDTO,
-      applePayConfigurationDTO,
-    ]
-  }
+        return InstantPaymentConfigurationDTO(
+            instantPaymentType: instantPaymentType,
+            environment: environment,
+            clientKey: clientKey,
+            countryCode: countryCode,
+            amount: amount,
+            shopperLocale: shopperLocale,
+            analyticsOptionsDTO: analyticsOptionsDTO,
+            googlePayConfigurationDTO: googlePayConfigurationDTO,
+            applePayConfigurationDTO: applePayConfigurationDTO
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            instantPaymentType,
+            environment,
+            clientKey,
+            countryCode,
+            amount,
+            shopperLocale,
+            analyticsOptionsDTO,
+            googlePayConfigurationDTO,
+            applePayConfigurationDTO
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct InstantPaymentSetupResultDTO {
-  var instantPaymentType: InstantPaymentType
-  var isSupported: Bool
-  var resultData: Any? = nil
+    var instantPaymentType: InstantPaymentType
+    var isSupported: Bool
+    var resultData: Any?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> InstantPaymentSetupResultDTO? {
-    let instantPaymentType = __pigeon_list[0] as! InstantPaymentType
-    let isSupported = __pigeon_list[1] as! Bool
-    let resultData: Any? = __pigeon_list[2]
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> InstantPaymentSetupResultDTO? {
+        let instantPaymentType = __pigeon_list[0] as! InstantPaymentType
+        let isSupported = __pigeon_list[1] as! Bool
+        let resultData: Any? = __pigeon_list[2]
 
-    return InstantPaymentSetupResultDTO(
-      instantPaymentType: instantPaymentType,
-      isSupported: isSupported,
-      resultData: resultData
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      instantPaymentType,
-      isSupported,
-      resultData,
-    ]
-  }
+        return InstantPaymentSetupResultDTO(
+            instantPaymentType: instantPaymentType,
+            isSupported: isSupported,
+            resultData: resultData
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            instantPaymentType,
+            isSupported,
+            resultData
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct UnencryptedCardDTO {
-  var cardNumber: String? = nil
-  var expiryMonth: String? = nil
-  var expiryYear: String? = nil
-  var cvc: String? = nil
+    var cardNumber: String?
+    var expiryMonth: String?
+    var expiryYear: String?
+    var cvc: String?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> UnencryptedCardDTO? {
-    let cardNumber: String? = nilOrValue(__pigeon_list[0])
-    let expiryMonth: String? = nilOrValue(__pigeon_list[1])
-    let expiryYear: String? = nilOrValue(__pigeon_list[2])
-    let cvc: String? = nilOrValue(__pigeon_list[3])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> UnencryptedCardDTO? {
+        let cardNumber: String? = nilOrValue(__pigeon_list[0])
+        let expiryMonth: String? = nilOrValue(__pigeon_list[1])
+        let expiryYear: String? = nilOrValue(__pigeon_list[2])
+        let cvc: String? = nilOrValue(__pigeon_list[3])
 
-    return UnencryptedCardDTO(
-      cardNumber: cardNumber,
-      expiryMonth: expiryMonth,
-      expiryYear: expiryYear,
-      cvc: cvc
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      cardNumber,
-      expiryMonth,
-      expiryYear,
-      cvc,
-    ]
-  }
+        return UnencryptedCardDTO(
+            cardNumber: cardNumber,
+            expiryMonth: expiryMonth,
+            expiryYear: expiryYear,
+            cvc: cvc
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            cardNumber,
+            expiryMonth,
+            expiryYear,
+            cvc
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct EncryptedCardDTO {
-  var encryptedCardNumber: String? = nil
-  var encryptedExpiryMonth: String? = nil
-  var encryptedExpiryYear: String? = nil
-  var encryptedSecurityCode: String? = nil
+    var encryptedCardNumber: String?
+    var encryptedExpiryMonth: String?
+    var encryptedExpiryYear: String?
+    var encryptedSecurityCode: String?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> EncryptedCardDTO? {
-    let encryptedCardNumber: String? = nilOrValue(__pigeon_list[0])
-    let encryptedExpiryMonth: String? = nilOrValue(__pigeon_list[1])
-    let encryptedExpiryYear: String? = nilOrValue(__pigeon_list[2])
-    let encryptedSecurityCode: String? = nilOrValue(__pigeon_list[3])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> EncryptedCardDTO? {
+        let encryptedCardNumber: String? = nilOrValue(__pigeon_list[0])
+        let encryptedExpiryMonth: String? = nilOrValue(__pigeon_list[1])
+        let encryptedExpiryYear: String? = nilOrValue(__pigeon_list[2])
+        let encryptedSecurityCode: String? = nilOrValue(__pigeon_list[3])
 
-    return EncryptedCardDTO(
-      encryptedCardNumber: encryptedCardNumber,
-      encryptedExpiryMonth: encryptedExpiryMonth,
-      encryptedExpiryYear: encryptedExpiryYear,
-      encryptedSecurityCode: encryptedSecurityCode
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      encryptedCardNumber,
-      encryptedExpiryMonth,
-      encryptedExpiryYear,
-      encryptedSecurityCode,
-    ]
-  }
+        return EncryptedCardDTO(
+            encryptedCardNumber: encryptedCardNumber,
+            encryptedExpiryMonth: encryptedExpiryMonth,
+            encryptedExpiryYear: encryptedExpiryYear,
+            encryptedSecurityCode: encryptedSecurityCode
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            encryptedCardNumber,
+            encryptedExpiryMonth,
+            encryptedExpiryYear,
+            encryptedSecurityCode
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct ActionComponentConfigurationDTO {
-  var environment: Environment
-  var clientKey: String
-  var shopperLocale: String? = nil
-  var amount: AmountDTO? = nil
-  var analyticsOptionsDTO: AnalyticsOptionsDTO
-  var threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nil
+    var environment: Environment
+    var clientKey: String
+    var shopperLocale: String?
+    var amount: AmountDTO?
+    var analyticsOptionsDTO: AnalyticsOptionsDTO
+    var threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> ActionComponentConfigurationDTO? {
-    let environment = __pigeon_list[0] as! Environment
-    let clientKey = __pigeon_list[1] as! String
-    let shopperLocale: String? = nilOrValue(__pigeon_list[2])
-    let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
-    let analyticsOptionsDTO = __pigeon_list[4] as! AnalyticsOptionsDTO
-    let threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nilOrValue(__pigeon_list[5])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> ActionComponentConfigurationDTO? {
+        let environment = __pigeon_list[0] as! Environment
+        let clientKey = __pigeon_list[1] as! String
+        let shopperLocale: String? = nilOrValue(__pigeon_list[2])
+        let amount: AmountDTO? = nilOrValue(__pigeon_list[3])
+        let analyticsOptionsDTO = __pigeon_list[4] as! AnalyticsOptionsDTO
+        let threeDS2ConfigurationDTO: ThreeDS2ConfigurationDTO? = nilOrValue(__pigeon_list[5])
 
-    return ActionComponentConfigurationDTO(
-      environment: environment,
-      clientKey: clientKey,
-      shopperLocale: shopperLocale,
-      amount: amount,
-      analyticsOptionsDTO: analyticsOptionsDTO,
-      threeDS2ConfigurationDTO: threeDS2ConfigurationDTO
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      environment,
-      clientKey,
-      shopperLocale,
-      amount,
-      analyticsOptionsDTO,
-      threeDS2ConfigurationDTO,
-    ]
-  }
+        return ActionComponentConfigurationDTO(
+            environment: environment,
+            clientKey: clientKey,
+            shopperLocale: shopperLocale,
+            amount: amount,
+            analyticsOptionsDTO: analyticsOptionsDTO,
+            threeDS2ConfigurationDTO: threeDS2ConfigurationDTO
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            environment,
+            clientKey,
+            shopperLocale,
+            amount,
+            analyticsOptionsDTO,
+            threeDS2ConfigurationDTO
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct OrderCancelResultDTO {
-  var orderCancelResponseBody: [String?: Any?]
-  var updatedPaymentMethodsResponseBody: [String?: Any?]? = nil
+    var orderCancelResponseBody: [String?: Any?]
+    var updatedPaymentMethodsResponseBody: [String?: Any?]?
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> OrderCancelResultDTO? {
-    let orderCancelResponseBody = __pigeon_list[0] as! [String?: Any?]
-    let updatedPaymentMethodsResponseBody: [String?: Any?]? = nilOrValue(__pigeon_list[1])
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> OrderCancelResultDTO? {
+        let orderCancelResponseBody = __pigeon_list[0] as! [String?: Any?]
+        let updatedPaymentMethodsResponseBody: [String?: Any?]? = nilOrValue(__pigeon_list[1])
 
-    return OrderCancelResultDTO(
-      orderCancelResponseBody: orderCancelResponseBody,
-      updatedPaymentMethodsResponseBody: updatedPaymentMethodsResponseBody
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      orderCancelResponseBody,
-      updatedPaymentMethodsResponseBody,
-    ]
-  }
+        return OrderCancelResultDTO(
+            orderCancelResponseBody: orderCancelResponseBody,
+            updatedPaymentMethodsResponseBody: updatedPaymentMethodsResponseBody
+        )
+    }
+
+    func toList() -> [Any?] {
+        [
+            orderCancelResponseBody,
+            updatedPaymentMethodsResponseBody
+        ]
+    }
 }
 
 /// Generated class from Pigeon that represents data sent in messages.
 struct BinLookupDataDTO {
-  var brand: String
+    var brand: String
 
-  // swift-format-ignore: AlwaysUseLowerCamelCase
-  static func fromList(_ __pigeon_list: [Any?]) -> BinLookupDataDTO? {
-    let brand = __pigeon_list[0] as! String
+    // swift-format-ignore: AlwaysUseLowerCamelCase
+    static func fromList(_ __pigeon_list: [Any?]) -> BinLookupDataDTO? {
+        let brand = __pigeon_list[0] as! String
 
-    return BinLookupDataDTO(
-      brand: brand
-    )
-  }
-  func toList() -> [Any?] {
-    return [
-      brand
-    ]
-  }
-}
-private class PlatformApiPigeonCodecReader: FlutterStandardReader {
-  override func readValue(ofType type: UInt8) -> Any? {
-    switch type {
-    case 129:
-      return SessionDTO.fromList(self.readValue() as! [Any?])
-    case 130:
-      return AmountDTO.fromList(self.readValue() as! [Any?])
-    case 131:
-      return AnalyticsOptionsDTO.fromList(self.readValue() as! [Any?])
-    case 132:
-      return ThreeDS2UICustomizationDTO.fromList(self.readValue() as! [Any?])
-    case 133:
-      return ThreeDS2ScreenCustomizationDTO.fromList(self.readValue() as! [Any?])
-    case 134:
-      return ThreeDS2ButtonCustomizationDTO.fromList(self.readValue() as! [Any?])
-    case 135:
-      return ThreeDS2SelectionItemCustomizationDTO.fromList(self.readValue() as! [Any?])
-    case 136:
-      return ThreeDS2LabelCustomizationDTO.fromList(self.readValue() as! [Any?])
-    case 137:
-      return ThreeDS2InputCustomizationDTO.fromList(self.readValue() as! [Any?])
-    case 138:
-      return ThreeDS2ToolbarCustomizationDTO.fromList(self.readValue() as! [Any?])
-    case 139:
-      return ThreeDS2ConfigurationDTO.fromList(self.readValue() as! [Any?])
-    case 140:
-      return DefaultInstallmentOptionsDTO.fromList(self.readValue() as! [Any?])
-    case 141:
-      return CardBasedInstallmentOptionsDTO.fromList(self.readValue() as! [Any?])
-    case 142:
-      return InstallmentConfigurationDTO.fromList(self.readValue() as! [Any?])
-    case 143:
-      return DropInConfigurationDTO.fromList(self.readValue() as! [Any?])
-    case 144:
-      return CardConfigurationDTO.fromList(self.readValue() as! [Any?])
-    case 145:
-      return ApplePayConfigurationDTO.fromList(self.readValue() as! [Any?])
-    case 146:
-      return ApplePayContactDTO.fromList(self.readValue() as! [Any?])
-    case 147:
-      return ApplePayShippingMethodDTO.fromList(self.readValue() as! [Any?])
-    case 148:
-      return ApplePaySummaryItemDTO.fromList(self.readValue() as! [Any?])
-    case 149:
-      return GooglePayConfigurationDTO.fromList(self.readValue() as! [Any?])
-    case 150:
-      return MerchantInfoDTO.fromList(self.readValue() as! [Any?])
-    case 151:
-      return ShippingAddressParametersDTO.fromList(self.readValue() as! [Any?])
-    case 152:
-      return BillingAddressParametersDTO.fromList(self.readValue() as! [Any?])
-    case 153:
-      return CashAppPayConfigurationDTO.fromList(self.readValue() as! [Any?])
-    case 154:
-      return TwintConfigurationDTO.fromList(self.readValue() as! [Any?])
-    case 155:
-      return PaymentResultDTO.fromList(self.readValue() as! [Any?])
-    case 156:
-      return PaymentResultModelDTO.fromList(self.readValue() as! [Any?])
-    case 157:
-      return OrderResponseDTO.fromList(self.readValue() as! [Any?])
-    case 158:
-      return CheckoutEvent.fromList(self.readValue() as! [Any?])
-    case 159:
-      return ComponentCommunicationModel.fromList(self.readValue() as! [Any?])
-    case 160:
-      return PaymentEventDTO.fromList(self.readValue() as! [Any?])
-    case 161:
-      return ErrorDTO.fromList(self.readValue() as! [Any?])
-    case 162:
-      return DeletedStoredPaymentMethodResultDTO.fromList(self.readValue() as! [Any?])
-    case 163:
-      return CardComponentConfigurationDTO.fromList(self.readValue() as! [Any?])
-    case 164:
-      return BlikComponentConfigurationDTO.fromList(self.readValue() as! [Any?])
-    case 165:
-      return InstantPaymentConfigurationDTO.fromList(self.readValue() as! [Any?])
-    case 166:
-      return InstantPaymentSetupResultDTO.fromList(self.readValue() as! [Any?])
-    case 167:
-      return UnencryptedCardDTO.fromList(self.readValue() as! [Any?])
-    case 168:
-      return EncryptedCardDTO.fromList(self.readValue() as! [Any?])
-    case 169:
-      return ActionComponentConfigurationDTO.fromList(self.readValue() as! [Any?])
-    case 170:
-      return OrderCancelResultDTO.fromList(self.readValue() as! [Any?])
-    case 171:
-      return BinLookupDataDTO.fromList(self.readValue() as! [Any?])
-    case 172:
-      var enumResult: Environment? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = Environment(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 173:
-      var enumResult: AddressMode? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = AddressMode(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 174:
-      var enumResult: CardAuthMethod? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = CardAuthMethod(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 175:
-      var enumResult: TotalPriceStatus? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = TotalPriceStatus(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 176:
-      var enumResult: GooglePayEnvironment? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = GooglePayEnvironment(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 177:
-      var enumResult: CashAppPayEnvironment? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = CashAppPayEnvironment(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 178:
-      var enumResult: PaymentResultEnum? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = PaymentResultEnum(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 179:
-      var enumResult: CheckoutEventType? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = CheckoutEventType(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 180:
-      var enumResult: ComponentCommunicationType? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = ComponentCommunicationType(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 181:
-      var enumResult: PaymentEventType? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = PaymentEventType(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 182:
-      var enumResult: FieldVisibility? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = FieldVisibility(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 183:
-      var enumResult: InstantPaymentType? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = InstantPaymentType(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 184:
-      var enumResult: ApplePayShippingType? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = ApplePayShippingType(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 185:
-      var enumResult: ApplePayMerchantCapability? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = ApplePayMerchantCapability(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 186:
-      var enumResult: ApplePaySummaryItemType? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = ApplePaySummaryItemType(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 187:
-      var enumResult: CardNumberValidationResultDTO? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = CardNumberValidationResultDTO(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 188:
-      var enumResult: CardExpiryDateValidationResultDTO? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = CardExpiryDateValidationResultDTO(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    case 189:
-      var enumResult: CardSecurityCodeValidationResultDTO? = nil
-      let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
-      if let enumResultAsInt = enumResultAsInt {
-        enumResult = CardSecurityCodeValidationResultDTO(rawValue: enumResultAsInt)
-      }
-      return enumResult
-    default:
-      return super.readValue(ofType: type)
+        return BinLookupDataDTO(
+            brand: brand
+        )
     }
-  }
+
+    func toList() -> [Any?] {
+        [
+            brand
+        ]
+    }
+}
+
+private class PlatformApiPigeonCodecReader: FlutterStandardReader {
+    override func readValue(ofType type: UInt8) -> Any? {
+        switch type {
+        case 129:
+            return SessionDTO.fromList(self.readValue() as! [Any?])
+        case 130:
+            return AmountDTO.fromList(self.readValue() as! [Any?])
+        case 131:
+            return AnalyticsOptionsDTO.fromList(self.readValue() as! [Any?])
+        case 132:
+            return ThreeDS2UICustomizationDTO.fromList(self.readValue() as! [Any?])
+        case 133:
+            return ThreeDS2ScreenCustomizationDTO.fromList(self.readValue() as! [Any?])
+        case 134:
+            return ThreeDS2ButtonCustomizationDTO.fromList(self.readValue() as! [Any?])
+        case 135:
+            return ThreeDS2SelectionItemCustomizationDTO.fromList(self.readValue() as! [Any?])
+        case 136:
+            return ThreeDS2LabelCustomizationDTO.fromList(self.readValue() as! [Any?])
+        case 137:
+            return ThreeDS2InputCustomizationDTO.fromList(self.readValue() as! [Any?])
+        case 138:
+            return ThreeDS2ToolbarCustomizationDTO.fromList(self.readValue() as! [Any?])
+        case 139:
+            return ThreeDS2ConfigurationDTO.fromList(self.readValue() as! [Any?])
+        case 140:
+            return DefaultInstallmentOptionsDTO.fromList(self.readValue() as! [Any?])
+        case 141:
+            return CardBasedInstallmentOptionsDTO.fromList(self.readValue() as! [Any?])
+        case 142:
+            return InstallmentConfigurationDTO.fromList(self.readValue() as! [Any?])
+        case 143:
+            return DropInConfigurationDTO.fromList(self.readValue() as! [Any?])
+        case 144:
+            return CardConfigurationDTO.fromList(self.readValue() as! [Any?])
+        case 145:
+            return ApplePayConfigurationDTO.fromList(self.readValue() as! [Any?])
+        case 146:
+            return ApplePayContactDTO.fromList(self.readValue() as! [Any?])
+        case 147:
+            return ApplePayShippingMethodDTO.fromList(self.readValue() as! [Any?])
+        case 148:
+            return ApplePaySummaryItemDTO.fromList(self.readValue() as! [Any?])
+        case 149:
+            return GooglePayConfigurationDTO.fromList(self.readValue() as! [Any?])
+        case 150:
+            return MerchantInfoDTO.fromList(self.readValue() as! [Any?])
+        case 151:
+            return ShippingAddressParametersDTO.fromList(self.readValue() as! [Any?])
+        case 152:
+            return BillingAddressParametersDTO.fromList(self.readValue() as! [Any?])
+        case 153:
+            return CashAppPayConfigurationDTO.fromList(self.readValue() as! [Any?])
+        case 154:
+            return TwintConfigurationDTO.fromList(self.readValue() as! [Any?])
+        case 155:
+            return PaymentResultDTO.fromList(self.readValue() as! [Any?])
+        case 156:
+            return PaymentResultModelDTO.fromList(self.readValue() as! [Any?])
+        case 157:
+            return OrderResponseDTO.fromList(self.readValue() as! [Any?])
+        case 158:
+            return CheckoutEvent.fromList(self.readValue() as! [Any?])
+        case 159:
+            return ComponentCommunicationModel.fromList(self.readValue() as! [Any?])
+        case 160:
+            return PaymentEventDTO.fromList(self.readValue() as! [Any?])
+        case 161:
+            return ErrorDTO.fromList(self.readValue() as! [Any?])
+        case 162:
+            return DeletedStoredPaymentMethodResultDTO.fromList(self.readValue() as! [Any?])
+        case 163:
+            return CardComponentConfigurationDTO.fromList(self.readValue() as! [Any?])
+        case 164:
+            return BlikComponentConfigurationDTO.fromList(self.readValue() as! [Any?])
+        case 165:
+            return InstantPaymentConfigurationDTO.fromList(self.readValue() as! [Any?])
+        case 166:
+            return InstantPaymentSetupResultDTO.fromList(self.readValue() as! [Any?])
+        case 167:
+            return UnencryptedCardDTO.fromList(self.readValue() as! [Any?])
+        case 168:
+            return EncryptedCardDTO.fromList(self.readValue() as! [Any?])
+        case 169:
+            return ActionComponentConfigurationDTO.fromList(self.readValue() as! [Any?])
+        case 170:
+            return OrderCancelResultDTO.fromList(self.readValue() as! [Any?])
+        case 171:
+            return BinLookupDataDTO.fromList(self.readValue() as! [Any?])
+        case 172:
+            var enumResult: Environment? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = Environment(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 173:
+            var enumResult: AddressMode? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = AddressMode(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 174:
+            var enumResult: CardAuthMethod? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = CardAuthMethod(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 175:
+            var enumResult: TotalPriceStatus? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = TotalPriceStatus(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 176:
+            var enumResult: GooglePayEnvironment? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = GooglePayEnvironment(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 177:
+            var enumResult: CashAppPayEnvironment? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = CashAppPayEnvironment(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 178:
+            var enumResult: PaymentResultEnum? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = PaymentResultEnum(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 179:
+            var enumResult: CheckoutEventType? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = CheckoutEventType(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 180:
+            var enumResult: ComponentCommunicationType? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = ComponentCommunicationType(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 181:
+            var enumResult: PaymentEventType? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = PaymentEventType(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 182:
+            var enumResult: FieldVisibility? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = FieldVisibility(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 183:
+            var enumResult: InstantPaymentType? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = InstantPaymentType(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 184:
+            var enumResult: ApplePayShippingType? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = ApplePayShippingType(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 185:
+            var enumResult: ApplePayMerchantCapability? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = ApplePayMerchantCapability(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 186:
+            var enumResult: ApplePaySummaryItemType? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = ApplePaySummaryItemType(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 187:
+            var enumResult: CardNumberValidationResultDTO? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = CardNumberValidationResultDTO(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 188:
+            var enumResult: CardExpiryDateValidationResultDTO? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = CardExpiryDateValidationResultDTO(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        case 189:
+            var enumResult: CardSecurityCodeValidationResultDTO? = nil
+            let enumResultAsInt: Int? = nilOrValue(self.readValue() as? Int)
+            if let enumResultAsInt {
+                enumResult = CardSecurityCodeValidationResultDTO(rawValue: enumResultAsInt)
+            }
+            return enumResult
+        default:
+            return super.readValue(ofType: type)
+        }
+    }
 }
 
 private class PlatformApiPigeonCodecWriter: FlutterStandardWriter {
-  override func writeValue(_ value: Any) {
-    if let value = value as? SessionDTO {
-      super.writeByte(129)
-      super.writeValue(value.toList())
-    } else if let value = value as? AmountDTO {
-      super.writeByte(130)
-      super.writeValue(value.toList())
-    } else if let value = value as? AnalyticsOptionsDTO {
-      super.writeByte(131)
-      super.writeValue(value.toList())
-    } else if let value = value as? ThreeDS2UICustomizationDTO {
-      super.writeByte(132)
-      super.writeValue(value.toList())
-    } else if let value = value as? ThreeDS2ScreenCustomizationDTO {
-      super.writeByte(133)
-      super.writeValue(value.toList())
-    } else if let value = value as? ThreeDS2ButtonCustomizationDTO {
-      super.writeByte(134)
-      super.writeValue(value.toList())
-    } else if let value = value as? ThreeDS2SelectionItemCustomizationDTO {
-      super.writeByte(135)
-      super.writeValue(value.toList())
-    } else if let value = value as? ThreeDS2LabelCustomizationDTO {
-      super.writeByte(136)
-      super.writeValue(value.toList())
-    } else if let value = value as? ThreeDS2InputCustomizationDTO {
-      super.writeByte(137)
-      super.writeValue(value.toList())
-    } else if let value = value as? ThreeDS2ToolbarCustomizationDTO {
-      super.writeByte(138)
-      super.writeValue(value.toList())
-    } else if let value = value as? ThreeDS2ConfigurationDTO {
-      super.writeByte(139)
-      super.writeValue(value.toList())
-    } else if let value = value as? DefaultInstallmentOptionsDTO {
-      super.writeByte(140)
-      super.writeValue(value.toList())
-    } else if let value = value as? CardBasedInstallmentOptionsDTO {
-      super.writeByte(141)
-      super.writeValue(value.toList())
-    } else if let value = value as? InstallmentConfigurationDTO {
-      super.writeByte(142)
-      super.writeValue(value.toList())
-    } else if let value = value as? DropInConfigurationDTO {
-      super.writeByte(143)
-      super.writeValue(value.toList())
-    } else if let value = value as? CardConfigurationDTO {
-      super.writeByte(144)
-      super.writeValue(value.toList())
-    } else if let value = value as? ApplePayConfigurationDTO {
-      super.writeByte(145)
-      super.writeValue(value.toList())
-    } else if let value = value as? ApplePayContactDTO {
-      super.writeByte(146)
-      super.writeValue(value.toList())
-    } else if let value = value as? ApplePayShippingMethodDTO {
-      super.writeByte(147)
-      super.writeValue(value.toList())
-    } else if let value = value as? ApplePaySummaryItemDTO {
-      super.writeByte(148)
-      super.writeValue(value.toList())
-    } else if let value = value as? GooglePayConfigurationDTO {
-      super.writeByte(149)
-      super.writeValue(value.toList())
-    } else if let value = value as? MerchantInfoDTO {
-      super.writeByte(150)
-      super.writeValue(value.toList())
-    } else if let value = value as? ShippingAddressParametersDTO {
-      super.writeByte(151)
-      super.writeValue(value.toList())
-    } else if let value = value as? BillingAddressParametersDTO {
-      super.writeByte(152)
-      super.writeValue(value.toList())
-    } else if let value = value as? CashAppPayConfigurationDTO {
-      super.writeByte(153)
-      super.writeValue(value.toList())
-    } else if let value = value as? TwintConfigurationDTO {
-      super.writeByte(154)
-      super.writeValue(value.toList())
-    } else if let value = value as? PaymentResultDTO {
-      super.writeByte(155)
-      super.writeValue(value.toList())
-    } else if let value = value as? PaymentResultModelDTO {
-      super.writeByte(156)
-      super.writeValue(value.toList())
-    } else if let value = value as? OrderResponseDTO {
-      super.writeByte(157)
-      super.writeValue(value.toList())
-    } else if let value = value as? CheckoutEvent {
-      super.writeByte(158)
-      super.writeValue(value.toList())
-    } else if let value = value as? ComponentCommunicationModel {
-      super.writeByte(159)
-      super.writeValue(value.toList())
-    } else if let value = value as? PaymentEventDTO {
-      super.writeByte(160)
-      super.writeValue(value.toList())
-    } else if let value = value as? ErrorDTO {
-      super.writeByte(161)
-      super.writeValue(value.toList())
-    } else if let value = value as? DeletedStoredPaymentMethodResultDTO {
-      super.writeByte(162)
-      super.writeValue(value.toList())
-    } else if let value = value as? CardComponentConfigurationDTO {
-      super.writeByte(163)
-      super.writeValue(value.toList())
-    } else if let value = value as? BlikComponentConfigurationDTO {
-      super.writeByte(164)
-      super.writeValue(value.toList())
-    } else if let value = value as? InstantPaymentConfigurationDTO {
-      super.writeByte(165)
-      super.writeValue(value.toList())
-    } else if let value = value as? InstantPaymentSetupResultDTO {
-      super.writeByte(166)
-      super.writeValue(value.toList())
-    } else if let value = value as? UnencryptedCardDTO {
-      super.writeByte(167)
-      super.writeValue(value.toList())
-    } else if let value = value as? EncryptedCardDTO {
-      super.writeByte(168)
-      super.writeValue(value.toList())
-    } else if let value = value as? ActionComponentConfigurationDTO {
-      super.writeByte(169)
-      super.writeValue(value.toList())
-    } else if let value = value as? OrderCancelResultDTO {
-      super.writeByte(170)
-      super.writeValue(value.toList())
-    } else if let value = value as? BinLookupDataDTO {
-      super.writeByte(171)
-      super.writeValue(value.toList())
-    } else if let value = value as? Environment {
-      super.writeByte(172)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? AddressMode {
-      super.writeByte(173)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? CardAuthMethod {
-      super.writeByte(174)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? TotalPriceStatus {
-      super.writeByte(175)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? GooglePayEnvironment {
-      super.writeByte(176)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? CashAppPayEnvironment {
-      super.writeByte(177)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? PaymentResultEnum {
-      super.writeByte(178)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? CheckoutEventType {
-      super.writeByte(179)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? ComponentCommunicationType {
-      super.writeByte(180)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? PaymentEventType {
-      super.writeByte(181)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? FieldVisibility {
-      super.writeByte(182)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? InstantPaymentType {
-      super.writeByte(183)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? ApplePayShippingType {
-      super.writeByte(184)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? ApplePayMerchantCapability {
-      super.writeByte(185)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? ApplePaySummaryItemType {
-      super.writeByte(186)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? CardNumberValidationResultDTO {
-      super.writeByte(187)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? CardExpiryDateValidationResultDTO {
-      super.writeByte(188)
-      super.writeValue(value.rawValue)
-    } else if let value = value as? CardSecurityCodeValidationResultDTO {
-      super.writeByte(189)
-      super.writeValue(value.rawValue)
-    } else {
-      super.writeValue(value)
+    override func writeValue(_ value: Any) {
+        if let value = value as? SessionDTO {
+            super.writeByte(129)
+            super.writeValue(value.toList())
+        } else if let value = value as? AmountDTO {
+            super.writeByte(130)
+            super.writeValue(value.toList())
+        } else if let value = value as? AnalyticsOptionsDTO {
+            super.writeByte(131)
+            super.writeValue(value.toList())
+        } else if let value = value as? ThreeDS2UICustomizationDTO {
+            super.writeByte(132)
+            super.writeValue(value.toList())
+        } else if let value = value as? ThreeDS2ScreenCustomizationDTO {
+            super.writeByte(133)
+            super.writeValue(value.toList())
+        } else if let value = value as? ThreeDS2ButtonCustomizationDTO {
+            super.writeByte(134)
+            super.writeValue(value.toList())
+        } else if let value = value as? ThreeDS2SelectionItemCustomizationDTO {
+            super.writeByte(135)
+            super.writeValue(value.toList())
+        } else if let value = value as? ThreeDS2LabelCustomizationDTO {
+            super.writeByte(136)
+            super.writeValue(value.toList())
+        } else if let value = value as? ThreeDS2InputCustomizationDTO {
+            super.writeByte(137)
+            super.writeValue(value.toList())
+        } else if let value = value as? ThreeDS2ToolbarCustomizationDTO {
+            super.writeByte(138)
+            super.writeValue(value.toList())
+        } else if let value = value as? ThreeDS2ConfigurationDTO {
+            super.writeByte(139)
+            super.writeValue(value.toList())
+        } else if let value = value as? DefaultInstallmentOptionsDTO {
+            super.writeByte(140)
+            super.writeValue(value.toList())
+        } else if let value = value as? CardBasedInstallmentOptionsDTO {
+            super.writeByte(141)
+            super.writeValue(value.toList())
+        } else if let value = value as? InstallmentConfigurationDTO {
+            super.writeByte(142)
+            super.writeValue(value.toList())
+        } else if let value = value as? DropInConfigurationDTO {
+            super.writeByte(143)
+            super.writeValue(value.toList())
+        } else if let value = value as? CardConfigurationDTO {
+            super.writeByte(144)
+            super.writeValue(value.toList())
+        } else if let value = value as? ApplePayConfigurationDTO {
+            super.writeByte(145)
+            super.writeValue(value.toList())
+        } else if let value = value as? ApplePayContactDTO {
+            super.writeByte(146)
+            super.writeValue(value.toList())
+        } else if let value = value as? ApplePayShippingMethodDTO {
+            super.writeByte(147)
+            super.writeValue(value.toList())
+        } else if let value = value as? ApplePaySummaryItemDTO {
+            super.writeByte(148)
+            super.writeValue(value.toList())
+        } else if let value = value as? GooglePayConfigurationDTO {
+            super.writeByte(149)
+            super.writeValue(value.toList())
+        } else if let value = value as? MerchantInfoDTO {
+            super.writeByte(150)
+            super.writeValue(value.toList())
+        } else if let value = value as? ShippingAddressParametersDTO {
+            super.writeByte(151)
+            super.writeValue(value.toList())
+        } else if let value = value as? BillingAddressParametersDTO {
+            super.writeByte(152)
+            super.writeValue(value.toList())
+        } else if let value = value as? CashAppPayConfigurationDTO {
+            super.writeByte(153)
+            super.writeValue(value.toList())
+        } else if let value = value as? TwintConfigurationDTO {
+            super.writeByte(154)
+            super.writeValue(value.toList())
+        } else if let value = value as? PaymentResultDTO {
+            super.writeByte(155)
+            super.writeValue(value.toList())
+        } else if let value = value as? PaymentResultModelDTO {
+            super.writeByte(156)
+            super.writeValue(value.toList())
+        } else if let value = value as? OrderResponseDTO {
+            super.writeByte(157)
+            super.writeValue(value.toList())
+        } else if let value = value as? CheckoutEvent {
+            super.writeByte(158)
+            super.writeValue(value.toList())
+        } else if let value = value as? ComponentCommunicationModel {
+            super.writeByte(159)
+            super.writeValue(value.toList())
+        } else if let value = value as? PaymentEventDTO {
+            super.writeByte(160)
+            super.writeValue(value.toList())
+        } else if let value = value as? ErrorDTO {
+            super.writeByte(161)
+            super.writeValue(value.toList())
+        } else if let value = value as? DeletedStoredPaymentMethodResultDTO {
+            super.writeByte(162)
+            super.writeValue(value.toList())
+        } else if let value = value as? CardComponentConfigurationDTO {
+            super.writeByte(163)
+            super.writeValue(value.toList())
+        } else if let value = value as? BlikComponentConfigurationDTO {
+            super.writeByte(164)
+            super.writeValue(value.toList())
+        } else if let value = value as? InstantPaymentConfigurationDTO {
+            super.writeByte(165)
+            super.writeValue(value.toList())
+        } else if let value = value as? InstantPaymentSetupResultDTO {
+            super.writeByte(166)
+            super.writeValue(value.toList())
+        } else if let value = value as? UnencryptedCardDTO {
+            super.writeByte(167)
+            super.writeValue(value.toList())
+        } else if let value = value as? EncryptedCardDTO {
+            super.writeByte(168)
+            super.writeValue(value.toList())
+        } else if let value = value as? ActionComponentConfigurationDTO {
+            super.writeByte(169)
+            super.writeValue(value.toList())
+        } else if let value = value as? OrderCancelResultDTO {
+            super.writeByte(170)
+            super.writeValue(value.toList())
+        } else if let value = value as? BinLookupDataDTO {
+            super.writeByte(171)
+            super.writeValue(value.toList())
+        } else if let value = value as? Environment {
+            super.writeByte(172)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? AddressMode {
+            super.writeByte(173)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? CardAuthMethod {
+            super.writeByte(174)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? TotalPriceStatus {
+            super.writeByte(175)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? GooglePayEnvironment {
+            super.writeByte(176)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? CashAppPayEnvironment {
+            super.writeByte(177)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? PaymentResultEnum {
+            super.writeByte(178)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? CheckoutEventType {
+            super.writeByte(179)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? ComponentCommunicationType {
+            super.writeByte(180)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? PaymentEventType {
+            super.writeByte(181)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? FieldVisibility {
+            super.writeByte(182)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? InstantPaymentType {
+            super.writeByte(183)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? ApplePayShippingType {
+            super.writeByte(184)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? ApplePayMerchantCapability {
+            super.writeByte(185)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? ApplePaySummaryItemType {
+            super.writeByte(186)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? CardNumberValidationResultDTO {
+            super.writeByte(187)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? CardExpiryDateValidationResultDTO {
+            super.writeByte(188)
+            super.writeValue(value.rawValue)
+        } else if let value = value as? CardSecurityCodeValidationResultDTO {
+            super.writeByte(189)
+            super.writeValue(value.rawValue)
+        } else {
+            super.writeValue(value)
+        }
     }
-  }
 }
 
 private class PlatformApiPigeonCodecReaderWriter: FlutterStandardReaderWriter {
-  override func reader(with data: Data) -> FlutterStandardReader {
-    return PlatformApiPigeonCodecReader(data: data)
-  }
+    override func reader(with data: Data) -> FlutterStandardReader {
+        PlatformApiPigeonCodecReader(data: data)
+    }
 
-  override func writer(with data: NSMutableData) -> FlutterStandardWriter {
-    return PlatformApiPigeonCodecWriter(data: data)
-  }
+    override func writer(with data: NSMutableData) -> FlutterStandardWriter {
+        PlatformApiPigeonCodecWriter(data: data)
+    }
 }
 
 class PlatformApiPigeonCodec: FlutterStandardMessageCodec, @unchecked Sendable {
-  static let shared = PlatformApiPigeonCodec(readerWriter: PlatformApiPigeonCodecReaderWriter())
+    static let shared = PlatformApiPigeonCodec(readerWriter: PlatformApiPigeonCodecReaderWriter())
 }
-
 
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol CheckoutPlatformInterface {
-  func getReturnUrl(completion: @escaping (Result<String, Error>) -> Void)
-  func createSession(sessionId: String, sessionData: String, configuration: Any?, completion: @escaping (Result<SessionDTO, Error>) -> Void)
-  func clearSession() throws
-  func encryptCard(unencryptedCardDTO: UnencryptedCardDTO, publicKey: String, completion: @escaping (Result<EncryptedCardDTO, Error>) -> Void)
-  func encryptBin(bin: String, publicKey: String, completion: @escaping (Result<String, Error>) -> Void)
-  func validateCardNumber(cardNumber: String, enableLuhnCheck: Bool) throws -> CardNumberValidationResultDTO
-  func validateCardExpiryDate(expiryMonth: String, expiryYear: String) throws -> CardExpiryDateValidationResultDTO
-  func validateCardSecurityCode(securityCode: String, cardBrand: String?) throws -> CardSecurityCodeValidationResultDTO
-  func enableConsoleLogging(loggingEnabled: Bool) throws
-  func getThreeDS2SdkVersion() throws -> String
+    func getReturnUrl(completion: @escaping (Result<String, Error>) -> Void)
+    func createSession(sessionId: String, sessionData: String, configuration: Any?, completion: @escaping (Result<SessionDTO, Error>) -> Void)
+    func clearSession() throws
+    func encryptCard(unencryptedCardDTO: UnencryptedCardDTO, publicKey: String, completion: @escaping (Result<EncryptedCardDTO, Error>) -> Void)
+    func encryptBin(bin: String, publicKey: String, completion: @escaping (Result<String, Error>) -> Void)
+    func validateCardNumber(cardNumber: String, enableLuhnCheck: Bool) throws -> CardNumberValidationResultDTO
+    func validateCardExpiryDate(expiryMonth: String, expiryYear: String) throws -> CardExpiryDateValidationResultDTO
+    func validateCardSecurityCode(securityCode: String, cardBrand: String?) throws -> CardSecurityCodeValidationResultDTO
+    func enableConsoleLogging(loggingEnabled: Bool) throws
+    func getThreeDS2SdkVersion() throws -> String
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
 class CheckoutPlatformInterfaceSetup {
-  static var codec: FlutterStandardMessageCodec { PlatformApiPigeonCodec.shared }
-  /// Sets up an instance of `CheckoutPlatformInterface` to handle messages through the `binaryMessenger`.
-  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: CheckoutPlatformInterface?, messageChannelSuffix: String = "") {
-    let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-    let getReturnUrlChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.getReturnUrl\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      getReturnUrlChannel.setMessageHandler { _, reply in
-        api.getReturnUrl { result in
-          switch result {
-          case .success(let res):
-            reply(wrapResult(res))
-          case .failure(let error):
-            reply(wrapError(error))
-          }
-        }
-      }
-    } else {
-      getReturnUrlChannel.setMessageHandler(nil)
+    static var codec: FlutterStandardMessageCodec {
+        PlatformApiPigeonCodec.shared
     }
-    let createSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.createSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      createSessionChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let sessionIdArg = args[0] as! String
-        let sessionDataArg = args[1] as! String
-        let configurationArg: Any? = args[2]
-        api.createSession(sessionId: sessionIdArg, sessionData: sessionDataArg, configuration: configurationArg) { result in
-          switch result {
-          case .success(let res):
-            reply(wrapResult(res))
-          case .failure(let error):
-            reply(wrapError(error))
-          }
+
+    /// Sets up an instance of `CheckoutPlatformInterface` to handle messages through the `binaryMessenger`.
+    static func setUp(binaryMessenger: FlutterBinaryMessenger, api: CheckoutPlatformInterface?, messageChannelSuffix: String = "") {
+        let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
+        let getReturnUrlChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.getReturnUrl\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            getReturnUrlChannel.setMessageHandler { _, reply in
+                api.getReturnUrl { result in
+                    switch result {
+                    case let .success(res):
+                        reply(wrapResult(res))
+                    case let .failure(error):
+                        reply(wrapError(error))
+                    }
+                }
+            }
+        } else {
+            getReturnUrlChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      createSessionChannel.setMessageHandler(nil)
-    }
-    let clearSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.clearSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      clearSessionChannel.setMessageHandler { _, reply in
-        do {
-          try api.clearSession()
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let createSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.createSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            createSessionChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let sessionIdArg = args[0] as! String
+                let sessionDataArg = args[1] as! String
+                let configurationArg: Any? = args[2]
+                api.createSession(sessionId: sessionIdArg, sessionData: sessionDataArg, configuration: configurationArg) { result in
+                    switch result {
+                    case let .success(res):
+                        reply(wrapResult(res))
+                    case let .failure(error):
+                        reply(wrapError(error))
+                    }
+                }
+            }
+        } else {
+            createSessionChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      clearSessionChannel.setMessageHandler(nil)
-    }
-    let encryptCardChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.encryptCard\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      encryptCardChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let unencryptedCardDTOArg = args[0] as! UnencryptedCardDTO
-        let publicKeyArg = args[1] as! String
-        api.encryptCard(unencryptedCardDTO: unencryptedCardDTOArg, publicKey: publicKeyArg) { result in
-          switch result {
-          case .success(let res):
-            reply(wrapResult(res))
-          case .failure(let error):
-            reply(wrapError(error))
-          }
+        let clearSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.clearSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            clearSessionChannel.setMessageHandler { _, reply in
+                do {
+                    try api.clearSession()
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            clearSessionChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      encryptCardChannel.setMessageHandler(nil)
-    }
-    let encryptBinChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.encryptBin\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      encryptBinChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let binArg = args[0] as! String
-        let publicKeyArg = args[1] as! String
-        api.encryptBin(bin: binArg, publicKey: publicKeyArg) { result in
-          switch result {
-          case .success(let res):
-            reply(wrapResult(res))
-          case .failure(let error):
-            reply(wrapError(error))
-          }
+        let encryptCardChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.encryptCard\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            encryptCardChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let unencryptedCardDTOArg = args[0] as! UnencryptedCardDTO
+                let publicKeyArg = args[1] as! String
+                api.encryptCard(unencryptedCardDTO: unencryptedCardDTOArg, publicKey: publicKeyArg) { result in
+                    switch result {
+                    case let .success(res):
+                        reply(wrapResult(res))
+                    case let .failure(error):
+                        reply(wrapError(error))
+                    }
+                }
+            }
+        } else {
+            encryptCardChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      encryptBinChannel.setMessageHandler(nil)
-    }
-    let validateCardNumberChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.validateCardNumber\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      validateCardNumberChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let cardNumberArg = args[0] as! String
-        let enableLuhnCheckArg = args[1] as! Bool
-        do {
-          let result = try api.validateCardNumber(cardNumber: cardNumberArg, enableLuhnCheck: enableLuhnCheckArg)
-          reply(wrapResult(result))
-        } catch {
-          reply(wrapError(error))
+        let encryptBinChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.encryptBin\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            encryptBinChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let binArg = args[0] as! String
+                let publicKeyArg = args[1] as! String
+                api.encryptBin(bin: binArg, publicKey: publicKeyArg) { result in
+                    switch result {
+                    case let .success(res):
+                        reply(wrapResult(res))
+                    case let .failure(error):
+                        reply(wrapError(error))
+                    }
+                }
+            }
+        } else {
+            encryptBinChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      validateCardNumberChannel.setMessageHandler(nil)
-    }
-    let validateCardExpiryDateChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.validateCardExpiryDate\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      validateCardExpiryDateChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let expiryMonthArg = args[0] as! String
-        let expiryYearArg = args[1] as! String
-        do {
-          let result = try api.validateCardExpiryDate(expiryMonth: expiryMonthArg, expiryYear: expiryYearArg)
-          reply(wrapResult(result))
-        } catch {
-          reply(wrapError(error))
+        let validateCardNumberChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.validateCardNumber\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            validateCardNumberChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let cardNumberArg = args[0] as! String
+                let enableLuhnCheckArg = args[1] as! Bool
+                do {
+                    let result = try api.validateCardNumber(cardNumber: cardNumberArg, enableLuhnCheck: enableLuhnCheckArg)
+                    reply(wrapResult(result))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            validateCardNumberChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      validateCardExpiryDateChannel.setMessageHandler(nil)
-    }
-    let validateCardSecurityCodeChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.validateCardSecurityCode\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      validateCardSecurityCodeChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let securityCodeArg = args[0] as! String
-        let cardBrandArg: String? = nilOrValue(args[1])
-        do {
-          let result = try api.validateCardSecurityCode(securityCode: securityCodeArg, cardBrand: cardBrandArg)
-          reply(wrapResult(result))
-        } catch {
-          reply(wrapError(error))
+        let validateCardExpiryDateChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.validateCardExpiryDate\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            validateCardExpiryDateChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let expiryMonthArg = args[0] as! String
+                let expiryYearArg = args[1] as! String
+                do {
+                    let result = try api.validateCardExpiryDate(expiryMonth: expiryMonthArg, expiryYear: expiryYearArg)
+                    reply(wrapResult(result))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            validateCardExpiryDateChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      validateCardSecurityCodeChannel.setMessageHandler(nil)
-    }
-    let enableConsoleLoggingChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.enableConsoleLogging\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      enableConsoleLoggingChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let loggingEnabledArg = args[0] as! Bool
-        do {
-          try api.enableConsoleLogging(loggingEnabled: loggingEnabledArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let validateCardSecurityCodeChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.validateCardSecurityCode\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            validateCardSecurityCodeChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let securityCodeArg = args[0] as! String
+                let cardBrandArg: String? = nilOrValue(args[1])
+                do {
+                    let result = try api.validateCardSecurityCode(securityCode: securityCodeArg, cardBrand: cardBrandArg)
+                    reply(wrapResult(result))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            validateCardSecurityCodeChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      enableConsoleLoggingChannel.setMessageHandler(nil)
-    }
-    let getThreeDS2SdkVersionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.getThreeDS2SdkVersion\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      getThreeDS2SdkVersionChannel.setMessageHandler { _, reply in
-        do {
-          let result = try api.getThreeDS2SdkVersion()
-          reply(wrapResult(result))
-        } catch {
-          reply(wrapError(error))
+        let enableConsoleLoggingChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.enableConsoleLogging\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            enableConsoleLoggingChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let loggingEnabledArg = args[0] as! Bool
+                do {
+                    try api.enableConsoleLogging(loggingEnabled: loggingEnabledArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            enableConsoleLoggingChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      getThreeDS2SdkVersionChannel.setMessageHandler(nil)
+        let getThreeDS2SdkVersionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.CheckoutPlatformInterface.getThreeDS2SdkVersion\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            getThreeDS2SdkVersionChannel.setMessageHandler { _, reply in
+                do {
+                    let result = try api.getThreeDS2SdkVersion()
+                    reply(wrapResult(result))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            getThreeDS2SdkVersionChannel.setMessageHandler(nil)
+        }
     }
-  }
 }
+
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol DropInPlatformInterface {
-  func showDropInSession(dropInConfigurationDTO: DropInConfigurationDTO) throws
-  func showDropInAdvanced(dropInConfigurationDTO: DropInConfigurationDTO, paymentMethodsResponse: String) throws
-  func stopDropIn() throws
-  func onPaymentsResult(paymentsResult: PaymentEventDTO) throws
-  func onPaymentsDetailsResult(paymentsDetailsResult: PaymentEventDTO) throws
-  func onDeleteStoredPaymentMethodResult(deleteStoredPaymentMethodResultDTO: DeletedStoredPaymentMethodResultDTO) throws
-  func onBalanceCheckResult(balanceCheckResponse: String) throws
-  func onOrderRequestResult(orderRequestResponse: String) throws
-  func onOrderCancelResult(orderCancelResult: OrderCancelResultDTO) throws
-  func cleanUpDropIn() throws
+    func showDropInSession(dropInConfigurationDTO: DropInConfigurationDTO) throws
+    func showDropInAdvanced(dropInConfigurationDTO: DropInConfigurationDTO, paymentMethodsResponse: String) throws
+    func stopDropIn() throws
+    func onPaymentsResult(paymentsResult: PaymentEventDTO) throws
+    func onPaymentsDetailsResult(paymentsDetailsResult: PaymentEventDTO) throws
+    func onDeleteStoredPaymentMethodResult(deleteStoredPaymentMethodResultDTO: DeletedStoredPaymentMethodResultDTO) throws
+    func onBalanceCheckResult(balanceCheckResponse: String) throws
+    func onOrderRequestResult(orderRequestResponse: String) throws
+    func onOrderCancelResult(orderCancelResult: OrderCancelResultDTO) throws
+    func cleanUpDropIn() throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
 class DropInPlatformInterfaceSetup {
-  static var codec: FlutterStandardMessageCodec { PlatformApiPigeonCodec.shared }
-  /// Sets up an instance of `DropInPlatformInterface` to handle messages through the `binaryMessenger`.
-  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: DropInPlatformInterface?, messageChannelSuffix: String = "") {
-    let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-    let showDropInSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.showDropInSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      showDropInSessionChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let dropInConfigurationDTOArg = args[0] as! DropInConfigurationDTO
-        do {
-          try api.showDropInSession(dropInConfigurationDTO: dropInConfigurationDTOArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
-        }
-      }
-    } else {
-      showDropInSessionChannel.setMessageHandler(nil)
+    static var codec: FlutterStandardMessageCodec {
+        PlatformApiPigeonCodec.shared
     }
-    let showDropInAdvancedChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.showDropInAdvanced\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      showDropInAdvancedChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let dropInConfigurationDTOArg = args[0] as! DropInConfigurationDTO
-        let paymentMethodsResponseArg = args[1] as! String
-        do {
-          try api.showDropInAdvanced(dropInConfigurationDTO: dropInConfigurationDTOArg, paymentMethodsResponse: paymentMethodsResponseArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+
+    /// Sets up an instance of `DropInPlatformInterface` to handle messages through the `binaryMessenger`.
+    static func setUp(binaryMessenger: FlutterBinaryMessenger, api: DropInPlatformInterface?, messageChannelSuffix: String = "") {
+        let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
+        let showDropInSessionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.showDropInSession\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            showDropInSessionChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let dropInConfigurationDTOArg = args[0] as! DropInConfigurationDTO
+                do {
+                    try api.showDropInSession(dropInConfigurationDTO: dropInConfigurationDTOArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            showDropInSessionChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      showDropInAdvancedChannel.setMessageHandler(nil)
-    }
-    let stopDropInChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.stopDropIn\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      stopDropInChannel.setMessageHandler { _, reply in
-        do {
-          try api.stopDropIn()
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let showDropInAdvancedChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.showDropInAdvanced\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            showDropInAdvancedChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let dropInConfigurationDTOArg = args[0] as! DropInConfigurationDTO
+                let paymentMethodsResponseArg = args[1] as! String
+                do {
+                    try api.showDropInAdvanced(dropInConfigurationDTO: dropInConfigurationDTOArg, paymentMethodsResponse: paymentMethodsResponseArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            showDropInAdvancedChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      stopDropInChannel.setMessageHandler(nil)
-    }
-    let onPaymentsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onPaymentsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      onPaymentsResultChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let paymentsResultArg = args[0] as! PaymentEventDTO
-        do {
-          try api.onPaymentsResult(paymentsResult: paymentsResultArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let stopDropInChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.stopDropIn\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            stopDropInChannel.setMessageHandler { _, reply in
+                do {
+                    try api.stopDropIn()
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            stopDropInChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      onPaymentsResultChannel.setMessageHandler(nil)
-    }
-    let onPaymentsDetailsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onPaymentsDetailsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      onPaymentsDetailsResultChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let paymentsDetailsResultArg = args[0] as! PaymentEventDTO
-        do {
-          try api.onPaymentsDetailsResult(paymentsDetailsResult: paymentsDetailsResultArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let onPaymentsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onPaymentsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            onPaymentsResultChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let paymentsResultArg = args[0] as! PaymentEventDTO
+                do {
+                    try api.onPaymentsResult(paymentsResult: paymentsResultArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            onPaymentsResultChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      onPaymentsDetailsResultChannel.setMessageHandler(nil)
-    }
-    let onDeleteStoredPaymentMethodResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onDeleteStoredPaymentMethodResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      onDeleteStoredPaymentMethodResultChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let deleteStoredPaymentMethodResultDTOArg = args[0] as! DeletedStoredPaymentMethodResultDTO
-        do {
-          try api.onDeleteStoredPaymentMethodResult(deleteStoredPaymentMethodResultDTO: deleteStoredPaymentMethodResultDTOArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let onPaymentsDetailsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onPaymentsDetailsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            onPaymentsDetailsResultChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let paymentsDetailsResultArg = args[0] as! PaymentEventDTO
+                do {
+                    try api.onPaymentsDetailsResult(paymentsDetailsResult: paymentsDetailsResultArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            onPaymentsDetailsResultChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      onDeleteStoredPaymentMethodResultChannel.setMessageHandler(nil)
-    }
-    let onBalanceCheckResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onBalanceCheckResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      onBalanceCheckResultChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let balanceCheckResponseArg = args[0] as! String
-        do {
-          try api.onBalanceCheckResult(balanceCheckResponse: balanceCheckResponseArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let onDeleteStoredPaymentMethodResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onDeleteStoredPaymentMethodResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            onDeleteStoredPaymentMethodResultChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let deleteStoredPaymentMethodResultDTOArg = args[0] as! DeletedStoredPaymentMethodResultDTO
+                do {
+                    try api.onDeleteStoredPaymentMethodResult(deleteStoredPaymentMethodResultDTO: deleteStoredPaymentMethodResultDTOArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            onDeleteStoredPaymentMethodResultChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      onBalanceCheckResultChannel.setMessageHandler(nil)
-    }
-    let onOrderRequestResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onOrderRequestResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      onOrderRequestResultChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let orderRequestResponseArg = args[0] as! String
-        do {
-          try api.onOrderRequestResult(orderRequestResponse: orderRequestResponseArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let onBalanceCheckResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onBalanceCheckResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            onBalanceCheckResultChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let balanceCheckResponseArg = args[0] as! String
+                do {
+                    try api.onBalanceCheckResult(balanceCheckResponse: balanceCheckResponseArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            onBalanceCheckResultChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      onOrderRequestResultChannel.setMessageHandler(nil)
-    }
-    let onOrderCancelResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onOrderCancelResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      onOrderCancelResultChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let orderCancelResultArg = args[0] as! OrderCancelResultDTO
-        do {
-          try api.onOrderCancelResult(orderCancelResult: orderCancelResultArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let onOrderRequestResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onOrderRequestResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            onOrderRequestResultChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let orderRequestResponseArg = args[0] as! String
+                do {
+                    try api.onOrderRequestResult(orderRequestResponse: orderRequestResponseArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            onOrderRequestResultChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      onOrderCancelResultChannel.setMessageHandler(nil)
-    }
-    let cleanUpDropInChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.cleanUpDropIn\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      cleanUpDropInChannel.setMessageHandler { _, reply in
-        do {
-          try api.cleanUpDropIn()
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let onOrderCancelResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.onOrderCancelResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            onOrderCancelResultChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let orderCancelResultArg = args[0] as! OrderCancelResultDTO
+                do {
+                    try api.onOrderCancelResult(orderCancelResult: orderCancelResultArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            onOrderCancelResultChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      cleanUpDropInChannel.setMessageHandler(nil)
+        let cleanUpDropInChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.DropInPlatformInterface.cleanUpDropIn\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            cleanUpDropInChannel.setMessageHandler { _, reply in
+                do {
+                    try api.cleanUpDropIn()
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            cleanUpDropInChannel.setMessageHandler(nil)
+        }
     }
-  }
 }
+
 /// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
 protocol CheckoutFlutterInterfaceProtocol {
-  func send(event eventArg: CheckoutEvent, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void)
+    func send(event eventArg: CheckoutEvent, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void)
 }
+
 class CheckoutFlutterInterface: CheckoutFlutterInterfaceProtocol {
-  private let binaryMessenger: FlutterBinaryMessenger
-  private let messageChannelSuffix: String
-  init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
-    self.binaryMessenger = binaryMessenger
-    self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-  }
-  var codec: PlatformApiPigeonCodec {
-    return PlatformApiPigeonCodec.shared
-  }
-  func send(event eventArg: CheckoutEvent, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.adyen_checkout.CheckoutFlutterInterface.send\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-    channel.sendMessage([eventArg] as [Any?]) { response in
-      guard let listResponse = response as? [Any?] else {
-        completion(.failure(createConnectionError(withChannelName: channelName)))
-        return
-      }
-      if listResponse.count > 1 {
-        let code: String = listResponse[0] as! String
-        let message: String? = nilOrValue(listResponse[1])
-        let details: String? = nilOrValue(listResponse[2])
-        completion(.failure(AdyenPigeonError(code: code, message: message, details: details)))
-      } else {
-        completion(.success(Void()))
-      }
+    private let binaryMessenger: FlutterBinaryMessenger
+    private let messageChannelSuffix: String
+    init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
+        self.binaryMessenger = binaryMessenger
+        self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
     }
-  }
+
+    var codec: PlatformApiPigeonCodec {
+        PlatformApiPigeonCodec.shared
+    }
+
+    func send(event eventArg: CheckoutEvent, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void) {
+        let channelName = "dev.flutter.pigeon.adyen_checkout.CheckoutFlutterInterface.send\(messageChannelSuffix)"
+        let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+        channel.sendMessage([eventArg] as [Any?]) { response in
+            guard let listResponse = response as? [Any?] else {
+                completion(.failure(createConnectionError(withChannelName: channelName)))
+                return
+            }
+            if listResponse.count > 1 {
+                let code: String = listResponse[0] as! String
+                let message: String? = nilOrValue(listResponse[1])
+                let details: String? = nilOrValue(listResponse[2])
+                completion(.failure(AdyenPigeonError(code: code, message: message, details: details)))
+            } else {
+                completion(.success(()))
+            }
+        }
+    }
 }
+
 /// Generated protocol from Pigeon that represents a handler of messages from Flutter.
 protocol ComponentPlatformInterface {
-  func updateViewHeight(viewId: Int64) throws
-  func onPaymentsResult(componentId: String, paymentsResult: PaymentEventDTO) throws
-  func onPaymentsDetailsResult(componentId: String, paymentsDetailsResult: PaymentEventDTO) throws
-  func isInstantPaymentSupportedByPlatform(instantPaymentConfigurationDTO: InstantPaymentConfigurationDTO, paymentMethodResponse: String, componentId: String, completion: @escaping (Result<InstantPaymentSetupResultDTO, Error>) -> Void)
-  func onInstantPaymentPressed(instantPaymentConfigurationDTO: InstantPaymentConfigurationDTO, encodedPaymentMethod: String, componentId: String) throws
-  func handleAction(actionComponentConfiguration: ActionComponentConfigurationDTO, componentId: String, actionResponse: [String?: Any?]?) throws
-  func onDispose(componentId: String) throws
+    func updateViewHeight(viewId: Int64) throws
+    func onPaymentsResult(componentId: String, paymentsResult: PaymentEventDTO) throws
+    func onPaymentsDetailsResult(componentId: String, paymentsDetailsResult: PaymentEventDTO) throws
+    func isInstantPaymentSupportedByPlatform(instantPaymentConfigurationDTO: InstantPaymentConfigurationDTO, paymentMethodResponse: String, componentId: String, completion: @escaping (Result<InstantPaymentSetupResultDTO, Error>) -> Void)
+    func onInstantPaymentPressed(instantPaymentConfigurationDTO: InstantPaymentConfigurationDTO, encodedPaymentMethod: String, componentId: String) throws
+    func handleAction(actionComponentConfiguration: ActionComponentConfigurationDTO, componentId: String, actionResponse: [String?: Any?]?) throws
+    func onDispose(componentId: String) throws
 }
 
 /// Generated setup class from Pigeon to handle messages through the `binaryMessenger`.
 class ComponentPlatformInterfaceSetup {
-  static var codec: FlutterStandardMessageCodec { PlatformApiPigeonCodec.shared }
-  /// Sets up an instance of `ComponentPlatformInterface` to handle messages through the `binaryMessenger`.
-  static func setUp(binaryMessenger: FlutterBinaryMessenger, api: ComponentPlatformInterface?, messageChannelSuffix: String = "") {
-    let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-    let updateViewHeightChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.updateViewHeight\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      updateViewHeightChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let viewIdArg = args[0] is Int64 ? args[0] as! Int64 : Int64(args[0] as! Int32)
-        do {
-          try api.updateViewHeight(viewId: viewIdArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
-        }
-      }
-    } else {
-      updateViewHeightChannel.setMessageHandler(nil)
+    static var codec: FlutterStandardMessageCodec {
+        PlatformApiPigeonCodec.shared
     }
-    let onPaymentsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onPaymentsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      onPaymentsResultChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let componentIdArg = args[0] as! String
-        let paymentsResultArg = args[1] as! PaymentEventDTO
-        do {
-          try api.onPaymentsResult(componentId: componentIdArg, paymentsResult: paymentsResultArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+
+    /// Sets up an instance of `ComponentPlatformInterface` to handle messages through the `binaryMessenger`.
+    static func setUp(binaryMessenger: FlutterBinaryMessenger, api: ComponentPlatformInterface?, messageChannelSuffix: String = "") {
+        let channelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
+        let updateViewHeightChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.updateViewHeight\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            updateViewHeightChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let viewIdArg = args[0] is Int64 ? args[0] as! Int64 : Int64(args[0] as! Int32)
+                do {
+                    try api.updateViewHeight(viewId: viewIdArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            updateViewHeightChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      onPaymentsResultChannel.setMessageHandler(nil)
-    }
-    let onPaymentsDetailsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onPaymentsDetailsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      onPaymentsDetailsResultChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let componentIdArg = args[0] as! String
-        let paymentsDetailsResultArg = args[1] as! PaymentEventDTO
-        do {
-          try api.onPaymentsDetailsResult(componentId: componentIdArg, paymentsDetailsResult: paymentsDetailsResultArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let onPaymentsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onPaymentsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            onPaymentsResultChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let componentIdArg = args[0] as! String
+                let paymentsResultArg = args[1] as! PaymentEventDTO
+                do {
+                    try api.onPaymentsResult(componentId: componentIdArg, paymentsResult: paymentsResultArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            onPaymentsResultChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      onPaymentsDetailsResultChannel.setMessageHandler(nil)
-    }
-    let isInstantPaymentSupportedByPlatformChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.isInstantPaymentSupportedByPlatform\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      isInstantPaymentSupportedByPlatformChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let instantPaymentConfigurationDTOArg = args[0] as! InstantPaymentConfigurationDTO
-        let paymentMethodResponseArg = args[1] as! String
-        let componentIdArg = args[2] as! String
-        api.isInstantPaymentSupportedByPlatform(instantPaymentConfigurationDTO: instantPaymentConfigurationDTOArg, paymentMethodResponse: paymentMethodResponseArg, componentId: componentIdArg) { result in
-          switch result {
-          case .success(let res):
-            reply(wrapResult(res))
-          case .failure(let error):
-            reply(wrapError(error))
-          }
+        let onPaymentsDetailsResultChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onPaymentsDetailsResult\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            onPaymentsDetailsResultChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let componentIdArg = args[0] as! String
+                let paymentsDetailsResultArg = args[1] as! PaymentEventDTO
+                do {
+                    try api.onPaymentsDetailsResult(componentId: componentIdArg, paymentsDetailsResult: paymentsDetailsResultArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            onPaymentsDetailsResultChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      isInstantPaymentSupportedByPlatformChannel.setMessageHandler(nil)
-    }
-    let onInstantPaymentPressedChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onInstantPaymentPressed\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      onInstantPaymentPressedChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let instantPaymentConfigurationDTOArg = args[0] as! InstantPaymentConfigurationDTO
-        let encodedPaymentMethodArg = args[1] as! String
-        let componentIdArg = args[2] as! String
-        do {
-          try api.onInstantPaymentPressed(instantPaymentConfigurationDTO: instantPaymentConfigurationDTOArg, encodedPaymentMethod: encodedPaymentMethodArg, componentId: componentIdArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let isInstantPaymentSupportedByPlatformChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.isInstantPaymentSupportedByPlatform\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            isInstantPaymentSupportedByPlatformChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let instantPaymentConfigurationDTOArg = args[0] as! InstantPaymentConfigurationDTO
+                let paymentMethodResponseArg = args[1] as! String
+                let componentIdArg = args[2] as! String
+                api.isInstantPaymentSupportedByPlatform(instantPaymentConfigurationDTO: instantPaymentConfigurationDTOArg, paymentMethodResponse: paymentMethodResponseArg, componentId: componentIdArg) { result in
+                    switch result {
+                    case let .success(res):
+                        reply(wrapResult(res))
+                    case let .failure(error):
+                        reply(wrapError(error))
+                    }
+                }
+            }
+        } else {
+            isInstantPaymentSupportedByPlatformChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      onInstantPaymentPressedChannel.setMessageHandler(nil)
-    }
-    let handleActionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.handleAction\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      handleActionChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let actionComponentConfigurationArg = args[0] as! ActionComponentConfigurationDTO
-        let componentIdArg = args[1] as! String
-        let actionResponseArg: [String?: Any?]? = nilOrValue(args[2])
-        do {
-          try api.handleAction(actionComponentConfiguration: actionComponentConfigurationArg, componentId: componentIdArg, actionResponse: actionResponseArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let onInstantPaymentPressedChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onInstantPaymentPressed\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            onInstantPaymentPressedChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let instantPaymentConfigurationDTOArg = args[0] as! InstantPaymentConfigurationDTO
+                let encodedPaymentMethodArg = args[1] as! String
+                let componentIdArg = args[2] as! String
+                do {
+                    try api.onInstantPaymentPressed(instantPaymentConfigurationDTO: instantPaymentConfigurationDTOArg, encodedPaymentMethod: encodedPaymentMethodArg, componentId: componentIdArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            onInstantPaymentPressedChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      handleActionChannel.setMessageHandler(nil)
-    }
-    let onDisposeChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onDispose\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
-    if let api = api {
-      onDisposeChannel.setMessageHandler { message, reply in
-        let args = message as! [Any?]
-        let componentIdArg = args[0] as! String
-        do {
-          try api.onDispose(componentId: componentIdArg)
-          reply(wrapResult(nil))
-        } catch {
-          reply(wrapError(error))
+        let handleActionChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.handleAction\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            handleActionChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let actionComponentConfigurationArg = args[0] as! ActionComponentConfigurationDTO
+                let componentIdArg = args[1] as! String
+                let actionResponseArg: [String?: Any?]? = nilOrValue(args[2])
+                do {
+                    try api.handleAction(actionComponentConfiguration: actionComponentConfigurationArg, componentId: componentIdArg, actionResponse: actionResponseArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            handleActionChannel.setMessageHandler(nil)
         }
-      }
-    } else {
-      onDisposeChannel.setMessageHandler(nil)
+        let onDisposeChannel = FlutterBasicMessageChannel(name: "dev.flutter.pigeon.adyen_checkout.ComponentPlatformInterface.onDispose\(channelSuffix)", binaryMessenger: binaryMessenger, codec: codec)
+        if let api {
+            onDisposeChannel.setMessageHandler { message, reply in
+                let args = message as! [Any?]
+                let componentIdArg = args[0] as! String
+                do {
+                    try api.onDispose(componentId: componentIdArg)
+                    reply(wrapResult(nil))
+                } catch {
+                    reply(wrapError(error))
+                }
+            }
+        } else {
+            onDisposeChannel.setMessageHandler(nil)
+        }
     }
-  }
 }
+
 /// Generated protocol from Pigeon that represents Flutter messages that can be called from Swift.
 protocol ComponentFlutterInterfaceProtocol {
-  func _generateCodecForDTOs(cardComponentConfigurationDTO cardComponentConfigurationDTOArg: CardComponentConfigurationDTO, blikComponentConfigurationDTO blikComponentConfigurationDTOArg: BlikComponentConfigurationDTO, sessionDTO sessionDTOArg: SessionDTO, binLookupDataDTO binLookupDataDTOArg: BinLookupDataDTO, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void)
-  func onComponentCommunication(componentCommunicationModel componentCommunicationModelArg: ComponentCommunicationModel, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void)
+    func _generateCodecForDTOs(cardComponentConfigurationDTO cardComponentConfigurationDTOArg: CardComponentConfigurationDTO, blikComponentConfigurationDTO blikComponentConfigurationDTOArg: BlikComponentConfigurationDTO, sessionDTO sessionDTOArg: SessionDTO, binLookupDataDTO binLookupDataDTOArg: BinLookupDataDTO, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void)
+    func onComponentCommunication(componentCommunicationModel componentCommunicationModelArg: ComponentCommunicationModel, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void)
 }
+
 class ComponentFlutterInterface: ComponentFlutterInterfaceProtocol {
-  private let binaryMessenger: FlutterBinaryMessenger
-  private let messageChannelSuffix: String
-  init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
-    self.binaryMessenger = binaryMessenger
-    self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
-  }
-  var codec: PlatformApiPigeonCodec {
-    return PlatformApiPigeonCodec.shared
-  }
-  func _generateCodecForDTOs(cardComponentConfigurationDTO cardComponentConfigurationDTOArg: CardComponentConfigurationDTO, blikComponentConfigurationDTO blikComponentConfigurationDTOArg: BlikComponentConfigurationDTO, sessionDTO sessionDTOArg: SessionDTO, binLookupDataDTO binLookupDataDTOArg: BinLookupDataDTO, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.adyen_checkout.ComponentFlutterInterface._generateCodecForDTOs\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-    channel.sendMessage([cardComponentConfigurationDTOArg, blikComponentConfigurationDTOArg, sessionDTOArg, binLookupDataDTOArg] as [Any?]) { response in
-      guard let listResponse = response as? [Any?] else {
-        completion(.failure(createConnectionError(withChannelName: channelName)))
-        return
-      }
-      if listResponse.count > 1 {
-        let code: String = listResponse[0] as! String
-        let message: String? = nilOrValue(listResponse[1])
-        let details: String? = nilOrValue(listResponse[2])
-        completion(.failure(AdyenPigeonError(code: code, message: message, details: details)))
-      } else {
-        completion(.success(Void()))
-      }
+    private let binaryMessenger: FlutterBinaryMessenger
+    private let messageChannelSuffix: String
+    init(binaryMessenger: FlutterBinaryMessenger, messageChannelSuffix: String = "") {
+        self.binaryMessenger = binaryMessenger
+        self.messageChannelSuffix = messageChannelSuffix.count > 0 ? ".\(messageChannelSuffix)" : ""
     }
-  }
-  func onComponentCommunication(componentCommunicationModel componentCommunicationModelArg: ComponentCommunicationModel, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void) {
-    let channelName: String = "dev.flutter.pigeon.adyen_checkout.ComponentFlutterInterface.onComponentCommunication\(messageChannelSuffix)"
-    let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
-    channel.sendMessage([componentCommunicationModelArg] as [Any?]) { response in
-      guard let listResponse = response as? [Any?] else {
-        completion(.failure(createConnectionError(withChannelName: channelName)))
-        return
-      }
-      if listResponse.count > 1 {
-        let code: String = listResponse[0] as! String
-        let message: String? = nilOrValue(listResponse[1])
-        let details: String? = nilOrValue(listResponse[2])
-        completion(.failure(AdyenPigeonError(code: code, message: message, details: details)))
-      } else {
-        completion(.success(Void()))
-      }
+
+    var codec: PlatformApiPigeonCodec {
+        PlatformApiPigeonCodec.shared
     }
-  }
+
+    func _generateCodecForDTOs(cardComponentConfigurationDTO cardComponentConfigurationDTOArg: CardComponentConfigurationDTO, blikComponentConfigurationDTO blikComponentConfigurationDTOArg: BlikComponentConfigurationDTO, sessionDTO sessionDTOArg: SessionDTO, binLookupDataDTO binLookupDataDTOArg: BinLookupDataDTO, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void) {
+        let channelName = "dev.flutter.pigeon.adyen_checkout.ComponentFlutterInterface._generateCodecForDTOs\(messageChannelSuffix)"
+        let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+        channel.sendMessage([cardComponentConfigurationDTOArg, blikComponentConfigurationDTOArg, sessionDTOArg, binLookupDataDTOArg] as [Any?]) { response in
+            guard let listResponse = response as? [Any?] else {
+                completion(.failure(createConnectionError(withChannelName: channelName)))
+                return
+            }
+            if listResponse.count > 1 {
+                let code: String = listResponse[0] as! String
+                let message: String? = nilOrValue(listResponse[1])
+                let details: String? = nilOrValue(listResponse[2])
+                completion(.failure(AdyenPigeonError(code: code, message: message, details: details)))
+            } else {
+                completion(.success(()))
+            }
+        }
+    }
+
+    func onComponentCommunication(componentCommunicationModel componentCommunicationModelArg: ComponentCommunicationModel, completion: @escaping (Result<Void, AdyenPigeonError>) -> Void) {
+        let channelName = "dev.flutter.pigeon.adyen_checkout.ComponentFlutterInterface.onComponentCommunication\(messageChannelSuffix)"
+        let channel = FlutterBasicMessageChannel(name: channelName, binaryMessenger: binaryMessenger, codec: codec)
+        channel.sendMessage([componentCommunicationModelArg] as [Any?]) { response in
+            guard let listResponse = response as? [Any?] else {
+                completion(.failure(createConnectionError(withChannelName: channelName)))
+                return
+            }
+            if listResponse.count > 1 {
+                let code: String = listResponse[0] as! String
+                let message: String? = nilOrValue(listResponse[1])
+                let details: String? = nilOrValue(listResponse[2])
+                completion(.failure(AdyenPigeonError(code: code, message: message, details: details)))
+            } else {
+                completion(.success(()))
+            }
+        }
+    }
 }

--- a/ios/adyen_checkout/Sources/adyen_checkout/utils/ConfigurationMapper.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/utils/ConfigurationMapper.swift
@@ -1,6 +1,5 @@
 @_spi(AdyenInternal) import Adyen
 import PassKit
-
 #if canImport(AdyenComponents)
     import AdyenComponents
 #endif
@@ -30,13 +29,10 @@ extension DropInConfigurationDTO {
             allowPreselectedPaymentView: showPreselectedStoredPaymentMethod
         )
 
-        dropInConfiguration.paymentMethodsList.allowDisablingStoredPaymentMethods =
-            isRemoveStoredPaymentMethodEnabled
+        dropInConfiguration.paymentMethodsList.allowDisablingStoredPaymentMethods = isRemoveStoredPaymentMethodEnabled
 
         if let shopperLocal = shopperLocale {
-            dropInConfiguration.localizationParameters = LocalizationParameters(
-                enforcedLocale: shopperLocal
-            )
+            dropInConfiguration.localizationParameters = LocalizationParameters(enforcedLocale: shopperLocal)
         }
 
         if let cardConfigurationDTO {
@@ -44,26 +40,19 @@ extension DropInConfigurationDTO {
         }
 
         if let applePayConfigurationDTO {
-            dropInConfiguration.applePay = try applePayConfigurationDTO.toApplePayConfiguration(
-                payment: payment
-            )
+            dropInConfiguration.applePay = try applePayConfigurationDTO.toApplePayConfiguration(payment: payment)
         }
 
         if let cashAppPayConfigurationDTO {
-            dropInConfiguration.cashAppPay = DropInComponent.CashAppPay(
-                redirectURL: URL(string: cashAppPayConfigurationDTO.returnUrl)!
-            )
+            dropInConfiguration.cashAppPay = DropInComponent.CashAppPay(redirectURL: URL(string: cashAppPayConfigurationDTO.returnUrl)!)
         }
 
         if let twintConfigurationDTO {
-            dropInConfiguration.actionComponent.twint = .init(
-                callbackAppScheme: twintConfigurationDTO.iosCallbackAppScheme
-            )
+            dropInConfiguration.actionComponent.twint = .init(callbackAppScheme: twintConfigurationDTO.iosCallbackAppScheme)
         }
 
         if let threeDS2ConfigurationDTO {
-            dropInConfiguration.actionComponent.threeDS =
-                threeDS2ConfigurationDTO.mapToThreeDS2Configuration()
+            dropInConfiguration.actionComponent.threeDS = threeDS2ConfigurationDTO.mapToThreeDS2Configuration()
         }
 
         dropInConfiguration.style = AdyenAppearance.dropInStyle
@@ -73,19 +62,11 @@ extension DropInConfigurationDTO {
 
     private func buildCard(from cardConfigurationDTO: CardConfigurationDTO) -> DropInComponent.Card {
         let koreanAuthenticationMode = cardConfigurationDTO.kcpFieldVisibility.toCardFieldVisibility()
-        let socialSecurityNumberMode = cardConfigurationDTO.socialSecurityNumberFieldVisibility
-            .toCardFieldVisibility()
-        let storedCardConfiguration = createStoredCardConfiguration(
-            showCvcForStoredCard: cardConfigurationDTO.showCvcForStoredCard
-        )
-        let allowedCardTypes = determineAllowedCardTypes(
-            cardTypes: cardConfigurationDTO.supportedCardTypes
-        )
-        let billingAddressConfiguration = determineBillingAddressConfiguration(
-            addressMode: cardConfigurationDTO.addressMode
-        )
-        let installmentConfiguration = cardConfigurationDTO.installmentConfiguration?
-            .mapToInstallmentConfiguration()
+        let socialSecurityNumberMode = cardConfigurationDTO.socialSecurityNumberFieldVisibility.toCardFieldVisibility()
+        let storedCardConfiguration = createStoredCardConfiguration(showCvcForStoredCard: cardConfigurationDTO.showCvcForStoredCard)
+        let allowedCardTypes = determineAllowedCardTypes(cardTypes: cardConfigurationDTO.supportedCardTypes)
+        let billingAddressConfiguration = determineBillingAddressConfiguration(addressMode: cardConfigurationDTO.addressMode)
+        let installmentConfiguration = cardConfigurationDTO.installmentConfiguration?.mapToInstallmentConfiguration()
         return DropInComponent.Card(
             showsHolderNameField: cardConfigurationDTO.holderNameRequired,
             showsStorePaymentMethodField: cardConfigurationDTO.showStorePaymentField,
@@ -113,8 +94,7 @@ extension DropInConfigurationDTO {
         return mappedCardTypes.compactMap { $0 }.map { CardType(rawValue: $0.lowercased()) }
     }
 
-    private func determineBillingAddressConfiguration(addressMode: AddressMode?)
-        -> BillingAddressConfiguration {
+    private func determineBillingAddressConfiguration(addressMode: AddressMode?) -> BillingAddressConfiguration {
         var billingAddressConfiguration = BillingAddressConfiguration()
         switch addressMode {
         case .full:
@@ -158,13 +138,10 @@ extension DropInConfigurationDTO {
 extension CardConfigurationDTO {
     func mapToCardComponentConfiguration(shopperLocale: String?) -> CardComponent.Configuration {
         let cardComponentStyle = AdyenAppearance.cardComponentStyle
-        let localizationParameters =
-            shopperLocale != nil ? LocalizationParameters(enforcedLocale: shopperLocale!) : nil
+        let localizationParameters = shopperLocale != nil ? LocalizationParameters(enforcedLocale: shopperLocale!) : nil
         let koreanAuthenticationMode = kcpFieldVisibility.toCardFieldVisibility()
         let socialSecurityNumberMode = socialSecurityNumberFieldVisibility.toCardFieldVisibility()
-        let storedCardConfiguration = createStoredCardConfiguration(
-            showCvcForStoredCard: showCvcForStoredCard
-        )
+        let storedCardConfiguration = createStoredCardConfiguration(showCvcForStoredCard: showCvcForStoredCard)
         let allowedCardTypes = determineAllowedCardTypes(cardTypes: supportedCardTypes)
         let billingAddressConfiguration = determineBillingAddressConfiguration(addressMode: addressMode)
         let installmentConfiguration = installmentConfiguration?.mapToInstallmentConfiguration()
@@ -197,8 +174,7 @@ extension CardConfigurationDTO {
         return mappedCardTypes.compactMap { $0 }.map { CardType(rawValue: $0.lowercased()) }
     }
 
-    private func determineBillingAddressConfiguration(addressMode: AddressMode?)
-        -> BillingAddressConfiguration {
+    private func determineBillingAddressConfiguration(addressMode: AddressMode?) -> BillingAddressConfiguration {
         var billingAddressConfiguration = BillingAddressConfiguration()
         switch addressMode {
         case .full:
@@ -276,14 +252,10 @@ extension AmountDTO {
 
 extension InstantPaymentConfigurationDTO {
     func mapToApplePayConfiguration(payment: Payment?) throws -> ApplePayComponent.Configuration {
-        guard
-            let applePayConfiguration = try applePayConfigurationDTO?.toApplePayConfiguration(
-                payment: payment
-            )
-        else {
+        guard let applePayConfiguration = try applePayConfigurationDTO?.toApplePayConfiguration(payment: payment) else {
             throw PlatformError(errorDescription: "Apple pay configuration not provided.")
         }
-
+        
         return applePayConfiguration
     }
 
@@ -299,23 +271,18 @@ extension InstantPaymentConfigurationDTO {
     }
 }
 
-private func buildAdyenContext(
-    environment: Environment, clientKey: String, amount: AmountDTO?,
-    analyticsOptionsDTO: AnalyticsOptionsDTO, countryCode: String?, payment: Payment? = nil
-) throws -> AdyenContext {
+private func buildAdyenContext(environment: Environment, clientKey: String, amount: AmountDTO?, analyticsOptionsDTO: AnalyticsOptionsDTO, countryCode: String?, payment: Payment? = nil) throws -> AdyenContext {
     let environment = environment.mapToEnvironment()
     let apiContext = try APIContext(
         environment: environment,
         clientKey: clientKey
     )
-    let payment: Payment? =
-        payment
-            ?? {
-                if let amount, let countryCode {
-                    return Payment(amount: amount.mapToAmount(), countryCode: countryCode)
-                }
-                return nil
-            }()
+    let payment: Payment? = payment ?? {
+        if let amount, let countryCode {
+            return Payment(amount: amount.mapToAmount(), countryCode: countryCode)
+        }
+        return nil
+    }()
     var analyticsConfiguration = AnalyticsConfiguration()
     analyticsConfiguration.isEnabled = analyticsOptionsDTO.enabled
     analyticsConfiguration.context = AnalyticsContext(
@@ -362,10 +329,9 @@ extension PaymentResultEnum {
             .error
         }
     }
-
+    
     private static func isThree3ds2Cancellation(error: NSError) -> Bool {
-        error.domain == ADYRuntimeErrorDomain
-            && error.code == ADYRuntimeErrorCode.challengeCancelled.rawValue
+        error.domain == ADYRuntimeErrorDomain && error.code == ADYRuntimeErrorCode.challengeCancelled.rawValue
     }
 }
 
@@ -374,8 +340,7 @@ extension ResultCode {
         switch self {
         case .authorised, .received, .pending:
             return true
-        case .refused, .cancelled, .error, .redirectShopper, .identifyShopper, .challengeShopper,
-             .presentToShopper:
+        case .refused, .cancelled, .error, .redirectShopper, .identifyShopper, .challengeShopper, .presentToShopper:
             return false
         }
     }
@@ -407,8 +372,7 @@ extension ThreeDS2ConfigurationDTO {
     }
 
     func mapToThreeDS2Configuration() -> AdyenActionComponent.Configuration.ThreeDS {
-        let appearanceConfiguration =
-            uiCustomization?.toAppearanceConfiguration() ?? ADYAppearanceConfiguration()
+        let appearanceConfiguration = uiCustomization?.toAppearanceConfiguration() ?? ADYAppearanceConfiguration()
         guard let requestorAppURL, let url = URL(string: requestorAppURL) else {
             return .init(appearanceConfiguration: appearanceConfiguration)
         }
@@ -482,23 +446,19 @@ extension ThreeDS2LabelCustomizationDTO {
             configuration.labelAppearance.headingTextColor = headingColor
         }
         if let headingTextFontSize {
-            configuration.labelAppearance.headingFont = configuration.labelAppearance.headingFont
-                .withSize(CGFloat(headingTextFontSize))
+            configuration.labelAppearance.headingFont = configuration.labelAppearance.headingFont.withSize(CGFloat(headingTextFontSize))
         }
         if let textColor, let textUIColor = UIColor(hex: textColor) {
             configuration.labelAppearance.textColor = textUIColor
         }
         if let textFontSize {
-            configuration.labelAppearance.font = configuration.labelAppearance.font.withSize(
-                CGFloat(textFontSize)
-            )
+            configuration.labelAppearance.font = configuration.labelAppearance.font.withSize(CGFloat(textFontSize))
         }
         if let inputLabelTextColor, let inputLabelColor = UIColor(hex: inputLabelTextColor) {
             configuration.labelAppearance.subheadingTextColor = inputLabelColor
         }
         if let inputLabelFontSize {
-            configuration.labelAppearance.subheadingFont = configuration.labelAppearance.subheadingFont
-                .withSize(CGFloat(inputLabelFontSize))
+            configuration.labelAppearance.subheadingFont = configuration.labelAppearance.subheadingFont.withSize(CGFloat(inputLabelFontSize))
         }
     }
 }
@@ -526,8 +486,7 @@ extension ThreeDS2SelectionItemCustomizationDTO {
            let tintColor = UIColor(hex: selectionIndicatorTintColor) {
             configuration.selectAppearance.selectionIndicatorTintColor = tintColor
         }
-        if let highlightedBackgroundColor,
-           let backgroundColor = UIColor(hex: highlightedBackgroundColor) {
+        if let highlightedBackgroundColor, let backgroundColor = UIColor(hex: highlightedBackgroundColor) {
             configuration.selectAppearance.highlightedBackgroundColor = backgroundColor
         }
         if let textColor, let textUIColor = UIColor(hex: textColor) {
@@ -563,10 +522,7 @@ extension UIColor {
         var rgb: UInt64 = 0
         Scanner(string: hexSanitized).scanHexInt64(&rgb)
 
-        let red: CGFloat
-        let green: CGFloat
-        let blue: CGFloat
-        let alpha: CGFloat
+        let red, green, blue, alpha: CGFloat
         if hexSanitized.count == 8 {
             alpha = CGFloat((rgb & 0xFF00_0000) >> 24) / 255.0
             red = CGFloat((rgb & 0x00FF_0000) >> 16) / 255.0
@@ -590,7 +546,7 @@ extension InstallmentConfigurationDTO {
         guard defaultOptions != nil || cardBasedOptions != nil else { return nil }
         let cardBasedOptions = cardBasedOptions.flatMap { buildCardBasedInstallmentOptions(from: $0) }
         let defaultOptions = defaultOptions.map { buildDefaultInstallmentOptions(from: $0) }
-
+        
         switch (defaultOptions, cardBasedOptions) {
         case let (defaultOptions?, cardBasedOptions?):
             return InstallmentConfiguration(
@@ -598,27 +554,25 @@ extension InstallmentConfigurationDTO {
                 defaultOptions: defaultOptions,
                 showInstallmentAmount: showInstallmentAmount
             )
-
+            
         case (nil, let cardBasedOptions?):
             return InstallmentConfiguration(
                 cardBasedOptions: cardBasedOptions,
                 showInstallmentAmount: showInstallmentAmount
             )
-
+            
         case (let defaultOptions?, nil):
             return InstallmentConfiguration(
                 defaultOptions: defaultOptions,
                 showInstallmentAmount: showInstallmentAmount
             )
-
+            
         default:
             return nil
         }
     }
-
-    private func buildCardBasedInstallmentOptions(
-        from cardBasedOptions: [CardBasedInstallmentOptionsDTO?]
-    ) -> [CardType: InstallmentOptions]? {
+    
+    private func buildCardBasedInstallmentOptions(from cardBasedOptions: [CardBasedInstallmentOptionsDTO?]) -> [CardType: InstallmentOptions]? {
         var options: [CardType: InstallmentOptions] = [:]
         for cardBasedOption in cardBasedOptions {
             guard let cardBasedOption else { continue }
@@ -631,17 +585,15 @@ extension InstallmentConfigurationDTO {
         }
         return options.isEmpty ? nil : options
     }
-
-    private func buildDefaultInstallmentOptions(from defaultOptions: DefaultInstallmentOptionsDTO)
-        -> InstallmentOptions {
+    
+    private func buildDefaultInstallmentOptions(from defaultOptions: DefaultInstallmentOptionsDTO) -> InstallmentOptions {
         createInstallmentOptions(
             values: defaultOptions.values,
             includesRevolving: defaultOptions.includesRevolving
         )
     }
-
-    private func createInstallmentOptions(values: [Int64?], includesRevolving: Bool)
-        -> InstallmentOptions {
+    
+    private func createInstallmentOptions(values: [Int64?], includesRevolving: Bool) -> InstallmentOptions {
         InstallmentOptions(
             monthValues: values.compactMap { $0 }.map { UInt($0) },
             includesRevolving: includesRevolving

--- a/ios/adyen_checkout/Sources/adyen_checkout/utils/ConfigurationMapper.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/utils/ConfigurationMapper.swift
@@ -2,647 +2,649 @@
 import PassKit
 
 #if canImport(AdyenComponents)
-  import AdyenComponents
+    import AdyenComponents
 #endif
 #if canImport(AdyenDropIn)
-  import AdyenDropIn
+    import AdyenDropIn
 #endif
 #if canImport(AdyenSession)
-  import AdyenSession
+    import AdyenSession
 #endif
 #if canImport(AdyenCard)
-  import AdyenCard
+    import AdyenCard
 #endif
 #if canImport(AdyenEncryption)
-  import AdyenEncryption
+    import AdyenEncryption
 #endif
 #if canImport(Adyen3DS2)
-  import Adyen3DS2
+    import Adyen3DS2
 #endif
 #if canImport(AdyenActions)
-  import AdyenActions
+    import AdyenActions
 #endif
 
 extension DropInConfigurationDTO {
-  func createDropInConfiguration(payment: Payment?) throws -> DropInComponent.Configuration {
-    let dropInConfiguration = DropInComponent.Configuration(
-      allowsSkippingPaymentList: skipListWhenSinglePaymentMethod,
-      allowPreselectedPaymentView: showPreselectedStoredPaymentMethod
-    )
+    func createDropInConfiguration(payment: Payment?) throws -> DropInComponent.Configuration {
+        let dropInConfiguration = DropInComponent.Configuration(
+            allowsSkippingPaymentList: skipListWhenSinglePaymentMethod,
+            allowPreselectedPaymentView: showPreselectedStoredPaymentMethod
+        )
 
-    dropInConfiguration.paymentMethodsList.allowDisablingStoredPaymentMethods =
-      isRemoveStoredPaymentMethodEnabled
+        dropInConfiguration.paymentMethodsList.allowDisablingStoredPaymentMethods =
+            isRemoveStoredPaymentMethodEnabled
 
-    if let shopperLocal = shopperLocale {
-      dropInConfiguration.localizationParameters = LocalizationParameters(
-        enforcedLocale: shopperLocal)
+        if let shopperLocal = shopperLocale {
+            dropInConfiguration.localizationParameters = LocalizationParameters(
+                enforcedLocale: shopperLocal
+            )
+        }
+
+        if let cardConfigurationDTO {
+            dropInConfiguration.card = buildCard(from: cardConfigurationDTO)
+        }
+
+        if let applePayConfigurationDTO {
+            dropInConfiguration.applePay = try applePayConfigurationDTO.toApplePayConfiguration(
+                payment: payment
+            )
+        }
+
+        if let cashAppPayConfigurationDTO {
+            dropInConfiguration.cashAppPay = DropInComponent.CashAppPay(
+                redirectURL: URL(string: cashAppPayConfigurationDTO.returnUrl)!
+            )
+        }
+
+        if let twintConfigurationDTO {
+            dropInConfiguration.actionComponent.twint = .init(
+                callbackAppScheme: twintConfigurationDTO.iosCallbackAppScheme
+            )
+        }
+
+        if let threeDS2ConfigurationDTO {
+            dropInConfiguration.actionComponent.threeDS =
+                threeDS2ConfigurationDTO.mapToThreeDS2Configuration()
+        }
+
+        dropInConfiguration.style = AdyenAppearance.dropInStyle
+
+        return dropInConfiguration
     }
 
-    if let cardConfigurationDTO {
-      dropInConfiguration.card = buildCard(from: cardConfigurationDTO)
+    private func buildCard(from cardConfigurationDTO: CardConfigurationDTO) -> DropInComponent.Card {
+        let koreanAuthenticationMode = cardConfigurationDTO.kcpFieldVisibility.toCardFieldVisibility()
+        let socialSecurityNumberMode = cardConfigurationDTO.socialSecurityNumberFieldVisibility
+            .toCardFieldVisibility()
+        let storedCardConfiguration = createStoredCardConfiguration(
+            showCvcForStoredCard: cardConfigurationDTO.showCvcForStoredCard
+        )
+        let allowedCardTypes = determineAllowedCardTypes(
+            cardTypes: cardConfigurationDTO.supportedCardTypes
+        )
+        let billingAddressConfiguration = determineBillingAddressConfiguration(
+            addressMode: cardConfigurationDTO.addressMode
+        )
+        let installmentConfiguration = cardConfigurationDTO.installmentConfiguration?
+            .mapToInstallmentConfiguration()
+        return DropInComponent.Card(
+            showsHolderNameField: cardConfigurationDTO.holderNameRequired,
+            showsStorePaymentMethodField: cardConfigurationDTO.showStorePaymentField,
+            showsSecurityCodeField: cardConfigurationDTO.showCvc,
+            koreanAuthenticationMode: koreanAuthenticationMode,
+            socialSecurityNumberMode: socialSecurityNumberMode,
+            storedCardConfiguration: storedCardConfiguration,
+            allowedCardTypes: allowedCardTypes,
+            installmentConfiguration: installmentConfiguration,
+            billingAddress: billingAddressConfiguration
+        )
     }
 
-    if let applePayConfigurationDTO {
-      dropInConfiguration.applePay = try applePayConfigurationDTO.toApplePayConfiguration(
-        payment: payment)
+    private func createStoredCardConfiguration(showCvcForStoredCard: Bool) -> StoredCardConfiguration {
+        var storedCardConfiguration = StoredCardConfiguration()
+        storedCardConfiguration.showsSecurityCodeField = showCvcForStoredCard
+        return storedCardConfiguration
     }
 
-    if let cashAppPayConfigurationDTO {
-      dropInConfiguration.cashAppPay = DropInComponent.CashAppPay(
-        redirectURL: URL(string: cashAppPayConfigurationDTO.returnUrl)!)
+    private func determineAllowedCardTypes(cardTypes: [String?]?) -> [CardType]? {
+        guard let mappedCardTypes = cardTypes, !mappedCardTypes.isEmpty else {
+            return nil
+        }
+
+        return mappedCardTypes.compactMap { $0 }.map { CardType(rawValue: $0.lowercased()) }
     }
 
-    if let twintConfigurationDTO {
-      dropInConfiguration.actionComponent.twint = .init(
-        callbackAppScheme: twintConfigurationDTO.iosCallbackAppScheme)
+    private func determineBillingAddressConfiguration(addressMode: AddressMode?)
+        -> BillingAddressConfiguration {
+        var billingAddressConfiguration = BillingAddressConfiguration()
+        switch addressMode {
+        case .full:
+            billingAddressConfiguration.mode = CardComponent.AddressFormType.full
+        case .postalCode:
+            billingAddressConfiguration.mode = CardComponent.AddressFormType.postalCode
+        case .none:
+            billingAddressConfiguration.mode = CardComponent.AddressFormType.none
+        default:
+            billingAddressConfiguration.mode = CardComponent.AddressFormType.none
+        }
+
+        return billingAddressConfiguration
     }
-
-    if let threeDS2ConfigurationDTO {
-      dropInConfiguration.actionComponent.threeDS =
-        threeDS2ConfigurationDTO.mapToThreeDS2Configuration()
-    }
-
-    dropInConfiguration.style = AdyenAppearance.dropInStyle
-
-    return dropInConfiguration
-  }
-
-  private func buildCard(from cardConfigurationDTO: CardConfigurationDTO) -> DropInComponent.Card {
-    let koreanAuthenticationMode = cardConfigurationDTO.kcpFieldVisibility.toCardFieldVisibility()
-    let socialSecurityNumberMode = cardConfigurationDTO.socialSecurityNumberFieldVisibility
-      .toCardFieldVisibility()
-    let storedCardConfiguration = createStoredCardConfiguration(
-      showCvcForStoredCard: cardConfigurationDTO.showCvcForStoredCard)
-    let allowedCardTypes = determineAllowedCardTypes(
-      cardTypes: cardConfigurationDTO.supportedCardTypes)
-    let billingAddressConfiguration = determineBillingAddressConfiguration(
-      addressMode: cardConfigurationDTO.addressMode)
-    let installmentConfiguration = cardConfigurationDTO.installmentConfiguration?
-      .mapToInstallmentConfiguration()
-    return DropInComponent.Card(
-      showsHolderNameField: cardConfigurationDTO.holderNameRequired,
-      showsStorePaymentMethodField: cardConfigurationDTO.showStorePaymentField,
-      showsSecurityCodeField: cardConfigurationDTO.showCvc,
-      koreanAuthenticationMode: koreanAuthenticationMode,
-      socialSecurityNumberMode: socialSecurityNumberMode,
-      storedCardConfiguration: storedCardConfiguration,
-      allowedCardTypes: allowedCardTypes,
-      installmentConfiguration: installmentConfiguration,
-      billingAddress: billingAddressConfiguration
-    )
-  }
-
-  private func createStoredCardConfiguration(showCvcForStoredCard: Bool) -> StoredCardConfiguration
-  {
-    var storedCardConfiguration = StoredCardConfiguration()
-    storedCardConfiguration.showsSecurityCodeField = showCvcForStoredCard
-    return storedCardConfiguration
-  }
-
-  private func determineAllowedCardTypes(cardTypes: [String?]?) -> [CardType]? {
-    guard let mappedCardTypes = cardTypes, !mappedCardTypes.isEmpty else {
-      return nil
-    }
-
-    return mappedCardTypes.compactMap { $0 }.map { CardType(rawValue: $0.lowercased()) }
-  }
-
-  private func determineBillingAddressConfiguration(addressMode: AddressMode?)
-    -> BillingAddressConfiguration
-  {
-    var billingAddressConfiguration = BillingAddressConfiguration()
-    switch addressMode {
-    case .full:
-      billingAddressConfiguration.mode = CardComponent.AddressFormType.full
-    case .postalCode:
-      billingAddressConfiguration.mode = CardComponent.AddressFormType.postalCode
-    case .none:
-      billingAddressConfiguration.mode = CardComponent.AddressFormType.none
-    default:
-      billingAddressConfiguration.mode = CardComponent.AddressFormType.none
-    }
-
-    return billingAddressConfiguration
-  }
 }
 
 extension FieldVisibility {
-  func toCardFieldVisibility() -> CardComponent.FieldVisibility {
-    switch self {
-    case .show:
-      return .show
-    case .hide:
-      return .hide
+    func toCardFieldVisibility() -> CardComponent.FieldVisibility {
+        switch self {
+        case .show:
+            return .show
+        case .hide:
+            return .hide
+        }
     }
-  }
 }
 
 extension DropInConfigurationDTO {
-  func createAdyenContext(payment: Payment? = nil) throws -> AdyenContext {
-    try buildAdyenContext(
-      environment: environment,
-      clientKey: clientKey,
-      amount: amount,
-      analyticsOptionsDTO: analyticsOptionsDTO,
-      countryCode: countryCode,
-      payment: payment
-    )
-  }
+    func createAdyenContext(payment: Payment? = nil) throws -> AdyenContext {
+        try buildAdyenContext(
+            environment: environment,
+            clientKey: clientKey,
+            amount: amount,
+            analyticsOptionsDTO: analyticsOptionsDTO,
+            countryCode: countryCode,
+            payment: payment
+        )
+    }
 }
 
 extension CardConfigurationDTO {
-  func mapToCardComponentConfiguration(shopperLocale: String?) -> CardComponent.Configuration {
-    let cardComponentStyle = AdyenAppearance.cardComponentStyle
-    let localizationParameters =
-      shopperLocale != nil ? LocalizationParameters(enforcedLocale: shopperLocale!) : nil
-    let koreanAuthenticationMode = kcpFieldVisibility.toCardFieldVisibility()
-    let socialSecurityNumberMode = socialSecurityNumberFieldVisibility.toCardFieldVisibility()
-    let storedCardConfiguration = createStoredCardConfiguration(
-      showCvcForStoredCard: showCvcForStoredCard)
-    let allowedCardTypes = determineAllowedCardTypes(cardTypes: supportedCardTypes)
-    let billingAddressConfiguration = determineBillingAddressConfiguration(addressMode: addressMode)
-    let installmentConfiguration = installmentConfiguration?.mapToInstallmentConfiguration()
-    return CardComponent.Configuration(
-      style: cardComponentStyle,
-      localizationParameters: localizationParameters,
-      showsHolderNameField: holderNameRequired,
-      showsStorePaymentMethodField: showStorePaymentField,
-      showsSecurityCodeField: showCvc,
-      koreanAuthenticationMode: koreanAuthenticationMode,
-      socialSecurityNumberMode: socialSecurityNumberMode,
-      storedCardConfiguration: storedCardConfiguration,
-      allowedCardTypes: allowedCardTypes,
-      installmentConfiguration: installmentConfiguration,
-      billingAddress: billingAddressConfiguration
-    )
-  }
-
-  private func createStoredCardConfiguration(showCvcForStoredCard: Bool) -> StoredCardConfiguration
-  {
-    var storedCardConfiguration = StoredCardConfiguration()
-    storedCardConfiguration.showsSecurityCodeField = showCvcForStoredCard
-    return storedCardConfiguration
-  }
-
-  private func determineAllowedCardTypes(cardTypes: [String?]?) -> [CardType]? {
-    guard let mappedCardTypes = cardTypes, !mappedCardTypes.isEmpty else {
-      return nil
+    func mapToCardComponentConfiguration(shopperLocale: String?) -> CardComponent.Configuration {
+        let cardComponentStyle = AdyenAppearance.cardComponentStyle
+        let localizationParameters =
+            shopperLocale != nil ? LocalizationParameters(enforcedLocale: shopperLocale!) : nil
+        let koreanAuthenticationMode = kcpFieldVisibility.toCardFieldVisibility()
+        let socialSecurityNumberMode = socialSecurityNumberFieldVisibility.toCardFieldVisibility()
+        let storedCardConfiguration = createStoredCardConfiguration(
+            showCvcForStoredCard: showCvcForStoredCard
+        )
+        let allowedCardTypes = determineAllowedCardTypes(cardTypes: supportedCardTypes)
+        let billingAddressConfiguration = determineBillingAddressConfiguration(addressMode: addressMode)
+        let installmentConfiguration = installmentConfiguration?.mapToInstallmentConfiguration()
+        return CardComponent.Configuration(
+            style: cardComponentStyle,
+            localizationParameters: localizationParameters,
+            showsHolderNameField: holderNameRequired,
+            showsStorePaymentMethodField: showStorePaymentField,
+            showsSecurityCodeField: showCvc,
+            koreanAuthenticationMode: koreanAuthenticationMode,
+            socialSecurityNumberMode: socialSecurityNumberMode,
+            storedCardConfiguration: storedCardConfiguration,
+            allowedCardTypes: allowedCardTypes,
+            installmentConfiguration: installmentConfiguration,
+            billingAddress: billingAddressConfiguration
+        )
     }
 
-    return mappedCardTypes.compactMap { $0 }.map { CardType(rawValue: $0.lowercased()) }
-  }
-
-  private func determineBillingAddressConfiguration(addressMode: AddressMode?)
-    -> BillingAddressConfiguration
-  {
-    var billingAddressConfiguration = BillingAddressConfiguration()
-    switch addressMode {
-    case .full:
-      billingAddressConfiguration.mode = CardComponent.AddressFormType.full
-    case .postalCode:
-      billingAddressConfiguration.mode = CardComponent.AddressFormType.postalCode
-    case .none:
-      billingAddressConfiguration.mode = CardComponent.AddressFormType.none
-    default:
-      billingAddressConfiguration.mode = CardComponent.AddressFormType.none
+    private func createStoredCardConfiguration(showCvcForStoredCard: Bool) -> StoredCardConfiguration {
+        var storedCardConfiguration = StoredCardConfiguration()
+        storedCardConfiguration.showsSecurityCodeField = showCvcForStoredCard
+        return storedCardConfiguration
     }
 
-    return billingAddressConfiguration
-  }
+    private func determineAllowedCardTypes(cardTypes: [String?]?) -> [CardType]? {
+        guard let mappedCardTypes = cardTypes, !mappedCardTypes.isEmpty else {
+            return nil
+        }
+
+        return mappedCardTypes.compactMap { $0 }.map { CardType(rawValue: $0.lowercased()) }
+    }
+
+    private func determineBillingAddressConfiguration(addressMode: AddressMode?)
+        -> BillingAddressConfiguration {
+        var billingAddressConfiguration = BillingAddressConfiguration()
+        switch addressMode {
+        case .full:
+            billingAddressConfiguration.mode = CardComponent.AddressFormType.full
+        case .postalCode:
+            billingAddressConfiguration.mode = CardComponent.AddressFormType.postalCode
+        case .none:
+            billingAddressConfiguration.mode = CardComponent.AddressFormType.none
+        default:
+            billingAddressConfiguration.mode = CardComponent.AddressFormType.none
+        }
+
+        return billingAddressConfiguration
+    }
 }
 
 extension CardComponentConfigurationDTO {
-  func createAdyenContext() throws -> AdyenContext {
-    try buildAdyenContext(
-      environment: environment,
-      clientKey: clientKey,
-      amount: amount,
-      analyticsOptionsDTO: analyticsOptionsDTO,
-      countryCode: countryCode
-    )
-  }
+    func createAdyenContext() throws -> AdyenContext {
+        try buildAdyenContext(
+            environment: environment,
+            clientKey: clientKey,
+            amount: amount,
+            analyticsOptionsDTO: analyticsOptionsDTO,
+            countryCode: countryCode
+        )
+    }
 }
 
 extension BlikComponentConfigurationDTO {
-  func createAdyenContext() throws -> AdyenContext {
-    try buildAdyenContext(
-      environment: environment,
-      clientKey: clientKey,
-      amount: amount,
-      analyticsOptionsDTO: analyticsOptionsDTO,
-      countryCode: countryCode
-    )
-  }
+    func createAdyenContext() throws -> AdyenContext {
+        try buildAdyenContext(
+            environment: environment,
+            clientKey: clientKey,
+            amount: amount,
+            analyticsOptionsDTO: analyticsOptionsDTO,
+            countryCode: countryCode
+        )
+    }
 
-  func mapToBlikComponentConfiguration() -> BLIKComponent.Configuration {
-    let localizationParameters = shopperLocale.map { LocalizationParameters(enforcedLocale: $0) }
-    return BLIKComponent.Configuration(
-      style: AdyenAppearance.blikComponentStyle,
-      localizationParameters: localizationParameters
-    )
-  }
+    func mapToBlikComponentConfiguration() -> BLIKComponent.Configuration {
+        let localizationParameters = shopperLocale.map { LocalizationParameters(enforcedLocale: $0) }
+        return BLIKComponent.Configuration(
+            style: AdyenAppearance.blikComponentStyle,
+            localizationParameters: localizationParameters
+        )
+    }
 }
 
 extension Environment {
-  func mapToEnvironment() -> Adyen.Environment {
-    switch self {
-    case .test:
-      return Adyen.Environment.test
-    case .europe:
-      return .liveEurope
-    case .unitedStates:
-      return .liveUnitedStates
-    case .australia:
-      return .liveAustralia
-    case .india:
-      return .liveIndia
-    case .apse:
-      return .liveApse
-    case .nea:
-      return .liveNea
+    func mapToEnvironment() -> Adyen.Environment {
+        switch self {
+        case .test:
+            return Adyen.Environment.test
+        case .europe:
+            return .liveEurope
+        case .unitedStates:
+            return .liveUnitedStates
+        case .australia:
+            return .liveAustralia
+        case .india:
+            return .liveIndia
+        case .apse:
+            return .liveApse
+        case .nea:
+            return .liveNea
+        }
     }
-  }
 }
 
 extension AmountDTO {
-  func mapToAmount() -> Adyen.Amount {
-    Adyen.Amount(value: Int(value), currencyCode: currency)
-  }
+    func mapToAmount() -> Adyen.Amount {
+        Adyen.Amount(value: Int(value), currencyCode: currency)
+    }
 }
 
 extension InstantPaymentConfigurationDTO {
-  func mapToApplePayConfiguration(payment: Payment?) throws -> ApplePayComponent.Configuration {
-    guard
-      let applePayConfiguration = try applePayConfigurationDTO?.toApplePayConfiguration(
-        payment: payment)
-    else {
-      throw PlatformError(errorDescription: "Apple pay configuration not provided.")
+    func mapToApplePayConfiguration(payment: Payment?) throws -> ApplePayComponent.Configuration {
+        guard
+            let applePayConfiguration = try applePayConfigurationDTO?.toApplePayConfiguration(
+                payment: payment
+            )
+        else {
+            throw PlatformError(errorDescription: "Apple pay configuration not provided.")
+        }
+
+        return applePayConfiguration
     }
 
-    return applePayConfiguration
-  }
-
-  func createAdyenContext(payment: Payment? = nil) throws -> AdyenContext {
-    try buildAdyenContext(
-      environment: environment,
-      clientKey: clientKey,
-      amount: amount,
-      analyticsOptionsDTO: analyticsOptionsDTO,
-      countryCode: countryCode,
-      payment: payment
-    )
-  }
+    func createAdyenContext(payment: Payment? = nil) throws -> AdyenContext {
+        try buildAdyenContext(
+            environment: environment,
+            clientKey: clientKey,
+            amount: amount,
+            analyticsOptionsDTO: analyticsOptionsDTO,
+            countryCode: countryCode,
+            payment: payment
+        )
+    }
 }
 
 private func buildAdyenContext(
-  environment: Environment, clientKey: String, amount: AmountDTO?,
-  analyticsOptionsDTO: AnalyticsOptionsDTO, countryCode: String?, payment: Payment? = nil
+    environment: Environment, clientKey: String, amount: AmountDTO?,
+    analyticsOptionsDTO: AnalyticsOptionsDTO, countryCode: String?, payment: Payment? = nil
 ) throws -> AdyenContext {
-  let environment = environment.mapToEnvironment()
-  let apiContext = try APIContext(
-    environment: environment,
-    clientKey: clientKey
-  )
-  let payment: Payment? =
-    payment
-    ?? {
-      if let amount, let countryCode {
-        return Payment(amount: amount.mapToAmount(), countryCode: countryCode)
-      }
-      return nil
-    }()
-  var analyticsConfiguration = AnalyticsConfiguration()
-  analyticsConfiguration.isEnabled = analyticsOptionsDTO.enabled
-  analyticsConfiguration.context = AnalyticsContext(
-    version: analyticsOptionsDTO.version,
-    platform: .flutter
-  )
+    let environment = environment.mapToEnvironment()
+    let apiContext = try APIContext(
+        environment: environment,
+        clientKey: clientKey
+    )
+    let payment: Payment? =
+        payment
+            ?? {
+                if let amount, let countryCode {
+                    return Payment(amount: amount.mapToAmount(), countryCode: countryCode)
+                }
+                return nil
+            }()
+    var analyticsConfiguration = AnalyticsConfiguration()
+    analyticsConfiguration.isEnabled = analyticsOptionsDTO.enabled
+    analyticsConfiguration.context = AnalyticsContext(
+        version: analyticsOptionsDTO.version,
+        platform: .flutter
+    )
 
-  return AdyenContext(
-    apiContext: apiContext,
-    payment: payment,
-    analyticsConfiguration: analyticsConfiguration
-  )
+    return AdyenContext(
+        apiContext: apiContext,
+        payment: payment,
+        analyticsConfiguration: analyticsConfiguration
+    )
 }
 
 extension UnencryptedCardDTO {
-  func mapToUnencryptedCard() -> Card {
-    Card(
-      number: cardNumber,
-      securityCode: cvc,
-      expiryMonth: expiryMonth,
-      expiryYear: expiryYear
-    )
-  }
+    func mapToUnencryptedCard() -> Card {
+        Card(
+            number: cardNumber,
+            securityCode: cvc,
+            expiryMonth: expiryMonth,
+            expiryYear: expiryYear
+        )
+    }
 }
 
 extension EncryptedCard {
-  func mapToEncryptedCardDTO() -> EncryptedCardDTO {
-    EncryptedCardDTO(
-      encryptedCardNumber: number,
-      encryptedExpiryMonth: expiryMonth,
-      encryptedExpiryYear: expiryYear,
-      encryptedSecurityCode: securityCode
-    )
-  }
+    func mapToEncryptedCardDTO() -> EncryptedCardDTO {
+        EncryptedCardDTO(
+            encryptedCardNumber: number,
+            encryptedExpiryMonth: expiryMonth,
+            encryptedExpiryYear: expiryYear,
+            encryptedSecurityCode: securityCode
+        )
+    }
 }
 
 extension PaymentResultEnum {
-  static func from(error: Error) -> Self {
-    if let componentError = (error as? ComponentError), componentError == ComponentError.cancelled {
-      .cancelledByUser
-    } else if isThree3ds2Cancellation(error: error as NSError) {
-      .cancelledByUser
-    } else {
-      .error
+    static func from(error: Error) -> Self {
+        if let componentError = (error as? ComponentError), componentError == ComponentError.cancelled {
+            .cancelledByUser
+        } else if isThree3ds2Cancellation(error: error as NSError) {
+            .cancelledByUser
+        } else {
+            .error
+        }
     }
-  }
 
-  private static func isThree3ds2Cancellation(error: NSError) -> Bool {
-    error.domain == ADYRuntimeErrorDomain
-      && error.code == ADYRuntimeErrorCode.challengeCancelled.rawValue
-  }
+    private static func isThree3ds2Cancellation(error: NSError) -> Bool {
+        error.domain == ADYRuntimeErrorDomain
+            && error.code == ADYRuntimeErrorCode.challengeCancelled.rawValue
+    }
 }
 
 extension ResultCode {
-  var isAccepted: Bool {
-    switch self {
-    case .authorised, .received, .pending:
-      return true
-    case .refused, .cancelled, .error, .redirectShopper, .identifyShopper, .challengeShopper,
-      .presentToShopper:
-      return false
+    var isAccepted: Bool {
+        switch self {
+        case .authorised, .received, .pending:
+            return true
+        case .refused, .cancelled, .error, .redirectShopper, .identifyShopper, .challengeShopper,
+             .presentToShopper:
+            return false
+        }
     }
-  }
 }
 
 extension AdyenSession.Context {
-  func createPayment(fallbackCountryCode: String) -> Payment {
-    Payment(amount: amount, countryCode: countryCode ?? fallbackCountryCode)
-  }
+    func createPayment(fallbackCountryCode: String) -> Payment {
+        Payment(amount: amount, countryCode: countryCode ?? fallbackCountryCode)
+    }
 }
 
 extension ActionComponentConfigurationDTO {
-  func createAdyenContext() throws -> AdyenContext {
-    try buildAdyenContext(
-      environment: environment,
-      clientKey: clientKey,
-      amount: nil,
-      analyticsOptionsDTO: analyticsOptionsDTO,
-      countryCode: nil
-    )
-  }
+    func createAdyenContext() throws -> AdyenContext {
+        try buildAdyenContext(
+            environment: environment,
+            clientKey: clientKey,
+            amount: nil,
+            analyticsOptionsDTO: analyticsOptionsDTO,
+            countryCode: nil
+        )
+    }
 }
 
 extension ThreeDS2ConfigurationDTO {
-  func buildActionComponentConfiguration() -> AdyenActionComponent.Configuration {
-    var actionComponentConfiguration = AdyenActionComponent.Configuration()
-    actionComponentConfiguration.threeDS = mapToThreeDS2Configuration()
-    return actionComponentConfiguration
-  }
-
-  func mapToThreeDS2Configuration() -> AdyenActionComponent.Configuration.ThreeDS {
-    let appearanceConfiguration =
-      uiCustomization?.toAppearanceConfiguration() ?? ADYAppearanceConfiguration()
-    guard let requestorAppURL, let url = URL(string: requestorAppURL) else {
-      return .init(appearanceConfiguration: appearanceConfiguration)
+    func buildActionComponentConfiguration() -> AdyenActionComponent.Configuration {
+        var actionComponentConfiguration = AdyenActionComponent.Configuration()
+        actionComponentConfiguration.threeDS = mapToThreeDS2Configuration()
+        return actionComponentConfiguration
     }
-    return .init(requestorAppURL: url, appearanceConfiguration: appearanceConfiguration)
-  }
+
+    func mapToThreeDS2Configuration() -> AdyenActionComponent.Configuration.ThreeDS {
+        let appearanceConfiguration =
+            uiCustomization?.toAppearanceConfiguration() ?? ADYAppearanceConfiguration()
+        guard let requestorAppURL, let url = URL(string: requestorAppURL) else {
+            return .init(appearanceConfiguration: appearanceConfiguration)
+        }
+        return .init(requestorAppURL: url, appearanceConfiguration: appearanceConfiguration)
+    }
 }
 
 extension ThreeDS2UICustomizationDTO {
-  func toAppearanceConfiguration() -> ADYAppearanceConfiguration {
-    let configuration = ADYAppearanceConfiguration()
-    if let screenCustomization {
-      screenCustomization.apply(to: configuration)
+    func toAppearanceConfiguration() -> ADYAppearanceConfiguration {
+        let configuration = ADYAppearanceConfiguration()
+        if let screenCustomization {
+            screenCustomization.apply(to: configuration)
+        }
+        if let headingCustomization {
+            headingCustomization.apply(to: configuration)
+        }
+        if let labelCustomization {
+            labelCustomization.apply(to: configuration)
+        }
+        if let inputCustomization {
+            inputCustomization.apply(to: configuration)
+        }
+        if let selectionItemCustomization {
+            selectionItemCustomization.apply(to: configuration)
+        }
+        primaryButtonCustomization?.apply(to: configuration, buttonType: .submit)
+        primaryButtonCustomization?.apply(to: configuration, buttonType: .continue)
+        primaryButtonCustomization?.apply(to: configuration, buttonType: .next)
+        secondaryButtonCustomization?.apply(to: configuration, buttonType: .cancel)
+        secondaryButtonCustomization?.apply(to: configuration, buttonType: .resend)
+        secondaryButtonCustomization?.apply(to: configuration, buttonType: .OOB)
+        return configuration
     }
-    if let headingCustomization {
-      headingCustomization.apply(to: configuration)
-    }
-    if let labelCustomization {
-      labelCustomization.apply(to: configuration)
-    }
-    if let inputCustomization {
-      inputCustomization.apply(to: configuration)
-    }
-    if let selectionItemCustomization {
-      selectionItemCustomization.apply(to: configuration)
-    }
-    primaryButtonCustomization?.apply(to: configuration, buttonType: .submit)
-    primaryButtonCustomization?.apply(to: configuration, buttonType: .continue)
-    primaryButtonCustomization?.apply(to: configuration, buttonType: .next)
-    secondaryButtonCustomization?.apply(to: configuration, buttonType: .cancel)
-    secondaryButtonCustomization?.apply(to: configuration, buttonType: .resend)
-    secondaryButtonCustomization?.apply(to: configuration, buttonType: .OOB)
-    return configuration
-  }
 }
 
 extension ThreeDS2ScreenCustomizationDTO {
-  func apply(to configuration: ADYAppearanceConfiguration) {
-    if let backgroundColor, let bgColor = UIColor(hex: backgroundColor) {
-      configuration.backgroundColor = bgColor
+    func apply(to configuration: ADYAppearanceConfiguration) {
+        if let backgroundColor, let bgColor = UIColor(hex: backgroundColor) {
+            configuration.backgroundColor = bgColor
+        }
+        // Apply general text styling as fallback for labels
+        if let textColor, let textUIColor = UIColor(hex: textColor) {
+            configuration.textColor = textUIColor
+            configuration.tintColor = textUIColor
+            configuration.infoAppearance.headingTextColor = textUIColor
+            configuration.infoAppearance.textColor = textUIColor
+        }
     }
-    // Apply general text styling as fallback for labels
-    if let textColor, let textUIColor = UIColor(hex: textColor) {
-      configuration.textColor = textUIColor
-      configuration.tintColor = textUIColor
-      configuration.infoAppearance.headingTextColor = textUIColor
-      configuration.infoAppearance.textColor = textUIColor
-    }
-  }
 }
 
 extension ThreeDS2ToolbarCustomizationDTO {
-  func apply(to configuration: ADYAppearanceConfiguration) {
-    if let backgroundColor, let backgroundColor = UIColor(hex: backgroundColor) {
-      configuration.navigationBarAppearance.backgroundColor = backgroundColor
+    func apply(to configuration: ADYAppearanceConfiguration) {
+        if let backgroundColor, let backgroundColor = UIColor(hex: backgroundColor) {
+            configuration.navigationBarAppearance.backgroundColor = backgroundColor
+        }
+        if let textColor, let textUIColor = UIColor(hex: textColor) {
+            configuration.navigationBarAppearance.textColor = textUIColor
+        }
+        if let headerText {
+            configuration.navigationBarAppearance.title = headerText
+        }
+        if let cancelButtonColor, let cancelTextColor = UIColor(hex: cancelButtonColor) {
+            configuration.buttonAppearance(for: .cancel).textColor = cancelTextColor
+        }
     }
-    if let textColor, let textUIColor = UIColor(hex: textColor) {
-      configuration.navigationBarAppearance.textColor = textUIColor
-    }
-    if let headerText {
-      configuration.navigationBarAppearance.title = headerText
-    }
-    if let cancelButtonColor, let cancelTextColor = UIColor(hex: cancelButtonColor) {
-      configuration.buttonAppearance(for: .cancel).textColor = cancelTextColor
-    }
-  }
 }
 
 extension ThreeDS2LabelCustomizationDTO {
-  func apply(to configuration: ADYAppearanceConfiguration) {
-    if let headingTextColor, let headingColor = UIColor(hex: headingTextColor) {
-      configuration.labelAppearance.headingTextColor = headingColor
+    func apply(to configuration: ADYAppearanceConfiguration) {
+        if let headingTextColor, let headingColor = UIColor(hex: headingTextColor) {
+            configuration.labelAppearance.headingTextColor = headingColor
+        }
+        if let headingTextFontSize {
+            configuration.labelAppearance.headingFont = configuration.labelAppearance.headingFont
+                .withSize(CGFloat(headingTextFontSize))
+        }
+        if let textColor, let textUIColor = UIColor(hex: textColor) {
+            configuration.labelAppearance.textColor = textUIColor
+        }
+        if let textFontSize {
+            configuration.labelAppearance.font = configuration.labelAppearance.font.withSize(
+                CGFloat(textFontSize)
+            )
+        }
+        if let inputLabelTextColor, let inputLabelColor = UIColor(hex: inputLabelTextColor) {
+            configuration.labelAppearance.subheadingTextColor = inputLabelColor
+        }
+        if let inputLabelFontSize {
+            configuration.labelAppearance.subheadingFont = configuration.labelAppearance.subheadingFont
+                .withSize(CGFloat(inputLabelFontSize))
+        }
     }
-    if let headingTextFontSize {
-      configuration.labelAppearance.headingFont = configuration.labelAppearance.headingFont
-        .withSize(CGFloat(headingTextFontSize))
-    }
-    if let textColor, let textUIColor = UIColor(hex: textColor) {
-      configuration.labelAppearance.textColor = textUIColor
-    }
-    if let textFontSize {
-      configuration.labelAppearance.font = configuration.labelAppearance.font.withSize(
-        CGFloat(textFontSize))
-    }
-    if let inputLabelTextColor, let inputLabelColor = UIColor(hex: inputLabelTextColor) {
-      configuration.labelAppearance.subheadingTextColor = inputLabelColor
-    }
-    if let inputLabelFontSize {
-      configuration.labelAppearance.subheadingFont = configuration.labelAppearance.subheadingFont
-        .withSize(CGFloat(inputLabelFontSize))
-    }
-  }
 }
 
 extension ThreeDS2InputCustomizationDTO {
-  func apply(to configuration: ADYAppearanceConfiguration) {
-    if let borderColor, let boarderUIColor = UIColor(hex: borderColor) {
-      configuration.textFieldAppearance.borderColor = boarderUIColor
+    func apply(to configuration: ADYAppearanceConfiguration) {
+        if let borderColor, let boarderUIColor = UIColor(hex: borderColor) {
+            configuration.textFieldAppearance.borderColor = boarderUIColor
+        }
+        if let borderWidth {
+            configuration.textFieldAppearance.borderWidth = CGFloat(borderWidth)
+        }
+        if let cornerRadius {
+            configuration.textFieldAppearance.cornerRadius = CGFloat(cornerRadius)
+        }
+        if let textColor, let textUIColor = UIColor(hex: textColor) {
+            configuration.textFieldAppearance.textColor = textUIColor
+        }
     }
-    if let borderWidth {
-      configuration.textFieldAppearance.borderWidth = CGFloat(borderWidth)
-    }
-    if let cornerRadius {
-      configuration.textFieldAppearance.cornerRadius = CGFloat(cornerRadius)
-    }
-    if let textColor, let textUIColor = UIColor(hex: textColor) {
-      configuration.textFieldAppearance.textColor = textUIColor
-    }
-  }
 }
 
 extension ThreeDS2SelectionItemCustomizationDTO {
-  func apply(to configuration: ADYAppearanceConfiguration) {
-    if let selectionIndicatorTintColor,
-      let tintColor = UIColor(hex: selectionIndicatorTintColor)
-    {
-      configuration.selectAppearance.selectionIndicatorTintColor = tintColor
+    func apply(to configuration: ADYAppearanceConfiguration) {
+        if let selectionIndicatorTintColor,
+           let tintColor = UIColor(hex: selectionIndicatorTintColor) {
+            configuration.selectAppearance.selectionIndicatorTintColor = tintColor
+        }
+        if let highlightedBackgroundColor,
+           let backgroundColor = UIColor(hex: highlightedBackgroundColor) {
+            configuration.selectAppearance.highlightedBackgroundColor = backgroundColor
+        }
+        if let textColor, let textUIColor = UIColor(hex: textColor) {
+            configuration.selectAppearance.textColor = textUIColor
+        }
     }
-    if let highlightedBackgroundColor,
-      let backgroundColor = UIColor(hex: highlightedBackgroundColor)
-    {
-      configuration.selectAppearance.highlightedBackgroundColor = backgroundColor
-    }
-    if let textColor, let textUIColor = UIColor(hex: textColor) {
-      configuration.selectAppearance.textColor = textUIColor
-    }
-  }
 }
 
 extension ThreeDS2ButtonCustomizationDTO {
-  func apply(to configuration: ADYAppearanceConfiguration, buttonType: ADYAppearanceButtonType) {
-    let buttonAppearance = configuration.buttonAppearance(for: buttonType)
+    func apply(to configuration: ADYAppearanceConfiguration, buttonType: ADYAppearanceButtonType) {
+        let buttonAppearance = configuration.buttonAppearance(for: buttonType)
 
-    if let backgroundColor, let buttonColor = UIColor(hex: backgroundColor) {
-      buttonAppearance.backgroundColor = buttonColor
+        if let backgroundColor, let buttonColor = UIColor(hex: backgroundColor) {
+            buttonAppearance.backgroundColor = buttonColor
+        }
+        if let textColor, let textUIColor = UIColor(hex: textColor) {
+            buttonAppearance.textColor = textUIColor
+        }
+        if let cornerRadius {
+            buttonAppearance.cornerRadius = CGFloat(cornerRadius)
+        }
+        if let textFontSize {
+            buttonAppearance.font = buttonAppearance.font.withSize(CGFloat(textFontSize))
+        }
     }
-    if let textColor, let textUIColor = UIColor(hex: textColor) {
-      buttonAppearance.textColor = textUIColor
-    }
-    if let cornerRadius {
-      buttonAppearance.cornerRadius = CGFloat(cornerRadius)
-    }
-    if let textFontSize {
-      buttonAppearance.font = buttonAppearance.font.withSize(CGFloat(textFontSize))
-    }
-  }
 }
 
 extension UIColor {
-  convenience init?(hex: String) {
-    var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-    hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+    convenience init?(hex: String) {
+        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
 
-    var rgb: UInt64 = 0
-    Scanner(string: hexSanitized).scanHexInt64(&rgb)
+        var rgb: UInt64 = 0
+        Scanner(string: hexSanitized).scanHexInt64(&rgb)
 
-    let red: CGFloat
-    let green: CGFloat
-    let blue: CGFloat
-    let alpha: CGFloat
-    if hexSanitized.count == 8 {
-      alpha = CGFloat((rgb & 0xFF00_0000) >> 24) / 255.0
-      red = CGFloat((rgb & 0x00FF_0000) >> 16) / 255.0
-      green = CGFloat((rgb & 0x0000_FF00) >> 8) / 255.0
-      blue = CGFloat(rgb & 0x0000_00FF) / 255.0
-    } else if hexSanitized.count == 6 {
-      red = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
-      green = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
-      blue = CGFloat(rgb & 0x0000FF) / 255.0
-      alpha = 1.0
-    } else {
-      return nil
+        let red: CGFloat
+        let green: CGFloat
+        let blue: CGFloat
+        let alpha: CGFloat
+        if hexSanitized.count == 8 {
+            alpha = CGFloat((rgb & 0xFF00_0000) >> 24) / 255.0
+            red = CGFloat((rgb & 0x00FF_0000) >> 16) / 255.0
+            green = CGFloat((rgb & 0x0000_FF00) >> 8) / 255.0
+            blue = CGFloat(rgb & 0x0000_00FF) / 255.0
+        } else if hexSanitized.count == 6 {
+            red = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
+            green = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
+            blue = CGFloat(rgb & 0x0000FF) / 255.0
+            alpha = 1.0
+        } else {
+            return nil
+        }
+
+        self.init(red: red, green: green, blue: blue, alpha: alpha)
     }
-
-    self.init(red: red, green: green, blue: blue, alpha: alpha)
-  }
 }
 
 extension InstallmentConfigurationDTO {
-  func mapToInstallmentConfiguration() -> InstallmentConfiguration? {
-    guard defaultOptions != nil || cardBasedOptions != nil else { return nil }
-    let cardBasedOptions = cardBasedOptions.flatMap { buildCardBasedInstallmentOptions(from: $0) }
-    let defaultOptions = defaultOptions.map { buildDefaultInstallmentOptions(from: $0) }
+    func mapToInstallmentConfiguration() -> InstallmentConfiguration? {
+        guard defaultOptions != nil || cardBasedOptions != nil else { return nil }
+        let cardBasedOptions = cardBasedOptions.flatMap { buildCardBasedInstallmentOptions(from: $0) }
+        let defaultOptions = defaultOptions.map { buildDefaultInstallmentOptions(from: $0) }
 
-    switch (defaultOptions, cardBasedOptions) {
-    case (let defaultOptions?, let cardBasedOptions?):
-      return InstallmentConfiguration(
-        cardBasedOptions: cardBasedOptions,
-        defaultOptions: defaultOptions,
-        showInstallmentAmount: showInstallmentAmount
-      )
+        switch (defaultOptions, cardBasedOptions) {
+        case let (defaultOptions?, cardBasedOptions?):
+            return InstallmentConfiguration(
+                cardBasedOptions: cardBasedOptions,
+                defaultOptions: defaultOptions,
+                showInstallmentAmount: showInstallmentAmount
+            )
 
-    case (nil, let cardBasedOptions?):
-      return InstallmentConfiguration(
-        cardBasedOptions: cardBasedOptions,
-        showInstallmentAmount: showInstallmentAmount
-      )
+        case (nil, let cardBasedOptions?):
+            return InstallmentConfiguration(
+                cardBasedOptions: cardBasedOptions,
+                showInstallmentAmount: showInstallmentAmount
+            )
 
-    case (let defaultOptions?, nil):
-      return InstallmentConfiguration(
-        defaultOptions: defaultOptions,
-        showInstallmentAmount: showInstallmentAmount
-      )
+        case (let defaultOptions?, nil):
+            return InstallmentConfiguration(
+                defaultOptions: defaultOptions,
+                showInstallmentAmount: showInstallmentAmount
+            )
 
-    default:
-      return nil
+        default:
+            return nil
+        }
     }
-  }
 
-  private func buildCardBasedInstallmentOptions(
-    from cardBasedOptions: [CardBasedInstallmentOptionsDTO?]
-  ) -> [CardType: InstallmentOptions]? {
-    var options: [CardType: InstallmentOptions] = [:]
-    for cardBasedOption in cardBasedOptions {
-      guard let cardBasedOption else { continue }
-      let cardBrandRaw = cardBasedOption.cardBrand
-      let cardType = CardType(rawValue: cardBrandRaw)
-      options[cardType] = createInstallmentOptions(
-        values: cardBasedOption.values,
-        includesRevolving: cardBasedOption.includesRevolving
-      )
+    private func buildCardBasedInstallmentOptions(
+        from cardBasedOptions: [CardBasedInstallmentOptionsDTO?]
+    ) -> [CardType: InstallmentOptions]? {
+        var options: [CardType: InstallmentOptions] = [:]
+        for cardBasedOption in cardBasedOptions {
+            guard let cardBasedOption else { continue }
+            let cardBrandRaw = cardBasedOption.cardBrand
+            let cardType = CardType(rawValue: cardBrandRaw)
+            options[cardType] = createInstallmentOptions(
+                values: cardBasedOption.values,
+                includesRevolving: cardBasedOption.includesRevolving
+            )
+        }
+        return options.isEmpty ? nil : options
     }
-    return options.isEmpty ? nil : options
-  }
 
-  private func buildDefaultInstallmentOptions(from defaultOptions: DefaultInstallmentOptionsDTO)
-    -> InstallmentOptions
-  {
-    createInstallmentOptions(
-      values: defaultOptions.values,
-      includesRevolving: defaultOptions.includesRevolving
-    )
-  }
+    private func buildDefaultInstallmentOptions(from defaultOptions: DefaultInstallmentOptionsDTO)
+        -> InstallmentOptions {
+        createInstallmentOptions(
+            values: defaultOptions.values,
+            includesRevolving: defaultOptions.includesRevolving
+        )
+    }
 
-  private func createInstallmentOptions(values: [Int64?], includesRevolving: Bool)
-    -> InstallmentOptions
-  {
-    InstallmentOptions(
-      monthValues: values.compactMap { $0 }.map { UInt($0) },
-      includesRevolving: includesRevolving
-    )
-  }
+    private func createInstallmentOptions(values: [Int64?], includesRevolving: Bool)
+        -> InstallmentOptions {
+        InstallmentOptions(
+            monthValues: values.compactMap { $0 }.map { UInt($0) },
+            includesRevolving: includesRevolving
+        )
+    }
 }

--- a/ios/adyen_checkout/Sources/adyen_checkout/utils/ConfigurationMapper.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/utils/ConfigurationMapper.swift
@@ -1,596 +1,648 @@
 @_spi(AdyenInternal) import Adyen
 import PassKit
+
 #if canImport(AdyenComponents)
-    import AdyenComponents
+  import AdyenComponents
 #endif
 #if canImport(AdyenDropIn)
-    import AdyenDropIn
+  import AdyenDropIn
 #endif
 #if canImport(AdyenSession)
-    import AdyenSession
+  import AdyenSession
 #endif
 #if canImport(AdyenCard)
-    import AdyenCard
+  import AdyenCard
 #endif
 #if canImport(AdyenEncryption)
-    import AdyenEncryption
+  import AdyenEncryption
 #endif
 #if canImport(Adyen3DS2)
-    import Adyen3DS2
+  import Adyen3DS2
 #endif
 #if canImport(AdyenActions)
-    import AdyenActions
+  import AdyenActions
 #endif
 
 extension DropInConfigurationDTO {
-    func createDropInConfiguration(payment: Payment?) throws -> DropInComponent.Configuration {
-        let dropInConfiguration = DropInComponent.Configuration(
-            allowsSkippingPaymentList: skipListWhenSinglePaymentMethod,
-            allowPreselectedPaymentView: showPreselectedStoredPaymentMethod
-        )
+  func createDropInConfiguration(payment: Payment?) throws -> DropInComponent.Configuration {
+    let dropInConfiguration = DropInComponent.Configuration(
+      allowsSkippingPaymentList: skipListWhenSinglePaymentMethod,
+      allowPreselectedPaymentView: showPreselectedStoredPaymentMethod
+    )
 
-        dropInConfiguration.paymentMethodsList.allowDisablingStoredPaymentMethods = isRemoveStoredPaymentMethodEnabled
+    dropInConfiguration.paymentMethodsList.allowDisablingStoredPaymentMethods =
+      isRemoveStoredPaymentMethodEnabled
 
-        if let shopperLocal = shopperLocale {
-            dropInConfiguration.localizationParameters = LocalizationParameters(enforcedLocale: shopperLocal)
-        }
-
-        if let cardConfigurationDTO {
-            dropInConfiguration.card = buildCard(from: cardConfigurationDTO)
-        }
-
-        if let applePayConfigurationDTO {
-            dropInConfiguration.applePay = try applePayConfigurationDTO.toApplePayConfiguration(payment: payment)
-        }
-
-        if let cashAppPayConfigurationDTO {
-            dropInConfiguration.cashAppPay = DropInComponent.CashAppPay(redirectURL: URL(string: cashAppPayConfigurationDTO.returnUrl)!)
-        }
-
-        if let twintConfigurationDTO {
-            dropInConfiguration.actionComponent.twint = .init(callbackAppScheme: twintConfigurationDTO.iosCallbackAppScheme)
-        }
-
-        if let threeDS2ConfigurationDTO {
-            dropInConfiguration.actionComponent.threeDS = threeDS2ConfigurationDTO.mapToThreeDS2Configuration()
-        }
-
-        dropInConfiguration.style = AdyenAppearance.dropInStyle
-
-        return dropInConfiguration
+    if let shopperLocal = shopperLocale {
+      dropInConfiguration.localizationParameters = LocalizationParameters(
+        enforcedLocale: shopperLocal)
     }
 
-    private func buildCard(from cardConfigurationDTO: CardConfigurationDTO) -> DropInComponent.Card {
-        let koreanAuthenticationMode = cardConfigurationDTO.kcpFieldVisibility.toCardFieldVisibility()
-        let socialSecurityNumberMode = cardConfigurationDTO.socialSecurityNumberFieldVisibility.toCardFieldVisibility()
-        let storedCardConfiguration = createStoredCardConfiguration(showCvcForStoredCard: cardConfigurationDTO.showCvcForStoredCard)
-        let allowedCardTypes = determineAllowedCardTypes(cardTypes: cardConfigurationDTO.supportedCardTypes)
-        let billingAddressConfiguration = determineBillingAddressConfiguration(addressMode: cardConfigurationDTO.addressMode)
-        let installmentConfiguration = cardConfigurationDTO.installmentConfiguration?.mapToInstallmentConfiguration()
-        return DropInComponent.Card(
-            showsHolderNameField: cardConfigurationDTO.holderNameRequired,
-            showsStorePaymentMethodField: cardConfigurationDTO.showStorePaymentField,
-            showsSecurityCodeField: cardConfigurationDTO.showCvc,
-            koreanAuthenticationMode: koreanAuthenticationMode,
-            socialSecurityNumberMode: socialSecurityNumberMode,
-            storedCardConfiguration: storedCardConfiguration,
-            allowedCardTypes: allowedCardTypes,
-            installmentConfiguration: installmentConfiguration,
-            billingAddress: billingAddressConfiguration
-        )
+    if let cardConfigurationDTO {
+      dropInConfiguration.card = buildCard(from: cardConfigurationDTO)
     }
 
-    private func createStoredCardConfiguration(showCvcForStoredCard: Bool) -> StoredCardConfiguration {
-        var storedCardConfiguration = StoredCardConfiguration()
-        storedCardConfiguration.showsSecurityCodeField = showCvcForStoredCard
-        return storedCardConfiguration
+    if let applePayConfigurationDTO {
+      dropInConfiguration.applePay = try applePayConfigurationDTO.toApplePayConfiguration(
+        payment: payment)
     }
 
-    private func determineAllowedCardTypes(cardTypes: [String?]?) -> [CardType]? {
-        guard let mappedCardTypes = cardTypes, !mappedCardTypes.isEmpty else {
-            return nil
-        }
-
-        return mappedCardTypes.compactMap { $0 }.map { CardType(rawValue: $0.lowercased()) }
+    if let cashAppPayConfigurationDTO {
+      dropInConfiguration.cashAppPay = DropInComponent.CashAppPay(
+        redirectURL: URL(string: cashAppPayConfigurationDTO.returnUrl)!)
     }
 
-    private func determineBillingAddressConfiguration(addressMode: AddressMode?) -> BillingAddressConfiguration {
-        var billingAddressConfiguration = BillingAddressConfiguration()
-        switch addressMode {
-        case .full:
-            billingAddressConfiguration.mode = CardComponent.AddressFormType.full
-        case .postalCode:
-            billingAddressConfiguration.mode = CardComponent.AddressFormType.postalCode
-        case .none:
-            billingAddressConfiguration.mode = CardComponent.AddressFormType.none
-        default:
-            billingAddressConfiguration.mode = CardComponent.AddressFormType.none
-        }
-
-        return billingAddressConfiguration
+    if let twintConfigurationDTO {
+      dropInConfiguration.actionComponent.twint = .init(
+        callbackAppScheme: twintConfigurationDTO.iosCallbackAppScheme)
     }
+
+    if let threeDS2ConfigurationDTO {
+      dropInConfiguration.actionComponent.threeDS =
+        threeDS2ConfigurationDTO.mapToThreeDS2Configuration()
+    }
+
+    dropInConfiguration.style = AdyenAppearance.dropInStyle
+
+    return dropInConfiguration
+  }
+
+  private func buildCard(from cardConfigurationDTO: CardConfigurationDTO) -> DropInComponent.Card {
+    let koreanAuthenticationMode = cardConfigurationDTO.kcpFieldVisibility.toCardFieldVisibility()
+    let socialSecurityNumberMode = cardConfigurationDTO.socialSecurityNumberFieldVisibility
+      .toCardFieldVisibility()
+    let storedCardConfiguration = createStoredCardConfiguration(
+      showCvcForStoredCard: cardConfigurationDTO.showCvcForStoredCard)
+    let allowedCardTypes = determineAllowedCardTypes(
+      cardTypes: cardConfigurationDTO.supportedCardTypes)
+    let billingAddressConfiguration = determineBillingAddressConfiguration(
+      addressMode: cardConfigurationDTO.addressMode)
+    let installmentConfiguration = cardConfigurationDTO.installmentConfiguration?
+      .mapToInstallmentConfiguration()
+    return DropInComponent.Card(
+      showsHolderNameField: cardConfigurationDTO.holderNameRequired,
+      showsStorePaymentMethodField: cardConfigurationDTO.showStorePaymentField,
+      showsSecurityCodeField: cardConfigurationDTO.showCvc,
+      koreanAuthenticationMode: koreanAuthenticationMode,
+      socialSecurityNumberMode: socialSecurityNumberMode,
+      storedCardConfiguration: storedCardConfiguration,
+      allowedCardTypes: allowedCardTypes,
+      installmentConfiguration: installmentConfiguration,
+      billingAddress: billingAddressConfiguration
+    )
+  }
+
+  private func createStoredCardConfiguration(showCvcForStoredCard: Bool) -> StoredCardConfiguration
+  {
+    var storedCardConfiguration = StoredCardConfiguration()
+    storedCardConfiguration.showsSecurityCodeField = showCvcForStoredCard
+    return storedCardConfiguration
+  }
+
+  private func determineAllowedCardTypes(cardTypes: [String?]?) -> [CardType]? {
+    guard let mappedCardTypes = cardTypes, !mappedCardTypes.isEmpty else {
+      return nil
+    }
+
+    return mappedCardTypes.compactMap { $0 }.map { CardType(rawValue: $0.lowercased()) }
+  }
+
+  private func determineBillingAddressConfiguration(addressMode: AddressMode?)
+    -> BillingAddressConfiguration
+  {
+    var billingAddressConfiguration = BillingAddressConfiguration()
+    switch addressMode {
+    case .full:
+      billingAddressConfiguration.mode = CardComponent.AddressFormType.full
+    case .postalCode:
+      billingAddressConfiguration.mode = CardComponent.AddressFormType.postalCode
+    case .none:
+      billingAddressConfiguration.mode = CardComponent.AddressFormType.none
+    default:
+      billingAddressConfiguration.mode = CardComponent.AddressFormType.none
+    }
+
+    return billingAddressConfiguration
+  }
 }
 
 extension FieldVisibility {
-    func toCardFieldVisibility() -> CardComponent.FieldVisibility {
-        switch self {
-        case .show:
-            return .show
-        case .hide:
-            return .hide
-        }
+  func toCardFieldVisibility() -> CardComponent.FieldVisibility {
+    switch self {
+    case .show:
+      return .show
+    case .hide:
+      return .hide
     }
+  }
 }
 
 extension DropInConfigurationDTO {
-    func createAdyenContext(payment: Payment? = nil) throws -> AdyenContext {
-        try buildAdyenContext(
-            environment: environment,
-            clientKey: clientKey,
-            amount: amount,
-            analyticsOptionsDTO: analyticsOptionsDTO,
-            countryCode: countryCode,
-            payment: payment
-        )
-    }
+  func createAdyenContext(payment: Payment? = nil) throws -> AdyenContext {
+    try buildAdyenContext(
+      environment: environment,
+      clientKey: clientKey,
+      amount: amount,
+      analyticsOptionsDTO: analyticsOptionsDTO,
+      countryCode: countryCode,
+      payment: payment
+    )
+  }
 }
 
 extension CardConfigurationDTO {
-    func mapToCardComponentConfiguration(shopperLocale: String?) -> CardComponent.Configuration {
-        let cardComponentStyle = AdyenAppearance.cardComponentStyle
-        let localizationParameters = shopperLocale != nil ? LocalizationParameters(enforcedLocale: shopperLocale!) : nil
-        let koreanAuthenticationMode = kcpFieldVisibility.toCardFieldVisibility()
-        let socialSecurityNumberMode = socialSecurityNumberFieldVisibility.toCardFieldVisibility()
-        let storedCardConfiguration = createStoredCardConfiguration(showCvcForStoredCard: showCvcForStoredCard)
-        let allowedCardTypes = determineAllowedCardTypes(cardTypes: supportedCardTypes)
-        let billingAddressConfiguration = determineBillingAddressConfiguration(addressMode: addressMode)
-        let installmentConfiguration = installmentConfiguration?.mapToInstallmentConfiguration()
-        return CardComponent.Configuration(
-            style: cardComponentStyle,
-            localizationParameters: localizationParameters,
-            showsHolderNameField: holderNameRequired,
-            showsStorePaymentMethodField: showStorePaymentField,
-            showsSecurityCodeField: showCvc,
-            koreanAuthenticationMode: koreanAuthenticationMode,
-            socialSecurityNumberMode: socialSecurityNumberMode,
-            storedCardConfiguration: storedCardConfiguration,
-            allowedCardTypes: allowedCardTypes,
-            installmentConfiguration: installmentConfiguration,
-            billingAddress: billingAddressConfiguration
-        )
+  func mapToCardComponentConfiguration(shopperLocale: String?) -> CardComponent.Configuration {
+    let cardComponentStyle = AdyenAppearance.cardComponentStyle
+    let localizationParameters =
+      shopperLocale != nil ? LocalizationParameters(enforcedLocale: shopperLocale!) : nil
+    let koreanAuthenticationMode = kcpFieldVisibility.toCardFieldVisibility()
+    let socialSecurityNumberMode = socialSecurityNumberFieldVisibility.toCardFieldVisibility()
+    let storedCardConfiguration = createStoredCardConfiguration(
+      showCvcForStoredCard: showCvcForStoredCard)
+    let allowedCardTypes = determineAllowedCardTypes(cardTypes: supportedCardTypes)
+    let billingAddressConfiguration = determineBillingAddressConfiguration(addressMode: addressMode)
+    let installmentConfiguration = installmentConfiguration?.mapToInstallmentConfiguration()
+    return CardComponent.Configuration(
+      style: cardComponentStyle,
+      localizationParameters: localizationParameters,
+      showsHolderNameField: holderNameRequired,
+      showsStorePaymentMethodField: showStorePaymentField,
+      showsSecurityCodeField: showCvc,
+      koreanAuthenticationMode: koreanAuthenticationMode,
+      socialSecurityNumberMode: socialSecurityNumberMode,
+      storedCardConfiguration: storedCardConfiguration,
+      allowedCardTypes: allowedCardTypes,
+      installmentConfiguration: installmentConfiguration,
+      billingAddress: billingAddressConfiguration
+    )
+  }
+
+  private func createStoredCardConfiguration(showCvcForStoredCard: Bool) -> StoredCardConfiguration
+  {
+    var storedCardConfiguration = StoredCardConfiguration()
+    storedCardConfiguration.showsSecurityCodeField = showCvcForStoredCard
+    return storedCardConfiguration
+  }
+
+  private func determineAllowedCardTypes(cardTypes: [String?]?) -> [CardType]? {
+    guard let mappedCardTypes = cardTypes, !mappedCardTypes.isEmpty else {
+      return nil
     }
 
-    private func createStoredCardConfiguration(showCvcForStoredCard: Bool) -> StoredCardConfiguration {
-        var storedCardConfiguration = StoredCardConfiguration()
-        storedCardConfiguration.showsSecurityCodeField = showCvcForStoredCard
-        return storedCardConfiguration
+    return mappedCardTypes.compactMap { $0 }.map { CardType(rawValue: $0.lowercased()) }
+  }
+
+  private func determineBillingAddressConfiguration(addressMode: AddressMode?)
+    -> BillingAddressConfiguration
+  {
+    var billingAddressConfiguration = BillingAddressConfiguration()
+    switch addressMode {
+    case .full:
+      billingAddressConfiguration.mode = CardComponent.AddressFormType.full
+    case .postalCode:
+      billingAddressConfiguration.mode = CardComponent.AddressFormType.postalCode
+    case .none:
+      billingAddressConfiguration.mode = CardComponent.AddressFormType.none
+    default:
+      billingAddressConfiguration.mode = CardComponent.AddressFormType.none
     }
 
-    private func determineAllowedCardTypes(cardTypes: [String?]?) -> [CardType]? {
-        guard let mappedCardTypes = cardTypes, !mappedCardTypes.isEmpty else {
-            return nil
-        }
-
-        return mappedCardTypes.compactMap { $0 }.map { CardType(rawValue: $0.lowercased()) }
-    }
-
-    private func determineBillingAddressConfiguration(addressMode: AddressMode?) -> BillingAddressConfiguration {
-        var billingAddressConfiguration = BillingAddressConfiguration()
-        switch addressMode {
-        case .full:
-            billingAddressConfiguration.mode = CardComponent.AddressFormType.full
-        case .postalCode:
-            billingAddressConfiguration.mode = CardComponent.AddressFormType.postalCode
-        case .none:
-            billingAddressConfiguration.mode = CardComponent.AddressFormType.none
-        default:
-            billingAddressConfiguration.mode = CardComponent.AddressFormType.none
-        }
-
-        return billingAddressConfiguration
-    }
+    return billingAddressConfiguration
+  }
 }
 
 extension CardComponentConfigurationDTO {
-    func createAdyenContext() throws -> AdyenContext {
-        try buildAdyenContext(
-            environment: environment,
-            clientKey: clientKey,
-            amount: amount,
-            analyticsOptionsDTO: analyticsOptionsDTO,
-            countryCode: countryCode
-        )
-    }
+  func createAdyenContext() throws -> AdyenContext {
+    try buildAdyenContext(
+      environment: environment,
+      clientKey: clientKey,
+      amount: amount,
+      analyticsOptionsDTO: analyticsOptionsDTO,
+      countryCode: countryCode
+    )
+  }
 }
 
 extension BlikComponentConfigurationDTO {
-    func createAdyenContext() throws -> AdyenContext {
-        try buildAdyenContext(
-            environment: environment,
-            clientKey: clientKey,
-            amount: amount,
-            analyticsOptionsDTO: analyticsOptionsDTO,
-            countryCode: countryCode
-        )
-    }
+  func createAdyenContext() throws -> AdyenContext {
+    try buildAdyenContext(
+      environment: environment,
+      clientKey: clientKey,
+      amount: amount,
+      analyticsOptionsDTO: analyticsOptionsDTO,
+      countryCode: countryCode
+    )
+  }
 
-    func mapToBlikComponentConfiguration() -> BLIKComponent.Configuration {
-        let localizationParameters = shopperLocale.map { LocalizationParameters(enforcedLocale: $0) }
-        return BLIKComponent.Configuration(
-            style: AdyenAppearance.blikComponentStyle,
-            localizationParameters: localizationParameters
-        )
-    }
+  func mapToBlikComponentConfiguration() -> BLIKComponent.Configuration {
+    let localizationParameters = shopperLocale.map { LocalizationParameters(enforcedLocale: $0) }
+    return BLIKComponent.Configuration(
+      style: AdyenAppearance.blikComponentStyle,
+      localizationParameters: localizationParameters
+    )
+  }
 }
 
 extension Environment {
-    func mapToEnvironment() -> Adyen.Environment {
-        switch self {
-        case .test:
-            return Adyen.Environment.test
-        case .europe:
-            return .liveEurope
-        case .unitedStates:
-            return .liveUnitedStates
-        case .australia:
-            return .liveAustralia
-        case .india:
-            return .liveIndia
-        case .apse:
-            return .liveApse
-        case .nea:
-            return .liveNea
-        }
+  func mapToEnvironment() -> Adyen.Environment {
+    switch self {
+    case .test:
+      return Adyen.Environment.test
+    case .europe:
+      return .liveEurope
+    case .unitedStates:
+      return .liveUnitedStates
+    case .australia:
+      return .liveAustralia
+    case .india:
+      return .liveIndia
+    case .apse:
+      return .liveApse
+    case .nea:
+      return .liveNea
     }
+  }
 }
 
 extension AmountDTO {
-    func mapToAmount() -> Adyen.Amount {
-        Adyen.Amount(value: Int(value), currencyCode: currency)
-    }
+  func mapToAmount() -> Adyen.Amount {
+    Adyen.Amount(value: Int(value), currencyCode: currency)
+  }
 }
 
 extension InstantPaymentConfigurationDTO {
-    func mapToApplePayConfiguration(payment: Payment?) throws -> ApplePayComponent.Configuration {
-        guard let applePayConfiguration = try applePayConfigurationDTO?.toApplePayConfiguration(payment: payment) else {
-            throw PlatformError(errorDescription: "Apple pay configuration not provided.")
-        }
-        
-        return applePayConfiguration
+  func mapToApplePayConfiguration(payment: Payment?) throws -> ApplePayComponent.Configuration {
+    guard
+      let applePayConfiguration = try applePayConfigurationDTO?.toApplePayConfiguration(
+        payment: payment)
+    else {
+      throw PlatformError(errorDescription: "Apple pay configuration not provided.")
     }
 
-    func createAdyenContext(payment: Payment? = nil) throws -> AdyenContext {
-        try buildAdyenContext(
-            environment: environment,
-            clientKey: clientKey,
-            amount: amount,
-            analyticsOptionsDTO: analyticsOptionsDTO,
-            countryCode: countryCode,
-            payment: payment
-        )
-    }
+    return applePayConfiguration
+  }
+
+  func createAdyenContext(payment: Payment? = nil) throws -> AdyenContext {
+    try buildAdyenContext(
+      environment: environment,
+      clientKey: clientKey,
+      amount: amount,
+      analyticsOptionsDTO: analyticsOptionsDTO,
+      countryCode: countryCode,
+      payment: payment
+    )
+  }
 }
 
-private func buildAdyenContext(environment: Environment, clientKey: String, amount: AmountDTO?, analyticsOptionsDTO: AnalyticsOptionsDTO, countryCode: String?, payment: Payment? = nil) throws -> AdyenContext {
-    let environment = environment.mapToEnvironment()
-    let apiContext = try APIContext(
-        environment: environment,
-        clientKey: clientKey
-    )
-    let payment: Payment? = payment ?? {
-        if let amount, let countryCode {
-            return Payment(amount: amount.mapToAmount(), countryCode: countryCode)
-        }
-        return nil
+private func buildAdyenContext(
+  environment: Environment, clientKey: String, amount: AmountDTO?,
+  analyticsOptionsDTO: AnalyticsOptionsDTO, countryCode: String?, payment: Payment? = nil
+) throws -> AdyenContext {
+  let environment = environment.mapToEnvironment()
+  let apiContext = try APIContext(
+    environment: environment,
+    clientKey: clientKey
+  )
+  let payment: Payment? =
+    payment
+    ?? {
+      if let amount, let countryCode {
+        return Payment(amount: amount.mapToAmount(), countryCode: countryCode)
+      }
+      return nil
     }()
-    var analyticsConfiguration = AnalyticsConfiguration()
-    analyticsConfiguration.isEnabled = analyticsOptionsDTO.enabled
-    analyticsConfiguration.context = AnalyticsContext(
-        version: analyticsOptionsDTO.version,
-        platform: .flutter
-    )
+  var analyticsConfiguration = AnalyticsConfiguration()
+  analyticsConfiguration.isEnabled = analyticsOptionsDTO.enabled
+  analyticsConfiguration.context = AnalyticsContext(
+    version: analyticsOptionsDTO.version,
+    platform: .flutter
+  )
 
-    return AdyenContext(
-        apiContext: apiContext,
-        payment: payment,
-        analyticsConfiguration: analyticsConfiguration
-    )
+  return AdyenContext(
+    apiContext: apiContext,
+    payment: payment,
+    analyticsConfiguration: analyticsConfiguration
+  )
 }
 
 extension UnencryptedCardDTO {
-    func mapToUnencryptedCard() -> Card {
-        Card(
-            number: cardNumber,
-            securityCode: cvc,
-            expiryMonth: expiryMonth,
-            expiryYear: expiryYear
-        )
-    }
+  func mapToUnencryptedCard() -> Card {
+    Card(
+      number: cardNumber,
+      securityCode: cvc,
+      expiryMonth: expiryMonth,
+      expiryYear: expiryYear
+    )
+  }
 }
 
 extension EncryptedCard {
-    func mapToEncryptedCardDTO() -> EncryptedCardDTO {
-        EncryptedCardDTO(
-            encryptedCardNumber: number,
-            encryptedExpiryMonth: expiryMonth,
-            encryptedExpiryYear: expiryYear,
-            encryptedSecurityCode: securityCode
-        )
-    }
+  func mapToEncryptedCardDTO() -> EncryptedCardDTO {
+    EncryptedCardDTO(
+      encryptedCardNumber: number,
+      encryptedExpiryMonth: expiryMonth,
+      encryptedExpiryYear: expiryYear,
+      encryptedSecurityCode: securityCode
+    )
+  }
 }
 
 extension PaymentResultEnum {
-    static func from(error: Error) -> Self {
-        if let componentError = (error as? ComponentError), componentError == ComponentError.cancelled {
-            .cancelledByUser
-        } else if isThree3ds2Cancellation(error: error as NSError) {
-            .cancelledByUser
-        } else {
-            .error
-        }
+  static func from(error: Error) -> Self {
+    if let componentError = (error as? ComponentError), componentError == ComponentError.cancelled {
+      .cancelledByUser
+    } else if isThree3ds2Cancellation(error: error as NSError) {
+      .cancelledByUser
+    } else {
+      .error
     }
-    
-    private static func isThree3ds2Cancellation(error: NSError) -> Bool {
-        error.domain == ADYRuntimeErrorDomain && error.code == ADYRuntimeErrorCode.challengeCancelled.rawValue
-    }
+  }
+
+  private static func isThree3ds2Cancellation(error: NSError) -> Bool {
+    error.domain == ADYRuntimeErrorDomain
+      && error.code == ADYRuntimeErrorCode.challengeCancelled.rawValue
+  }
 }
 
 extension ResultCode {
-    var isAccepted: Bool {
-        switch self {
-        case .authorised, .received, .pending:
-            return true
-        case .refused, .cancelled, .error, .redirectShopper, .identifyShopper, .challengeShopper, .presentToShopper:
-            return false
-        }
+  var isAccepted: Bool {
+    switch self {
+    case .authorised, .received, .pending:
+      return true
+    case .refused, .cancelled, .error, .redirectShopper, .identifyShopper, .challengeShopper,
+      .presentToShopper:
+      return false
     }
+  }
 }
 
 extension AdyenSession.Context {
-    func createPayment(fallbackCountryCode: String) -> Payment {
-        Payment(amount: amount, countryCode: countryCode ?? fallbackCountryCode)
-    }
+  func createPayment(fallbackCountryCode: String) -> Payment {
+    Payment(amount: amount, countryCode: countryCode ?? fallbackCountryCode)
+  }
 }
 
 extension ActionComponentConfigurationDTO {
-    func createAdyenContext() throws -> AdyenContext {
-        try buildAdyenContext(
-            environment: environment,
-            clientKey: clientKey,
-            amount: nil,
-            analyticsOptionsDTO: analyticsOptionsDTO,
-            countryCode: nil
-        )
-    }
+  func createAdyenContext() throws -> AdyenContext {
+    try buildAdyenContext(
+      environment: environment,
+      clientKey: clientKey,
+      amount: nil,
+      analyticsOptionsDTO: analyticsOptionsDTO,
+      countryCode: nil
+    )
+  }
 }
 
 extension ThreeDS2ConfigurationDTO {
-    func mapToThreeDS2Configuration() -> AdyenActionComponent.Configuration.ThreeDS {
-        let appearanceConfiguration = uiCustomization?.toAppearanceConfiguration() ?? ADYAppearanceConfiguration()
-        guard let requestorAppURL, let url = URL(string: requestorAppURL) else {
-            return .init(appearanceConfiguration: appearanceConfiguration)
-        }
-        return .init(requestorAppURL: url, appearanceConfiguration: appearanceConfiguration)
+  func buildActionComponentConfiguration() -> AdyenActionComponent.Configuration {
+    var actionComponentConfiguration = AdyenActionComponent.Configuration()
+    actionComponentConfiguration.threeDS = mapToThreeDS2Configuration()
+    return actionComponentConfiguration
+  }
+
+  func mapToThreeDS2Configuration() -> AdyenActionComponent.Configuration.ThreeDS {
+    let appearanceConfiguration =
+      uiCustomization?.toAppearanceConfiguration() ?? ADYAppearanceConfiguration()
+    guard let requestorAppURL, let url = URL(string: requestorAppURL) else {
+      return .init(appearanceConfiguration: appearanceConfiguration)
     }
+    return .init(requestorAppURL: url, appearanceConfiguration: appearanceConfiguration)
+  }
 }
 
 extension ThreeDS2UICustomizationDTO {
-    func toAppearanceConfiguration() -> ADYAppearanceConfiguration {
-        let configuration = ADYAppearanceConfiguration()
-        if let screenCustomization {
-            screenCustomization.apply(to: configuration)
-        }
-        if let headingCustomization {
-            headingCustomization.apply(to: configuration)
-        }
-        if let labelCustomization {
-            labelCustomization.apply(to: configuration)
-        }
-        if let inputCustomization {
-            inputCustomization.apply(to: configuration)
-        }
-        if let selectionItemCustomization {
-            selectionItemCustomization.apply(to: configuration)
-        }
-        primaryButtonCustomization?.apply(to: configuration, buttonType: .submit)
-        primaryButtonCustomization?.apply(to: configuration, buttonType: .continue)
-        primaryButtonCustomization?.apply(to: configuration, buttonType: .next)
-        secondaryButtonCustomization?.apply(to: configuration, buttonType: .cancel)
-        secondaryButtonCustomization?.apply(to: configuration, buttonType: .resend)
-        secondaryButtonCustomization?.apply(to: configuration, buttonType: .OOB)
-        return configuration
+  func toAppearanceConfiguration() -> ADYAppearanceConfiguration {
+    let configuration = ADYAppearanceConfiguration()
+    if let screenCustomization {
+      screenCustomization.apply(to: configuration)
     }
+    if let headingCustomization {
+      headingCustomization.apply(to: configuration)
+    }
+    if let labelCustomization {
+      labelCustomization.apply(to: configuration)
+    }
+    if let inputCustomization {
+      inputCustomization.apply(to: configuration)
+    }
+    if let selectionItemCustomization {
+      selectionItemCustomization.apply(to: configuration)
+    }
+    primaryButtonCustomization?.apply(to: configuration, buttonType: .submit)
+    primaryButtonCustomization?.apply(to: configuration, buttonType: .continue)
+    primaryButtonCustomization?.apply(to: configuration, buttonType: .next)
+    secondaryButtonCustomization?.apply(to: configuration, buttonType: .cancel)
+    secondaryButtonCustomization?.apply(to: configuration, buttonType: .resend)
+    secondaryButtonCustomization?.apply(to: configuration, buttonType: .OOB)
+    return configuration
+  }
 }
 
 extension ThreeDS2ScreenCustomizationDTO {
-    func apply(to configuration: ADYAppearanceConfiguration) {
-        if let backgroundColor, let bgColor = UIColor(hex: backgroundColor) {
-            configuration.backgroundColor = bgColor
-        }
-        // Apply general text styling as fallback for labels
-        if let textColor, let textUIColor = UIColor(hex: textColor) {
-            configuration.textColor = textUIColor
-            configuration.tintColor = textUIColor
-            configuration.infoAppearance.headingTextColor = textUIColor
-            configuration.infoAppearance.textColor = textUIColor
-        }
+  func apply(to configuration: ADYAppearanceConfiguration) {
+    if let backgroundColor, let bgColor = UIColor(hex: backgroundColor) {
+      configuration.backgroundColor = bgColor
     }
+    // Apply general text styling as fallback for labels
+    if let textColor, let textUIColor = UIColor(hex: textColor) {
+      configuration.textColor = textUIColor
+      configuration.tintColor = textUIColor
+      configuration.infoAppearance.headingTextColor = textUIColor
+      configuration.infoAppearance.textColor = textUIColor
+    }
+  }
 }
 
 extension ThreeDS2ToolbarCustomizationDTO {
-    func apply(to configuration: ADYAppearanceConfiguration) {
-        if let backgroundColor, let backgroundColor = UIColor(hex: backgroundColor) {
-            configuration.navigationBarAppearance.backgroundColor = backgroundColor
-        }
-        if let textColor, let textUIColor = UIColor(hex: textColor) {
-            configuration.navigationBarAppearance.textColor = textUIColor
-        }
-        if let headerText {
-            configuration.navigationBarAppearance.title = headerText
-        }
-        if let cancelButtonColor, let cancelTextColor = UIColor(hex: cancelButtonColor) {
-            configuration.buttonAppearance(for: .cancel).textColor = cancelTextColor
-        }
+  func apply(to configuration: ADYAppearanceConfiguration) {
+    if let backgroundColor, let backgroundColor = UIColor(hex: backgroundColor) {
+      configuration.navigationBarAppearance.backgroundColor = backgroundColor
     }
+    if let textColor, let textUIColor = UIColor(hex: textColor) {
+      configuration.navigationBarAppearance.textColor = textUIColor
+    }
+    if let headerText {
+      configuration.navigationBarAppearance.title = headerText
+    }
+    if let cancelButtonColor, let cancelTextColor = UIColor(hex: cancelButtonColor) {
+      configuration.buttonAppearance(for: .cancel).textColor = cancelTextColor
+    }
+  }
 }
 
 extension ThreeDS2LabelCustomizationDTO {
-    func apply(to configuration: ADYAppearanceConfiguration) {
-        if let headingTextColor, let headingColor = UIColor(hex: headingTextColor) {
-            configuration.labelAppearance.headingTextColor = headingColor
-        }
-        if let headingTextFontSize {
-            configuration.labelAppearance.headingFont = configuration.labelAppearance.headingFont.withSize(CGFloat(headingTextFontSize))
-        }
-        if let textColor, let textUIColor = UIColor(hex: textColor) {
-            configuration.labelAppearance.textColor = textUIColor
-        }
-        if let textFontSize {
-            configuration.labelAppearance.font = configuration.labelAppearance.font.withSize(CGFloat(textFontSize))
-        }
-        if let inputLabelTextColor, let inputLabelColor = UIColor(hex: inputLabelTextColor) {
-            configuration.labelAppearance.subheadingTextColor = inputLabelColor
-        }
-        if let inputLabelFontSize {
-            configuration.labelAppearance.subheadingFont = configuration.labelAppearance.subheadingFont.withSize(CGFloat(inputLabelFontSize))
-        }
+  func apply(to configuration: ADYAppearanceConfiguration) {
+    if let headingTextColor, let headingColor = UIColor(hex: headingTextColor) {
+      configuration.labelAppearance.headingTextColor = headingColor
     }
+    if let headingTextFontSize {
+      configuration.labelAppearance.headingFont = configuration.labelAppearance.headingFont
+        .withSize(CGFloat(headingTextFontSize))
+    }
+    if let textColor, let textUIColor = UIColor(hex: textColor) {
+      configuration.labelAppearance.textColor = textUIColor
+    }
+    if let textFontSize {
+      configuration.labelAppearance.font = configuration.labelAppearance.font.withSize(
+        CGFloat(textFontSize))
+    }
+    if let inputLabelTextColor, let inputLabelColor = UIColor(hex: inputLabelTextColor) {
+      configuration.labelAppearance.subheadingTextColor = inputLabelColor
+    }
+    if let inputLabelFontSize {
+      configuration.labelAppearance.subheadingFont = configuration.labelAppearance.subheadingFont
+        .withSize(CGFloat(inputLabelFontSize))
+    }
+  }
 }
 
 extension ThreeDS2InputCustomizationDTO {
-    func apply(to configuration: ADYAppearanceConfiguration) {
-        if let borderColor, let boarderUIColor = UIColor(hex: borderColor) {
-            configuration.textFieldAppearance.borderColor = boarderUIColor
-        }
-        if let borderWidth {
-            configuration.textFieldAppearance.borderWidth = CGFloat(borderWidth)
-        }
-        if let cornerRadius {
-            configuration.textFieldAppearance.cornerRadius = CGFloat(cornerRadius)
-        }
-        if let textColor, let textUIColor = UIColor(hex: textColor) {
-            configuration.textFieldAppearance.textColor = textUIColor
-        }
+  func apply(to configuration: ADYAppearanceConfiguration) {
+    if let borderColor, let boarderUIColor = UIColor(hex: borderColor) {
+      configuration.textFieldAppearance.borderColor = boarderUIColor
     }
+    if let borderWidth {
+      configuration.textFieldAppearance.borderWidth = CGFloat(borderWidth)
+    }
+    if let cornerRadius {
+      configuration.textFieldAppearance.cornerRadius = CGFloat(cornerRadius)
+    }
+    if let textColor, let textUIColor = UIColor(hex: textColor) {
+      configuration.textFieldAppearance.textColor = textUIColor
+    }
+  }
 }
 
 extension ThreeDS2SelectionItemCustomizationDTO {
-    func apply(to configuration: ADYAppearanceConfiguration) {
-        if let selectionIndicatorTintColor,
-           let tintColor = UIColor(hex: selectionIndicatorTintColor) {
-            configuration.selectAppearance.selectionIndicatorTintColor = tintColor
-        }
-        if let highlightedBackgroundColor, let backgroundColor = UIColor(hex: highlightedBackgroundColor) {
-            configuration.selectAppearance.highlightedBackgroundColor = backgroundColor
-        }
-        if let textColor, let textUIColor = UIColor(hex: textColor) {
-            configuration.selectAppearance.textColor = textUIColor
-        }
+  func apply(to configuration: ADYAppearanceConfiguration) {
+    if let selectionIndicatorTintColor,
+      let tintColor = UIColor(hex: selectionIndicatorTintColor)
+    {
+      configuration.selectAppearance.selectionIndicatorTintColor = tintColor
     }
+    if let highlightedBackgroundColor,
+      let backgroundColor = UIColor(hex: highlightedBackgroundColor)
+    {
+      configuration.selectAppearance.highlightedBackgroundColor = backgroundColor
+    }
+    if let textColor, let textUIColor = UIColor(hex: textColor) {
+      configuration.selectAppearance.textColor = textUIColor
+    }
+  }
 }
 
 extension ThreeDS2ButtonCustomizationDTO {
-    func apply(to configuration: ADYAppearanceConfiguration, buttonType: ADYAppearanceButtonType) {
-        let buttonAppearance = configuration.buttonAppearance(for: buttonType)
+  func apply(to configuration: ADYAppearanceConfiguration, buttonType: ADYAppearanceButtonType) {
+    let buttonAppearance = configuration.buttonAppearance(for: buttonType)
 
-        if let backgroundColor, let buttonColor = UIColor(hex: backgroundColor) {
-            buttonAppearance.backgroundColor = buttonColor
-        }
-        if let textColor, let textUIColor = UIColor(hex: textColor) {
-            buttonAppearance.textColor = textUIColor
-        }
-        if let cornerRadius {
-            buttonAppearance.cornerRadius = CGFloat(cornerRadius)
-        }
-        if let textFontSize {
-            buttonAppearance.font = buttonAppearance.font.withSize(CGFloat(textFontSize))
-        }
+    if let backgroundColor, let buttonColor = UIColor(hex: backgroundColor) {
+      buttonAppearance.backgroundColor = buttonColor
     }
+    if let textColor, let textUIColor = UIColor(hex: textColor) {
+      buttonAppearance.textColor = textUIColor
+    }
+    if let cornerRadius {
+      buttonAppearance.cornerRadius = CGFloat(cornerRadius)
+    }
+    if let textFontSize {
+      buttonAppearance.font = buttonAppearance.font.withSize(CGFloat(textFontSize))
+    }
+  }
 }
 
 extension UIColor {
-    convenience init?(hex: String) {
-        var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
-        hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
+  convenience init?(hex: String) {
+    var hexSanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines)
+    hexSanitized = hexSanitized.replacingOccurrences(of: "#", with: "")
 
-        var rgb: UInt64 = 0
-        Scanner(string: hexSanitized).scanHexInt64(&rgb)
+    var rgb: UInt64 = 0
+    Scanner(string: hexSanitized).scanHexInt64(&rgb)
 
-        let red, green, blue, alpha: CGFloat
-        if hexSanitized.count == 8 {
-            alpha = CGFloat((rgb & 0xFF00_0000) >> 24) / 255.0
-            red = CGFloat((rgb & 0x00FF_0000) >> 16) / 255.0
-            green = CGFloat((rgb & 0x0000_FF00) >> 8) / 255.0
-            blue = CGFloat(rgb & 0x0000_00FF) / 255.0
-        } else if hexSanitized.count == 6 {
-            red = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
-            green = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
-            blue = CGFloat(rgb & 0x0000FF) / 255.0
-            alpha = 1.0
-        } else {
-            return nil
-        }
-
-        self.init(red: red, green: green, blue: blue, alpha: alpha)
+    let red: CGFloat
+    let green: CGFloat
+    let blue: CGFloat
+    let alpha: CGFloat
+    if hexSanitized.count == 8 {
+      alpha = CGFloat((rgb & 0xFF00_0000) >> 24) / 255.0
+      red = CGFloat((rgb & 0x00FF_0000) >> 16) / 255.0
+      green = CGFloat((rgb & 0x0000_FF00) >> 8) / 255.0
+      blue = CGFloat(rgb & 0x0000_00FF) / 255.0
+    } else if hexSanitized.count == 6 {
+      red = CGFloat((rgb & 0xFF0000) >> 16) / 255.0
+      green = CGFloat((rgb & 0x00FF00) >> 8) / 255.0
+      blue = CGFloat(rgb & 0x0000FF) / 255.0
+      alpha = 1.0
+    } else {
+      return nil
     }
+
+    self.init(red: red, green: green, blue: blue, alpha: alpha)
+  }
 }
 
 extension InstallmentConfigurationDTO {
-    func mapToInstallmentConfiguration() -> InstallmentConfiguration? {
-        guard defaultOptions != nil || cardBasedOptions != nil else { return nil }
-        let cardBasedOptions = cardBasedOptions.flatMap { buildCardBasedInstallmentOptions(from: $0) }
-        let defaultOptions = defaultOptions.map { buildDefaultInstallmentOptions(from: $0) }
-        
-        switch (defaultOptions, cardBasedOptions) {
-        case let (defaultOptions?, cardBasedOptions?):
-            return InstallmentConfiguration(
-                cardBasedOptions: cardBasedOptions,
-                defaultOptions: defaultOptions,
-                showInstallmentAmount: showInstallmentAmount
-            )
-            
-        case (nil, let cardBasedOptions?):
-            return InstallmentConfiguration(
-                cardBasedOptions: cardBasedOptions,
-                showInstallmentAmount: showInstallmentAmount
-            )
-            
-        case (let defaultOptions?, nil):
-            return InstallmentConfiguration(
-                defaultOptions: defaultOptions,
-                showInstallmentAmount: showInstallmentAmount
-            )
-            
-        default:
-            return nil
-        }
+  func mapToInstallmentConfiguration() -> InstallmentConfiguration? {
+    guard defaultOptions != nil || cardBasedOptions != nil else { return nil }
+    let cardBasedOptions = cardBasedOptions.flatMap { buildCardBasedInstallmentOptions(from: $0) }
+    let defaultOptions = defaultOptions.map { buildDefaultInstallmentOptions(from: $0) }
+
+    switch (defaultOptions, cardBasedOptions) {
+    case (let defaultOptions?, let cardBasedOptions?):
+      return InstallmentConfiguration(
+        cardBasedOptions: cardBasedOptions,
+        defaultOptions: defaultOptions,
+        showInstallmentAmount: showInstallmentAmount
+      )
+
+    case (nil, let cardBasedOptions?):
+      return InstallmentConfiguration(
+        cardBasedOptions: cardBasedOptions,
+        showInstallmentAmount: showInstallmentAmount
+      )
+
+    case (let defaultOptions?, nil):
+      return InstallmentConfiguration(
+        defaultOptions: defaultOptions,
+        showInstallmentAmount: showInstallmentAmount
+      )
+
+    default:
+      return nil
     }
-    
-    private func buildCardBasedInstallmentOptions(from cardBasedOptions: [CardBasedInstallmentOptionsDTO?]) -> [CardType: InstallmentOptions]? {
-        var options: [CardType: InstallmentOptions] = [:]
-        for cardBasedOption in cardBasedOptions {
-            guard let cardBasedOption else { continue }
-            let cardBrandRaw = cardBasedOption.cardBrand
-            let cardType = CardType(rawValue: cardBrandRaw)
-            options[cardType] = createInstallmentOptions(
-                values: cardBasedOption.values,
-                includesRevolving: cardBasedOption.includesRevolving
-            )
-        }
-        return options.isEmpty ? nil : options
+  }
+
+  private func buildCardBasedInstallmentOptions(
+    from cardBasedOptions: [CardBasedInstallmentOptionsDTO?]
+  ) -> [CardType: InstallmentOptions]? {
+    var options: [CardType: InstallmentOptions] = [:]
+    for cardBasedOption in cardBasedOptions {
+      guard let cardBasedOption else { continue }
+      let cardBrandRaw = cardBasedOption.cardBrand
+      let cardType = CardType(rawValue: cardBrandRaw)
+      options[cardType] = createInstallmentOptions(
+        values: cardBasedOption.values,
+        includesRevolving: cardBasedOption.includesRevolving
+      )
     }
-    
-    private func buildDefaultInstallmentOptions(from defaultOptions: DefaultInstallmentOptionsDTO) -> InstallmentOptions {
-        createInstallmentOptions(
-            values: defaultOptions.values,
-            includesRevolving: defaultOptions.includesRevolving
-        )
-    }
-    
-    private func createInstallmentOptions(values: [Int64?], includesRevolving: Bool) -> InstallmentOptions {
-        InstallmentOptions(
-            monthValues: values.compactMap { $0 }.map { UInt($0) },
-            includesRevolving: includesRevolving
-        )
-    }
+    return options.isEmpty ? nil : options
+  }
+
+  private func buildDefaultInstallmentOptions(from defaultOptions: DefaultInstallmentOptionsDTO)
+    -> InstallmentOptions
+  {
+    createInstallmentOptions(
+      values: defaultOptions.values,
+      includesRevolving: defaultOptions.includesRevolving
+    )
+  }
+
+  private func createInstallmentOptions(values: [Int64?], includesRevolving: Bool)
+    -> InstallmentOptions
+  {
+    InstallmentOptions(
+      monthValues: values.compactMap { $0 }.map { UInt($0) },
+      includesRevolving: includesRevolving
+    )
+  }
 }

--- a/lib/src/components/action_handling/model/action_component_configuration.dart
+++ b/lib/src/components/action_handling/model/action_component_configuration.dart
@@ -1,5 +1,6 @@
 import 'package:adyen_checkout/src/common/model/amount.dart';
 import 'package:adyen_checkout/src/common/model/analytics_options.dart';
+import 'package:adyen_checkout/src/common/model/payment_method_configurations/three_ds2/three_ds2_configuration.dart';
 import 'package:adyen_checkout/src/generated/platform_api.g.dart';
 
 final class ActionComponentConfiguration {
@@ -8,6 +9,7 @@ final class ActionComponentConfiguration {
   final String? shopperLocale;
   final Amount? amount;
   final AnalyticsOptions analyticsOptions;
+  final ThreeDS2Configuration? threeDS2Configuration;
 
   ActionComponentConfiguration({
     required this.environment,
@@ -15,6 +17,7 @@ final class ActionComponentConfiguration {
     this.shopperLocale,
     this.amount,
     AnalyticsOptions? analyticsOptions,
+    this.threeDS2Configuration,
   }) : analyticsOptions = analyticsOptions ?? AnalyticsOptions(enabled: true);
 
   @override
@@ -24,6 +27,7 @@ final class ActionComponentConfiguration {
         'clientKey: ****, '
         'shopperLocale: $shopperLocale, '
         'amount: $amount, '
-        'analyticsOptions: $analyticsOptions)';
+        'analyticsOptions: $analyticsOptions, '
+        'threeDS2Configuration: $threeDS2Configuration)';
   }
 }

--- a/lib/src/generated/platform_api.g.dart
+++ b/lib/src/generated/platform_api.g.dart
@@ -1789,6 +1789,7 @@ class ActionComponentConfigurationDTO {
     this.shopperLocale,
     this.amount,
     required this.analyticsOptionsDTO,
+    this.threeDS2ConfigurationDTO,
   });
 
   Environment environment;
@@ -1801,6 +1802,8 @@ class ActionComponentConfigurationDTO {
 
   AnalyticsOptionsDTO analyticsOptionsDTO;
 
+  ThreeDS2ConfigurationDTO? threeDS2ConfigurationDTO;
+
   Object encode() {
     return <Object?>[
       environment,
@@ -1808,6 +1811,7 @@ class ActionComponentConfigurationDTO {
       shopperLocale,
       amount,
       analyticsOptionsDTO,
+      threeDS2ConfigurationDTO,
     ];
   }
 
@@ -1819,6 +1823,7 @@ class ActionComponentConfigurationDTO {
       shopperLocale: result[2] as String?,
       amount: result[3] as AmountDTO?,
       analyticsOptionsDTO: result[4]! as AnalyticsOptionsDTO,
+      threeDS2ConfigurationDTO: result[5] as ThreeDS2ConfigurationDTO?,
     );
   }
 }

--- a/lib/src/util/dto_mapper.dart
+++ b/lib/src/util/dto_mapper.dart
@@ -461,6 +461,7 @@ extension ActionComponentConfigurationMapper on ActionComponentConfiguration {
         shopperLocale: shopperLocale,
         amount: amount?.toDTO(),
         analyticsOptionsDTO: analyticsOptions.toDTO(sdkVersionNumber),
+        threeDS2ConfigurationDTO: threeDS2Configuration?.toDTO(),
       );
 }
 

--- a/pigeons/platform_api.dart
+++ b/pigeons/platform_api.dart
@@ -775,6 +775,7 @@ class ActionComponentConfigurationDTO {
   final String? shopperLocale;
   final AmountDTO? amount;
   final AnalyticsOptionsDTO analyticsOptionsDTO;
+  final ThreeDS2ConfigurationDTO? threeDS2ConfigurationDTO;
 
   ActionComponentConfigurationDTO(
     this.environment,
@@ -782,6 +783,7 @@ class ActionComponentConfigurationDTO {
     this.shopperLocale,
     this.amount,
     this.analyticsOptionsDTO,
+    this.threeDS2ConfigurationDTO,
   );
 }
 

--- a/test/dto_mapping_test.dart
+++ b/test/dto_mapping_test.dart
@@ -623,6 +623,11 @@ void main() {
   test(
       'when action component configuration has 3DS2 configuration, then should map to ActionComponentConfigurationDTO',
       () {
+    const theme = Adyen3DSTheme(
+      headerTheme: Adyen3DSHeaderTheme(
+        textColor: Color(0xFFAABBCC),
+      ),
+    );
     final configuration = ActionComponentConfiguration(
       environment: Environment.test,
       clientKey: 'test_client_key',
@@ -630,6 +635,8 @@ void main() {
       amount: Amount(value: 1500, currency: 'EUR'),
       threeDS2Configuration: ThreeDS2Configuration(
         requestorAppURL: 'myapp://adyen3ds2',
+        headingTitle: 'Action heading',
+        theme: theme,
       ),
     );
 
@@ -641,6 +648,16 @@ void main() {
     expect(dto.amount?.value, 1500);
     expect(dto.amount?.currency, 'EUR');
     expect(dto.threeDS2ConfigurationDTO?.requestorAppURL, 'myapp://adyen3ds2');
+    expect(
+      dto.threeDS2ConfigurationDTO?.uiCustomization?.headingCustomization
+          ?.headerText,
+      'Action heading',
+    );
+    expect(
+      dto.threeDS2ConfigurationDTO?.uiCustomization?.headingCustomization
+          ?.textColor,
+      '#FFAABBCC',
+    );
   });
 
   test(

--- a/test/dto_mapping_test.dart
+++ b/test/dto_mapping_test.dart
@@ -620,6 +620,42 @@ void main() {
     expect(dto.uiCustomization?.headingCustomization?.headerText, 'Challenge');
   });
 
+  test(
+      'when action component configuration has 3DS2 configuration, then should map to ActionComponentConfigurationDTO',
+      () {
+    final configuration = ActionComponentConfiguration(
+      environment: Environment.test,
+      clientKey: 'test_client_key',
+      shopperLocale: 'en-US',
+      amount: Amount(value: 1500, currency: 'EUR'),
+      threeDS2Configuration: ThreeDS2Configuration(
+        requestorAppURL: 'myapp://adyen3ds2',
+      ),
+    );
+
+    final dto = configuration.toDTO('1.0.0');
+
+    expect(dto.environment, Environment.test);
+    expect(dto.clientKey, 'test_client_key');
+    expect(dto.shopperLocale, 'en-US');
+    expect(dto.amount?.value, 1500);
+    expect(dto.amount?.currency, 'EUR');
+    expect(dto.threeDS2ConfigurationDTO?.requestorAppURL, 'myapp://adyen3ds2');
+  });
+
+  test(
+      'when action component configuration omits 3DS2 configuration, then ActionComponentConfigurationDTO should contain null 3DS2 configuration',
+      () {
+    final configuration = ActionComponentConfiguration(
+      environment: Environment.test,
+      clientKey: 'test_client_key',
+    );
+
+    final dto = configuration.toDTO('1.0.0');
+
+    expect(dto.threeDS2ConfigurationDTO, isNull);
+  });
+
   test('color to hex should include alpha channel', () {
     const color = Color(0x80112233);
     expect(color.toHexString(), '#80112233');


### PR DESCRIPTION
### Summary

This PR adds `ThreeDS2Configuration` support to `ActionComponentConfiguration` for standalone action handling.

### What changed

- **Dart**
  - Added optional `threeDS2Configuration` to `ActionComponentConfiguration`
  - Updated DTO mapping to forward 3DS2 config into `ActionComponentConfigurationDTO`

- **Pigeon**
  - Added optional `threeDS2ConfigurationDTO` to `ActionComponentConfigurationDTO`
  - Regenerated Dart, Android, and iOS platform code

- **Android**
  - Threaded `threeDS2ConfigurationDTO` into action component checkout configuration mapping

- **iOS**
  - Applied 3DS2 action configuration when handling standalone actions
  - Reused shared 3DS2-to-action-component mapping via a `ThreeDS2ConfigurationDTO` extension method
  - Updated session-related action configuration call sites

- **Tests**
  - Added Dart coverage for `ActionComponentConfiguration` DTO mapping
  - Added Android coverage for action component 3DS2 mapping
  - Added iOS coverage for building action component configuration from 3DS2 config
  - Updated iOS test helpers for the new DTO field

- **Example / docs**
  - Updated the example standalone action flow to include `ThreeDS2Configuration`
  - Documented ActionComponent support in `doc/3DS_CUSTOMIZATION.md`
  - Added changelog entry under `1.10.0 (in development)`

### Notes

- `threeDS2Configuration` is optional
- Existing behavior remains unchanged when omitted

### Recordings

https://github.com/user-attachments/assets/f572cfb3-b37c-4746-88fb-c522d06416e8

[Screen_recording_20260413_105001.webm](https://github.com/user-attachments/assets/571830d7-086f-4db6-8efe-d81e0352aa7b)
