### PR TITLE
chore: Update iOS SDK to v5.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   | Name | Version |
   |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
   | [Android Drop-in/Components](https://docs.adyen.com/online-payments/release-notes/?title%5B0%5D=Android+Components%2FDrop-in&version%5B0%5D=5.18.0) | 5.17.0 -> **5.18.0** |
+  | [iOS Drop-in/Components](https://docs.adyen.com/online-payments/release-notes/?title%5B0%5D=iOS+Components%2FDrop-in&version%5B0%5D=5.24.0) | 5.23.1 -> **5.24.0** |
 
 ## 1.9.0
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Adyen Flutter
 
 [![Pub Package](https://img.shields.io/pub/v/adyen_checkout.svg)](https://pub.dev/packages/adyen_checkout)
-[![Adyen iOS](https://img.shields.io/badge/ios-v5.23.1-brightgreen.svg)](https://github.com/Adyen/adyen-ios/releases/tag/5.23.1)
+[![Adyen iOS](https://img.shields.io/badge/ios-v5.24.0-brightgreen.svg)](https://github.com/Adyen/adyen-ios/releases/tag/5.24.0)
 [![Adyen Android](https://img.shields.io/badge/android-v5.18.0-brightgreen.svg)](https://github.com/Adyen/adyen-android/releases/tag/5.18.0)
 
 The Adyen Flutter package provides you with the building blocks to create a checkout experience for

--- a/ios/adyen_checkout.podspec
+++ b/ios/adyen_checkout.podspec
@@ -15,7 +15,7 @@ Adyen checkout SDK for Flutter
   s.source           = { :path => '.' }
   s.source_files = 'adyen_checkout/Sources/adyen_checkout/**/*.swift'
   s.dependency 'Flutter'
-  s.dependency 'Adyen', '5.23.1'
+  s.dependency 'Adyen', '5.24.0'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/adyen_checkout/Package.swift
+++ b/ios/adyen_checkout/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "adyen-checkout", targets: ["adyen_checkout"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Adyen/adyen-ios", exact: "5.23.1")
+        .package(url: "https://github.com/Adyen/adyen-ios", exact: "5.24.0")
     ],
     targets: [
         .target(

--- a/ios/adyen_checkout/Sources/adyen_checkout/utils/ConfigurationMapper.swift
+++ b/ios/adyen_checkout/Sources/adyen_checkout/utils/ConfigurationMapper.swift
@@ -285,9 +285,9 @@ private func buildAdyenContext(environment: Environment, clientKey: String, amou
     }()
     var analyticsConfiguration = AnalyticsConfiguration()
     analyticsConfiguration.isEnabled = analyticsOptionsDTO.enabled
-    analyticsConfiguration.context = AnalyticsContext(
-        version: analyticsOptionsDTO.version,
-        platform: .flutter
+    CheckoutPlatformParams.shared.overrideForCrossPlatform(
+        platform: .flutter,
+        version: analyticsOptionsDTO.version
     )
 
     return AdyenContext(


### PR DESCRIPTION
Update Adyen iOS SDK from 5.23.1 to 5.24.0.

Changes:
- Updated CocoaPods dependency in adyen_checkout.podspec
- Updated Swift Package Manager pin in Package.swift
- Updated iOS version badge in README
- Updated iOS version in CHANGELOG v1.10.0 (in development)