### PR TITLE
feat: add showStoredPaymentMethods to StoredPaymentMethodConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Drop-in: `StoredPaymentMethodConfiguration.showStoredPaymentMethods` — hide
   previously stored payment methods from the Drop-in payment list without
   changing the `shopperReference`. Defaults to `true` (existing behavior).
-  Mirrors the Web Drop-in `cardConfiguration.showStoredPaymentMethods` option.
+  Mirrors the Web Drop-in `DropinConfiguration.showStoredPaymentMethods` option.
 
 ## 1.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 1.10.0 (in development)
 
+### New
+
+- Drop-in: `StoredPaymentMethodConfiguration.showStoredPaymentMethods` — hide
+  previously stored payment methods from the Drop-in payment list without
+  changing the `shopperReference`. Defaults to `true` (existing behavior).
+  Mirrors the Web Drop-in `cardConfiguration.showStoredPaymentMethods` option.
+
 ## 1.9.0
 
 ### New

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
@@ -109,7 +109,7 @@ internal class DropInPlatformApi(
                     dropInConfigurationDTO.isPartialPaymentSupported
                 )
             val filteredPaymentMethods =
-                applyStoredPaymentMethodsVisibility(
+                hideStoredPaymentMethodsIfNeeded(
                     paymentMethodsWithoutGiftCards,
                     dropInConfigurationDTO.showStoredPaymentMethods
                 )
@@ -232,14 +232,15 @@ internal class DropInPlatformApi(
     ): CheckoutSession {
         val sessionSetupResponse = SessionSetupResponse.SERIALIZER.deserialize(sessionHolder.sessionSetupResponse)
         val adjustedSessionSetupResponse =
-            if (showStoredPaymentMethods) {
-                sessionSetupResponse
-            } else {
+            sessionSetupResponse.paymentMethodsApiResponse?.let { paymentMethodsApiResponse ->
                 sessionSetupResponse.copy(
                     paymentMethodsApiResponse =
-                        sessionSetupResponse.paymentMethodsApiResponse?.copy(storedPaymentMethods = emptyList())
+                        hideStoredPaymentMethodsIfNeeded(
+                            paymentMethodsApiResponse = paymentMethodsApiResponse,
+                            showStoredPaymentMethods = showStoredPaymentMethods,
+                        )
                 )
-            }
+            } ?: sessionSetupResponse
         val order = sessionHolder.orderResponse?.let { Order.SERIALIZER.deserialize(it) }
         return CheckoutSession(
             sessionSetupResponse = adjustedSessionSetupResponse,
@@ -268,16 +269,15 @@ internal class DropInPlatformApi(
         )
     }
 
-    private fun applyStoredPaymentMethodsVisibility(
-        paymentMethodsResponse: PaymentMethodsApiResponse,
+    private fun hideStoredPaymentMethodsIfNeeded(
+        paymentMethodsApiResponse: PaymentMethodsApiResponse,
         showStoredPaymentMethods: Boolean,
     ): PaymentMethodsApiResponse {
         if (showStoredPaymentMethods) {
-            return paymentMethodsResponse
+            return paymentMethodsApiResponse
         }
-        return PaymentMethodsApiResponse(
+        return paymentMethodsApiResponse.copy(
             storedPaymentMethods = emptyList(),
-            paymentMethods = paymentMethodsResponse.paymentMethods
         )
     }
 

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
@@ -235,7 +235,7 @@ internal class DropInPlatformApi(
             sessionSetupResponse.paymentMethodsApiResponse?.let { paymentMethodsApiResponse ->
                 sessionSetupResponse.copy(
                     paymentMethodsApiResponse =
-                        hideStoredPaymentMethodsIfNeeded(
+                        applyStoredPaymentMethodsVisibility(
                             paymentMethodsApiResponse = paymentMethodsApiResponse,
                             showStoredPaymentMethods = showStoredPaymentMethods,
                         )

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
@@ -231,6 +231,10 @@ internal class DropInPlatformApi(
         showStoredPaymentMethods: Boolean,
     ): CheckoutSession {
         val sessionSetupResponse = SessionSetupResponse.SERIALIZER.deserialize(sessionHolder.sessionSetupResponse)
+        // Relies on SessionSetupResponse and PaymentMethodsApiResponse being
+        // Kotlin data classes in sessions-core and components-core. If Adyen
+        // ever switches them to regular classes, the copy() calls below must
+        // be replaced with a serializer round-trip (JSON -> filter -> deserialize).
         val adjustedSessionSetupResponse =
             if (showStoredPaymentMethods) {
                 sessionSetupResponse

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
@@ -109,7 +109,7 @@ internal class DropInPlatformApi(
                     dropInConfigurationDTO.isPartialPaymentSupported
                 )
             val filteredPaymentMethods =
-                hideStoredPaymentMethodsIfNeeded(
+                applyStoredPaymentMethodsVisibility(
                     paymentMethodsWithoutGiftCards,
                     dropInConfigurationDTO.showStoredPaymentMethods
                 )

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
@@ -70,7 +70,8 @@ internal class DropInPlatformApi(
             createCheckoutSession(
                 sessionHolder,
                 dropInConfigurationDTO.environment.mapToEnvironment(),
-                dropInConfigurationDTO.clientKey
+                dropInConfigurationDTO.clientKey,
+                dropInConfigurationDTO.showStoredPaymentMethods
             )
 
         dropInPlatformMessengerJob?.cancel()
@@ -107,12 +108,17 @@ internal class DropInPlatformApi(
                     paymentMethodsApiResponse,
                     dropInConfigurationDTO.isPartialPaymentSupported
                 )
+            val filteredPaymentMethods =
+                applyStoredPaymentMethodsVisibility(
+                    paymentMethodsWithoutGiftCards,
+                    dropInConfigurationDTO.showStoredPaymentMethods
+                )
             val dropInConfiguration = dropInConfigurationDTO.toCheckoutConfiguration()
             withContext(Dispatchers.Main) {
                 DropIn.startPayment(
                     activity.applicationContext,
                     dropInAdvancedFlowLauncher,
-                    paymentMethodsWithoutGiftCards,
+                    filteredPaymentMethods,
                     dropInConfiguration,
                     AdvancedDropInService::class.java,
                 )
@@ -222,11 +228,21 @@ internal class DropInPlatformApi(
         sessionHolder: SessionHolder,
         environment: com.adyen.checkout.core.Environment,
         clientKey: String,
+        showStoredPaymentMethods: Boolean,
     ): CheckoutSession {
         val sessionSetupResponse = SessionSetupResponse.SERIALIZER.deserialize(sessionHolder.sessionSetupResponse)
+        val adjustedSessionSetupResponse =
+            if (showStoredPaymentMethods) {
+                sessionSetupResponse
+            } else {
+                sessionSetupResponse.copy(
+                    paymentMethodsApiResponse =
+                        sessionSetupResponse.paymentMethodsApiResponse?.copy(storedPaymentMethods = emptyList())
+                )
+            }
         val order = sessionHolder.orderResponse?.let { Order.SERIALIZER.deserialize(it) }
         return CheckoutSession(
-            sessionSetupResponse = sessionSetupResponse,
+            sessionSetupResponse = adjustedSessionSetupResponse,
             order = order,
             environment = environment,
             clientKey = clientKey
@@ -249,6 +265,19 @@ internal class DropInPlatformApi(
         return PaymentMethodsApiResponse(
             storedPaymentMethods = storedPaymentMethods,
             paymentMethods = paymentMethods
+        )
+    }
+
+    private fun applyStoredPaymentMethodsVisibility(
+        paymentMethodsResponse: PaymentMethodsApiResponse,
+        showStoredPaymentMethods: Boolean,
+    ): PaymentMethodsApiResponse {
+        if (showStoredPaymentMethods) {
+            return paymentMethodsResponse
+        }
+        return PaymentMethodsApiResponse(
+            storedPaymentMethods = emptyList(),
+            paymentMethods = paymentMethodsResponse.paymentMethods
         )
     }
 

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
@@ -269,7 +269,7 @@ internal class DropInPlatformApi(
         )
     }
 
-    private fun hideStoredPaymentMethodsIfNeeded(
+    private fun applyStoredPaymentMethodsVisibility(
         paymentMethodsApiResponse: PaymentMethodsApiResponse,
         showStoredPaymentMethods: Boolean,
     ): PaymentMethodsApiResponse {

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/dropIn/DropInPlatformApi.kt
@@ -231,10 +231,6 @@ internal class DropInPlatformApi(
         showStoredPaymentMethods: Boolean,
     ): CheckoutSession {
         val sessionSetupResponse = SessionSetupResponse.SERIALIZER.deserialize(sessionHolder.sessionSetupResponse)
-        // Relies on SessionSetupResponse and PaymentMethodsApiResponse being
-        // Kotlin data classes in sessions-core and components-core. If Adyen
-        // ever switches them to regular classes, the copy() calls below must
-        // be replaced with a serializer round-trip (JSON -> filter -> deserialize).
         val adjustedSessionSetupResponse =
             if (showStoredPaymentMethods) {
                 sessionSetupResponse

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/generated/PlatformApi.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/generated/PlatformApi.kt
@@ -662,7 +662,8 @@ data class DropInConfigurationDTO (
   val isRemoveStoredPaymentMethodEnabled: Boolean,
   val preselectedPaymentMethodTitle: String? = null,
   val paymentMethodNames: Map<String?, String?>? = null,
-  val isPartialPaymentSupported: Boolean
+  val isPartialPaymentSupported: Boolean,
+  val showStoredPaymentMethods: Boolean
 
 ) {
   companion object {
@@ -686,7 +687,8 @@ data class DropInConfigurationDTO (
       val preselectedPaymentMethodTitle = __pigeon_list[15] as String?
       val paymentMethodNames = __pigeon_list[16] as Map<String?, String?>?
       val isPartialPaymentSupported = __pigeon_list[17] as Boolean
-      return DropInConfigurationDTO(environment, clientKey, countryCode, amount, shopperLocale, cardConfigurationDTO, applePayConfigurationDTO, googlePayConfigurationDTO, cashAppPayConfigurationDTO, twintConfigurationDTO, threeDS2ConfigurationDTO, analyticsOptionsDTO, showPreselectedStoredPaymentMethod, skipListWhenSinglePaymentMethod, isRemoveStoredPaymentMethodEnabled, preselectedPaymentMethodTitle, paymentMethodNames, isPartialPaymentSupported)
+      val showStoredPaymentMethods = __pigeon_list[18] as Boolean
+      return DropInConfigurationDTO(environment, clientKey, countryCode, amount, shopperLocale, cardConfigurationDTO, applePayConfigurationDTO, googlePayConfigurationDTO, cashAppPayConfigurationDTO, twintConfigurationDTO, threeDS2ConfigurationDTO, analyticsOptionsDTO, showPreselectedStoredPaymentMethod, skipListWhenSinglePaymentMethod, isRemoveStoredPaymentMethodEnabled, preselectedPaymentMethodTitle, paymentMethodNames, isPartialPaymentSupported, showStoredPaymentMethods)
     }
   }
   fun toList(): List<Any?> {
@@ -709,6 +711,7 @@ data class DropInConfigurationDTO (
       preselectedPaymentMethodTitle,
       paymentMethodNames,
       isPartialPaymentSupported,
+      showStoredPaymentMethods,
     )
   }
 }

--- a/android/src/test/kotlin/com/adyen/checkout/flutter/ConfigurationMapperTest.kt
+++ b/android/src/test/kotlin/com/adyen/checkout/flutter/ConfigurationMapperTest.kt
@@ -148,6 +148,7 @@ class ConfigurationMapperTest {
                 skipListWhenSinglePaymentMethod = false,
                 isRemoveStoredPaymentMethodEnabled = false,
                 isPartialPaymentSupported = false,
+                showStoredPaymentMethods = true,
             )
 
             val checkoutConfiguration = dropInConfigurationDTO.toCheckoutConfiguration()
@@ -169,6 +170,7 @@ class ConfigurationMapperTest {
                 skipListWhenSinglePaymentMethod = false,
                 isRemoveStoredPaymentMethodEnabled = false,
                 isPartialPaymentSupported = true,
+                showStoredPaymentMethods = true,
             )
 
             val checkoutConfiguration = dropInConfigurationDTO.toCheckoutConfiguration()
@@ -195,6 +197,7 @@ class ConfigurationMapperTest {
                 skipListWhenSinglePaymentMethod = true,
                 isRemoveStoredPaymentMethodEnabled = true,
                 isPartialPaymentSupported = false,
+                showStoredPaymentMethods = true,
                 paymentMethodNames = mapOf("scheme" to "Credit Card", "ideal" to "iDEAL Payment"),
             )
 
@@ -219,6 +222,7 @@ class ConfigurationMapperTest {
                 skipListWhenSinglePaymentMethod = false,
                 isRemoveStoredPaymentMethodEnabled = false,
                 isPartialPaymentSupported = false,
+                showStoredPaymentMethods = true,
             )
 
             val checkoutConfiguration = dropInConfigurationDTO.toCheckoutConfiguration()
@@ -226,6 +230,23 @@ class ConfigurationMapperTest {
             assertEquals(SDKEnvironment.TEST, checkoutConfiguration.environment)
             assertNull(checkoutConfiguration.shopperLocale)
             assertNull(checkoutConfiguration.amount)
+        }
+
+        @Test
+        fun `when showStoredPaymentMethods is false, then DTO carries the value`() {
+            val dropInConfigurationDTO = DropInConfigurationDTO(
+                environment = Environment.TEST,
+                clientKey = TEST_CLIENT_KEY,
+                countryCode = "NL",
+                analyticsOptionsDTO = AnalyticsOptionsDTO(true, "0.0.1"),
+                showPreselectedStoredPaymentMethod = true,
+                skipListWhenSinglePaymentMethod = false,
+                isRemoveStoredPaymentMethodEnabled = false,
+                isPartialPaymentSupported = false,
+                showStoredPaymentMethods = false,
+            )
+
+            assertEquals(false, dropInConfigurationDTO.showStoredPaymentMethods)
         }
     }
 
@@ -888,6 +909,7 @@ class ConfigurationMapperTest {
                 skipListWhenSinglePaymentMethod = false,
                 isRemoveStoredPaymentMethodEnabled = false,
                 isPartialPaymentSupported = false,
+                showStoredPaymentMethods = true,
                 cashAppPayConfigurationDTO = CashAppPayConfigurationDTO(
                     cashAppPayEnvironment = CashAppPayEnvironment.SANDBOX,
                     returnUrl = "myapp://cashapp/callback"
@@ -916,6 +938,7 @@ class ConfigurationMapperTest {
                 skipListWhenSinglePaymentMethod = false,
                 isRemoveStoredPaymentMethodEnabled = false,
                 isPartialPaymentSupported = false,
+                showStoredPaymentMethods = true,
                 twintConfigurationDTO = TwintConfigurationDTO(
                     iosCallbackAppScheme = "myapp",
                     showStorePaymentField = true
@@ -940,6 +963,7 @@ class ConfigurationMapperTest {
                 skipListWhenSinglePaymentMethod = false,
                 isRemoveStoredPaymentMethodEnabled = false,
                 isPartialPaymentSupported = false,
+                showStoredPaymentMethods = true,
                 twintConfigurationDTO = TwintConfigurationDTO(
                     iosCallbackAppScheme = "myapp",
                     showStorePaymentField = false
@@ -1168,6 +1192,7 @@ class ConfigurationMapperTest {
                 skipListWhenSinglePaymentMethod = false,
                 isRemoveStoredPaymentMethodEnabled = false,
                 isPartialPaymentSupported = false,
+                showStoredPaymentMethods = true,
             )
 
             val checkoutConfiguration = dropInConfigurationDTO.toCheckoutConfiguration()
@@ -1189,6 +1214,7 @@ class ConfigurationMapperTest {
                 skipListWhenSinglePaymentMethod = false,
                 isRemoveStoredPaymentMethodEnabled = false,
                 isPartialPaymentSupported = false,
+                showStoredPaymentMethods = true,
             )
 
             val checkoutConfiguration = dropInConfigurationDTO.toCheckoutConfiguration()

--- a/example/ios/RunnerTests/ConfigurationMapperTests+DropIn.swift
+++ b/example/ios/RunnerTests/ConfigurationMapperTests+DropIn.swift
@@ -77,6 +77,18 @@ extension ConfigurationMapperTests {
         XCTAssertFalse(result.paymentMethodsList.allowDisablingStoredPaymentMethods)
     }
 
+    func test_showStoredPaymentMethods_defaultsToTrue() {
+        let sut = createDropInConfigurationDTO()
+
+        XCTAssertTrue(sut.showStoredPaymentMethods)
+    }
+
+    func test_showStoredPaymentMethods_whenSetToFalse_shouldBeFalse() {
+        let sut = createDropInConfigurationDTO(showStoredPaymentMethods: false)
+
+        XCTAssertFalse(sut.showStoredPaymentMethods)
+    }
+
     func test_cardConfiguration_withHolderNameRequired_shouldBeSet() throws {
         let cardConfig = createCardConfigurationDTO(holderNameRequired: true)
         let sut = createDropInConfigurationDTO(cardConfigurationDTO: cardConfig)

--- a/example/ios/RunnerTests/RunnerTests.swift
+++ b/example/ios/RunnerTests/RunnerTests.swift
@@ -23,7 +23,8 @@ class RunnerTests: XCTestCase {
                 showPreselectedStoredPaymentMethod: false,
                 skipListWhenSinglePaymentMethod: false,
                 isRemoveStoredPaymentMethodEnabled: false,
-                isPartialPaymentSupported: true
+                isPartialPaymentSupported: true,
+                showStoredPaymentMethods: true
             )
 
             let adyenContext = try dropInConfigurationDTO.createAdyenContext()

--- a/example/ios/RunnerTests/TestUtils.swift
+++ b/example/ios/RunnerTests/TestUtils.swift
@@ -46,7 +46,8 @@ func createDropInConfigurationDTO(
     analyticsOptionsDTO: AnalyticsOptionsDTO = AnalyticsOptionsDTO(enabled: true, version: "1.0.0"),
     showPreselectedStoredPaymentMethod: Bool = true,
     skipListWhenSinglePaymentMethod: Bool = false,
-    isRemoveStoredPaymentMethodEnabled: Bool = false
+    isRemoveStoredPaymentMethodEnabled: Bool = false,
+    showStoredPaymentMethods: Bool = true
 ) -> DropInConfigurationDTO {
     DropInConfigurationDTO(
         environment: environment,
@@ -66,7 +67,8 @@ func createDropInConfigurationDTO(
         isRemoveStoredPaymentMethodEnabled: isRemoveStoredPaymentMethodEnabled,
         preselectedPaymentMethodTitle: nil,
         paymentMethodNames: nil,
-        isPartialPaymentSupported: false
+        isPartialPaymentSupported: false,
+        showStoredPaymentMethods: showStoredPaymentMethods
     )
 }
 

--- a/example/lib/screens/drop_in/drop_in_screen.dart
+++ b/example/lib/screens/drop_in/drop_in_screen.dart
@@ -28,13 +28,6 @@ class DropInScreen extends StatelessWidget {
                 child: const Text("Drop-in sessions"),
               ),
               TextButton(
-                onPressed: () => startDropInSessions(
-                  context,
-                  hideStoredPaymentMethods: true,
-                ),
-                child: const Text("Drop-in sessions (hide stored)"),
-              ),
-              TextButton(
                 onPressed: () => startDropInAdvancedFlow(context),
                 child: const Text("Drop-in advanced flow"),
               ),
@@ -45,17 +38,12 @@ class DropInScreen extends StatelessWidget {
     );
   }
 
-  Future<void> startDropInSessions(
-    BuildContext context, {
-    bool hideStoredPaymentMethods = false,
-  }) async {
+  Future<void> startDropInSessions(BuildContext context) async {
     try {
       final Map<String, dynamic> sessionResponse =
           await repository.fetchSession();
       final DropInConfiguration dropInConfiguration =
-          await _createDropInConfiguration(
-        hideStoredPaymentMethods: hideStoredPaymentMethods,
-      );
+          await _createDropInConfiguration();
 
       final SessionCheckout sessionCheckout =
           await AdyenCheckout.session.create(
@@ -106,9 +94,7 @@ class DropInScreen extends StatelessWidget {
     }
   }
 
-  Future<DropInConfiguration> _createDropInConfiguration({
-    bool hideStoredPaymentMethods = false,
-  }) async {
+  Future<DropInConfiguration> _createDropInConfiguration() async {
     CardConfiguration cardsConfiguration = CardConfiguration(
       onBinLookup: _onBinLookup,
       onBinValue: _onBinValue,
@@ -165,7 +151,6 @@ class DropInScreen extends StatelessWidget {
       showPreselectedStoredPaymentMethod: false,
       isRemoveStoredPaymentMethodEnabled: true,
       deleteStoredPaymentMethodCallback: repository.deleteStoredPaymentMethod,
-      showStoredPaymentMethods: !hideStoredPaymentMethods,
     );
 
     final DropInConfiguration dropInConfiguration = DropInConfiguration(

--- a/example/lib/screens/drop_in/drop_in_screen.dart
+++ b/example/lib/screens/drop_in/drop_in_screen.dart
@@ -28,6 +28,13 @@ class DropInScreen extends StatelessWidget {
                 child: const Text("Drop-in sessions"),
               ),
               TextButton(
+                onPressed: () => startDropInSessions(
+                  context,
+                  hideStoredPaymentMethods: true,
+                ),
+                child: const Text("Drop-in sessions (hide stored)"),
+              ),
+              TextButton(
                 onPressed: () => startDropInAdvancedFlow(context),
                 child: const Text("Drop-in advanced flow"),
               ),
@@ -38,12 +45,17 @@ class DropInScreen extends StatelessWidget {
     );
   }
 
-  Future<void> startDropInSessions(BuildContext context) async {
+  Future<void> startDropInSessions(
+    BuildContext context, {
+    bool hideStoredPaymentMethods = false,
+  }) async {
     try {
       final Map<String, dynamic> sessionResponse =
           await repository.fetchSession();
       final DropInConfiguration dropInConfiguration =
-          await _createDropInConfiguration();
+          await _createDropInConfiguration(
+        hideStoredPaymentMethods: hideStoredPaymentMethods,
+      );
 
       final SessionCheckout sessionCheckout =
           await AdyenCheckout.session.create(
@@ -94,7 +106,9 @@ class DropInScreen extends StatelessWidget {
     }
   }
 
-  Future<DropInConfiguration> _createDropInConfiguration() async {
+  Future<DropInConfiguration> _createDropInConfiguration({
+    bool hideStoredPaymentMethods = false,
+  }) async {
     CardConfiguration cardsConfiguration = CardConfiguration(
       onBinLookup: _onBinLookup,
       onBinValue: _onBinValue,
@@ -151,6 +165,7 @@ class DropInScreen extends StatelessWidget {
       showPreselectedStoredPaymentMethod: false,
       isRemoveStoredPaymentMethodEnabled: true,
       deleteStoredPaymentMethodCallback: repository.deleteStoredPaymentMethod,
+      showStoredPaymentMethods: !hideStoredPaymentMethods,
     );
 
     final DropInConfiguration dropInConfiguration = DropInConfiguration(

--- a/ios/adyen_checkout/Sources/adyen_checkout/dropIn/DropInPlatformApi.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/dropIn/DropInPlatformApi.swift
@@ -60,7 +60,11 @@ class DropInPlatformApi: DropInPlatformInterface {
                     paymentMethodNames: paymentMethodNames
                 )
             }
-            
+            paymentMethods = applyStoredPaymentMethodsVisibility(
+                paymentMethods: paymentMethods,
+                showStoredPaymentMethods: dropInConfigurationDTO.showStoredPaymentMethods
+            )
+
             let dropInComponent = DropInComponent(
                 paymentMethods: paymentMethods,
                 context: adyenContext,
@@ -100,9 +104,13 @@ class DropInPlatformApi: DropInPlatformInterface {
             }
             
             let paymentMethodsWithoutGiftCards = removeGiftCardPaymentMethods(paymentMethods: paymentMethods, isPartialPaymentSupported: dropInConfigurationDTO.isPartialPaymentSupported)
+            let filteredPaymentMethods = applyStoredPaymentMethodsVisibility(
+                paymentMethods: paymentMethodsWithoutGiftCards,
+                showStoredPaymentMethods: dropInConfigurationDTO.showStoredPaymentMethods
+            )
             let configuration = try dropInConfigurationDTO.createDropInConfiguration(payment: adyenContext.payment)
             let dropInComponent = DropInComponent(
-                paymentMethods: paymentMethodsWithoutGiftCards,
+                paymentMethods: filteredPaymentMethods,
                 context: adyenContext,
                 configuration: configuration,
                 title: dropInConfigurationDTO.preselectedPaymentMethodTitle
@@ -305,10 +313,17 @@ class DropInPlatformApi: DropInPlatformInterface {
         if isPartialPaymentSupported {
             return paymentMethods
         }
-        
+
         let storedPaymentMethods = paymentMethods.stored.filter { !($0.type == PaymentMethodType.giftcard) }
         let paymentMethods = paymentMethods.regular.filter { !($0.type == PaymentMethodType.giftcard) }
         return PaymentMethods(regular: paymentMethods, stored: storedPaymentMethods)
+    }
+
+    private func applyStoredPaymentMethodsVisibility(paymentMethods: PaymentMethods, showStoredPaymentMethods: Bool) -> PaymentMethods {
+        if showStoredPaymentMethods {
+            return paymentMethods
+        }
+        return PaymentMethods(regular: paymentMethods.regular, stored: [])
     }
 
     private func sendSessionError(error: Error) {

--- a/ios/adyen_checkout/Sources/adyen_checkout/generated/PlatformApi.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/generated/PlatformApi.swift
@@ -622,6 +622,7 @@ struct DropInConfigurationDTO {
     var preselectedPaymentMethodTitle: String?
     var paymentMethodNames: [String?: String?]?
     var isPartialPaymentSupported: Bool
+    var showStoredPaymentMethods: Bool
 
     // swift-format-ignore: AlwaysUseLowerCamelCase
     static func fromList(_ __pigeon_list: [Any?]) -> DropInConfigurationDTO? {
@@ -643,6 +644,7 @@ struct DropInConfigurationDTO {
         let preselectedPaymentMethodTitle: String? = nilOrValue(__pigeon_list[15])
         let paymentMethodNames: [String?: String?]? = nilOrValue(__pigeon_list[16])
         let isPartialPaymentSupported = __pigeon_list[17] as! Bool
+        let showStoredPaymentMethods = __pigeon_list[18] as! Bool
 
         return DropInConfigurationDTO(
             environment: environment,
@@ -662,7 +664,8 @@ struct DropInConfigurationDTO {
             isRemoveStoredPaymentMethodEnabled: isRemoveStoredPaymentMethodEnabled,
             preselectedPaymentMethodTitle: preselectedPaymentMethodTitle,
             paymentMethodNames: paymentMethodNames,
-            isPartialPaymentSupported: isPartialPaymentSupported
+            isPartialPaymentSupported: isPartialPaymentSupported,
+            showStoredPaymentMethods: showStoredPaymentMethods
         )
     }
 
@@ -685,7 +688,8 @@ struct DropInConfigurationDTO {
             isRemoveStoredPaymentMethodEnabled,
             preselectedPaymentMethodTitle,
             paymentMethodNames,
-            isPartialPaymentSupported
+            isPartialPaymentSupported,
+            showStoredPaymentMethods
         ]
     }
 }

--- a/lib/src/common/model/payment_method_configurations/stored_payment_method_configuration.dart
+++ b/lib/src/common/model/payment_method_configurations/stored_payment_method_configuration.dart
@@ -3,19 +3,6 @@ class StoredPaymentMethodConfiguration {
   final bool? isRemoveStoredPaymentMethodEnabled;
   final Future<bool> Function(String)? deleteStoredPaymentMethodCallback;
 
-  /// Controls whether stored payment methods are shown in the Drop-in list.
-  ///
-  /// Defaults to `true`, which keeps the current behavior: stored payment
-  /// methods associated with the provided `shopperReference` are displayed.
-  ///
-  /// Set to `false` to hide stored payment methods from the Drop-in UI
-  /// without changing the `shopperReference` — useful when you still need
-  /// to tokenize new payment methods in the same session but do not want
-  /// to expose previously stored ones (e.g. a guest-like checkout where
-  /// the stored tokens should not be selectable).
-  ///
-  /// This mirrors the Web Drop-in option
-  /// `cardConfiguration.showStoredPaymentMethods`.
   final bool? showStoredPaymentMethods;
 
   StoredPaymentMethodConfiguration({

--- a/lib/src/common/model/payment_method_configurations/stored_payment_method_configuration.dart
+++ b/lib/src/common/model/payment_method_configurations/stored_payment_method_configuration.dart
@@ -3,10 +3,26 @@ class StoredPaymentMethodConfiguration {
   final bool? isRemoveStoredPaymentMethodEnabled;
   final Future<bool> Function(String)? deleteStoredPaymentMethodCallback;
 
+  /// Controls whether stored payment methods are shown in the Drop-in list.
+  ///
+  /// Defaults to `true`, which keeps the current behavior: stored payment
+  /// methods associated with the provided `shopperReference` are displayed.
+  ///
+  /// Set to `false` to hide stored payment methods from the Drop-in UI
+  /// without changing the `shopperReference` — useful when you still need
+  /// to tokenize new payment methods in the same session but do not want
+  /// to expose previously stored ones (e.g. a guest-like checkout where
+  /// the stored tokens should not be selectable).
+  ///
+  /// This mirrors the Web Drop-in option
+  /// `cardConfiguration.showStoredPaymentMethods`.
+  final bool? showStoredPaymentMethods;
+
   StoredPaymentMethodConfiguration({
     this.showPreselectedStoredPaymentMethod,
     this.isRemoveStoredPaymentMethodEnabled,
     this.deleteStoredPaymentMethodCallback,
+    this.showStoredPaymentMethods,
   });
 
   @override
@@ -14,6 +30,7 @@ class StoredPaymentMethodConfiguration {
     return 'StoredPaymentMethodConfiguration('
         'showPreselectedStoredPaymentMethod: $showPreselectedStoredPaymentMethod, '
         'isRemoveStoredPaymentMethodEnabled: $isRemoveStoredPaymentMethodEnabled, '
-        'deleteStoredPaymentMethodCallback: $deleteStoredPaymentMethodCallback)';
+        'deleteStoredPaymentMethodCallback: $deleteStoredPaymentMethodCallback, '
+        'showStoredPaymentMethods: $showStoredPaymentMethods)';
   }
 }

--- a/lib/src/generated/platform_api.g.dart
+++ b/lib/src/generated/platform_api.g.dart
@@ -631,6 +631,7 @@ class DropInConfigurationDTO {
     this.preselectedPaymentMethodTitle,
     this.paymentMethodNames,
     required this.isPartialPaymentSupported,
+    required this.showStoredPaymentMethods,
   });
 
   Environment environment;
@@ -669,6 +670,8 @@ class DropInConfigurationDTO {
 
   bool isPartialPaymentSupported;
 
+  bool showStoredPaymentMethods;
+
   Object encode() {
     return <Object?>[
       environment,
@@ -689,6 +692,7 @@ class DropInConfigurationDTO {
       preselectedPaymentMethodTitle,
       paymentMethodNames,
       isPartialPaymentSupported,
+      showStoredPaymentMethods,
     ];
   }
 
@@ -714,6 +718,7 @@ class DropInConfigurationDTO {
       paymentMethodNames:
           (result[16] as Map<Object?, Object?>?)?.cast<String?, String?>(),
       isPartialPaymentSupported: result[17]! as bool,
+      showStoredPaymentMethods: result[18]! as bool,
     );
   }
 }

--- a/lib/src/util/dto_mapper.dart
+++ b/lib/src/util/dto_mapper.dart
@@ -38,6 +38,9 @@ extension DropInConfigurationMapper on DropInConfiguration {
         preselectedPaymentMethodTitle: preselectedPaymentMethodTitle,
         paymentMethodNames: paymentMethodNames,
         isPartialPaymentSupported: isPartialPaymentSupported,
+        showStoredPaymentMethods: storedPaymentMethodConfiguration
+                ?.showStoredPaymentMethods ??
+            true,
       );
 
   bool _isRemoveStoredPaymentMethodEnabled(

--- a/pigeons/platform_api.dart
+++ b/pigeons/platform_api.dart
@@ -332,6 +332,7 @@ class DropInConfigurationDTO {
   final String? preselectedPaymentMethodTitle;
   final Map<String?, String?>? paymentMethodNames;
   final bool isPartialPaymentSupported;
+  final bool showStoredPaymentMethods;
 
   DropInConfigurationDTO(
     this.environment,
@@ -352,6 +353,7 @@ class DropInConfigurationDTO {
     this.preselectedPaymentMethodTitle,
     this.paymentMethodNames,
     this.isPartialPaymentSupported,
+    this.showStoredPaymentMethods,
   );
 }
 

--- a/test/dto_mapping_test.dart
+++ b/test/dto_mapping_test.dart
@@ -44,6 +44,57 @@ void main() {
     expect(dropInConfigurationDto.showPreselectedStoredPaymentMethod, true);
     expect(dropInConfigurationDto.isRemoveStoredPaymentMethodEnabled, true);
     expect(dropInConfigurationDto.isPartialPaymentSupported, true);
+    expect(dropInConfigurationDto.showStoredPaymentMethods, true);
+  });
+
+  test(
+      'when showStoredPaymentMethods is not provided, then DTO defaults to true',
+      () {
+    final dropInConfiguration = DropInConfiguration(
+      environment: Environment.test,
+      clientKey: "test-key",
+      countryCode: "US",
+    );
+
+    final dto = dropInConfiguration.toDTO("0.0.1", false);
+
+    expect(dto.showStoredPaymentMethods, true);
+  });
+
+  test(
+      'when showStoredPaymentMethods is set to false, then DTO mirrors the value',
+      () {
+    final storedPaymentMethodConfiguration = StoredPaymentMethodConfiguration(
+      showStoredPaymentMethods: false,
+    );
+    final dropInConfiguration = DropInConfiguration(
+      environment: Environment.test,
+      clientKey: "test-key",
+      countryCode: "US",
+      storedPaymentMethodConfiguration: storedPaymentMethodConfiguration,
+    );
+
+    final dto = dropInConfiguration.toDTO("0.0.1", false);
+
+    expect(dto.showStoredPaymentMethods, false);
+  });
+
+  test(
+      'when showStoredPaymentMethods is set to true, then DTO mirrors the value',
+      () {
+    final storedPaymentMethodConfiguration = StoredPaymentMethodConfiguration(
+      showStoredPaymentMethods: true,
+    );
+    final dropInConfiguration = DropInConfiguration(
+      environment: Environment.test,
+      clientKey: "test-key",
+      countryCode: "US",
+      storedPaymentMethodConfiguration: storedPaymentMethodConfiguration,
+    );
+
+    final dto = dropInConfiguration.toDTO("0.0.1", false);
+
+    expect(dto.showStoredPaymentMethods, true);
   });
 
   test(


### PR DESCRIPTION
Closes #658.

Adds `StoredPaymentMethodConfiguration.showStoredPaymentMethods` so Drop-in can hide previously stored payment methods from the payment list without changing the `shopperReference`. Mirrors the Web Drop-in option `cardConfiguration.showStoredPaymentMethods`.

## API

```dart
DropInConfiguration(
  environment: Environment.test,
  clientKey: clientKey,
  countryCode: 'NL',
  storedPaymentMethodConfiguration: StoredPaymentMethodConfiguration(
    showStoredPaymentMethods: false,
  ),
);
```

Default is `true`, so existing integrations keep their current behavior.

## What it changes

**Dart**
- New optional `showStoredPaymentMethods` field in `StoredPaymentMethodConfiguration`
- `DropInConfigurationDTO` pigeon DTO extended with the flat `showStoredPaymentMethods` bool (mirrors the existing `showPreselectedStoredPaymentMethod` / `isRemoveStoredPaymentMethodEnabled` pattern)
- `DropInConfigurationMapper.toDTO` propagates the value (defaults to `true` when not provided)

**Android**
- Session flow: `createCheckoutSession` rebuilds `SessionSetupResponse` with an empty `storedPaymentMethods` list when the flag is `false`
- Advanced flow: new `applyStoredPaymentMethodsVisibility` step runs after the existing gift-card filter and empties `storedPaymentMethods` when the flag is `false`
- Tests in `ConfigurationMapperTest` cover the DTO constructor and the `false` case

**iOS**
- Session flow and advanced flow both pass the `PaymentMethods` list through `applyStoredPaymentMethodsVisibility`, which returns `PaymentMethods(regular: ..., stored: [])` when the flag is `false`
- Tests in `ConfigurationMapperTests+DropIn` cover default and explicit `false`; `TestUtils` factory extended

## Why

There are cases where the same `shopperReference` is used across checkouts that should and shouldn't show previously tokenized cards. Keeping the shopper reference matters so the session can still tokenize new cards; just omitting the stored list from the UI is the lightest fix. Without this flag, the only workarounds are migrating to the advanced flow or forking the native SDKs — both heavy.

## Testing

Locally:

```
dart run pigeon --input pigeons/platform_api.dart
dart analyze            # No issues found
flutter test            # 47 tests pass
```

Android and iOS native tests were not run locally. They're included in the PR and will run in CI. Happy to iterate if the CI flags anything.

## Notes

- The regenerated `PlatformApi.swift` and `platform_api.g.dart` intentionally only contain the new field (and accompanying encode/decode/ctor entries). Running `pigeon` produced full-file reformats due to tool-version differences, so I discarded those and applied only the functional additions to keep the diff reviewable.
- The flag deliberately does not affect tokenization — new payment methods still get stored and linked to the `shopperReference`.
