### PR TITLE
Update Adyen iOS SDK to v5.25.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
   | Name | Version |
   |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
   | [Android Drop-in/Components](https://docs.adyen.com/online-payments/release-notes/?title%5B0%5D=Android+Components%2FDrop-in&version%5B0%5D=5.19.0) | 5.18.0 -> **5.19.0** |
-  | [iOS Drop-in/Components](https://docs.adyen.com/online-payments/release-notes/?title%5B0%5D=iOS+Components%2FDrop-in&version%5B0%5D=5.25.0) | 5.24.0 -> **5.25.0** |
+  | [iOS Drop-in/Components](https://docs.adyen.com/online-payments/release-notes/?title%5B0%5D=iOS+Components%2FDrop-in&version%5B0%5D=5.25.1) | 5.25.0 -> **5.25.1** |
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Adyen Flutter
 
 [![Pub Package](https://img.shields.io/pub/v/adyen_checkout.svg)](https://pub.dev/packages/adyen_checkout)
-[![Adyen iOS](https://img.shields.io/badge/ios-v5.25.0-brightgreen.svg)](https://github.com/Adyen/adyen-ios/releases/tag/5.25.0)
+[![Adyen iOS](https://img.shields.io/badge/ios-v5.25.1-brightgreen.svg)](https://github.com/Adyen/adyen-ios/releases/tag/5.25.1)
 [![Adyen Android](https://img.shields.io/badge/android-v5.19.0-brightgreen.svg)](https://github.com/Adyen/adyen-android/releases/tag/5.19.0)
 
 The Adyen Flutter package provides you with the building blocks to create a checkout experience for

--- a/ios/adyen_checkout.podspec
+++ b/ios/adyen_checkout.podspec
@@ -15,7 +15,7 @@ Adyen checkout SDK for Flutter
   s.source           = { :path => '.' }
   s.source_files = 'adyen_checkout/Sources/adyen_checkout/**/*.swift'
   s.dependency 'Flutter'
-  s.dependency 'Adyen', '5.25.0'
+  s.dependency 'Adyen', '5.25.1'
   s.platform = :ios, '12.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/ios/adyen_checkout/Package.swift
+++ b/ios/adyen_checkout/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
         .library(name: "adyen-checkout", targets: ["adyen_checkout"])
     ],
     dependencies: [
-        .package(url: "https://github.com/Adyen/adyen-ios", exact: "5.25.0")
+        .package(url: "https://github.com/Adyen/adyen-ios", exact: "5.25.1")
     ],
     targets: [
         .target(


### PR DESCRIPTION
Update Adyen iOS SDK dependency from 5.25.0 to 5.25.1.

Changes:
- Updated iOS SDK version in podspec
- Updated SPM dependency in Package.swift
- Updated iOS version badge in README
- Added entry in CHANGELOG