### PR TITLE
chore: Update Android SDK to v5.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@
   Mirrors the Web Drop-in `DropinConfiguration.showStoredPaymentMethods` option.
 - `ActionComponentConfiguration` now supports `ThreeDS2Configuration`, including `requestorAppURL` and 3DS2 UI customization for standalone action handling.
 
+### Changed
+
+- Dependency versions:
+  | Name | Version |
+  |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+  | [Android Drop-in/Components](https://docs.adyen.com/online-payments/release-notes/?title%5B0%5D=Android+Components%2FDrop-in&version%5B0%5D=5.18.0) | 5.17.0 -> **5.18.0** |
+
 ## 1.9.0
 
 ### New

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Pub Package](https://img.shields.io/pub/v/adyen_checkout.svg)](https://pub.dev/packages/adyen_checkout)
 [![Adyen iOS](https://img.shields.io/badge/ios-v5.23.1-brightgreen.svg)](https://github.com/Adyen/adyen-ios/releases/tag/5.23.1)
-[![Adyen Android](https://img.shields.io/badge/android-v5.17.0-brightgreen.svg)](https://github.com/Adyen/adyen-android/releases/tag/5.17.0)
+[![Adyen Android](https://img.shields.io/badge/android-v5.18.0-brightgreen.svg)](https://github.com/Adyen/adyen-android/releases/tag/5.18.0)
 
 The Adyen Flutter package provides you with the building blocks to create a checkout experience for
 your shoppers, allowing them to pay using the payment method of their choice. This is

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.adyen.checkout:drop-in:5.17.0'
+        implementation 'com.adyen.checkout:drop-in:5.18.0'
         implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.23.0'


### PR DESCRIPTION
Update Adyen Android Checkout SDK from 5.17.0 to 5.18.0.

Changes:
- Updated Android dependency in build.gradle
- Updated Android version badge in README
- Updated Android version in CHANGELOG v1.10.0 (in development)