### PR TITLE
Bump minimum iOS version from 12.0 to 13.0

### DIFF
--- a/.github/workflows/ios_clean_build.yml
+++ b/.github/workflows/ios_clean_build.yml
@@ -44,6 +44,11 @@ jobs:
           cd demo_project
           dart pub add 'adyen_checkout:{"path":"../"}'
 
+      - name: Bump iOS deployment target to 13.0 for older Flutter versions
+        if: contains(fromJson('["3.16.x","3.19.x","3.22.x","3.24.x","3.27.x","3.29.x","3.32.x"]'), matrix.flutter-version)
+        working-directory: demo_project
+        run: sed -i '' 's/IPHONEOS_DEPLOYMENT_TARGET = [0-9.]*/IPHONEOS_DEPLOYMENT_TARGET = 13.0/g' ios/Runner.xcodeproj/project.pbxproj
+
       - name: Build app for simulator
         working-directory: demo_project
         run: flutter build ios --debug --simulator

--- a/.github/workflows/ios_spm_build.yml
+++ b/.github/workflows/ios_spm_build.yml
@@ -46,6 +46,11 @@ jobs:
           cd demo_project
           dart pub add 'adyen_checkout:{"path":"../"}'
 
+      - name: Bump iOS deployment target to 13.0 for older Flutter versions
+        if: matrix.flutter-version == '3.32.x'
+        working-directory: demo_project
+        run: sed -i '' 's/IPHONEOS_DEPLOYMENT_TARGET = [0-9.]*/IPHONEOS_DEPLOYMENT_TARGET = 13.0/g' ios/Runner.xcodeproj/project.pbxproj
+
       - name: Build app for simulator
         working-directory: demo_project
         run: flutter build ios --debug --simulator

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.12.0 (in development)
+
+### Changed
+
+- Minimum iOS version increased from 12.0 to 13.0. This aligns with Flutter's own minimum iOS
+  requirement.
+
 ## 1.11.0
 
 ### New

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ release a new version when we need to.
 
 #### iOS
 
-* [iOS 12](https://support.apple.com/en-us/118387) or later.
+* [iOS 13](https://support.apple.com/en-us/118392) or later.
 * Add the return URL handler to your AppDelegate in
   your [native iOS](https://github.com/Adyen/adyen-flutter/blob/main/example/ios/Runner/AppDelegate.swift#L19)
   layer.

--- a/ios/adyen_checkout.podspec
+++ b/ios/adyen_checkout.podspec
@@ -16,7 +16,7 @@ Adyen checkout SDK for Flutter
   s.source_files = 'adyen_checkout/Sources/adyen_checkout/**/*.swift'
   s.dependency 'Flutter'
   s.dependency 'Adyen', '5.25.1'
-  s.platform = :ios, '12.0'
+  s.platform = :ios, '13.0'
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }

--- a/ios/adyen_checkout/Package.swift
+++ b/ios/adyen_checkout/Package.swift
@@ -6,7 +6,7 @@ import PackageDescription
 let package = Package(
     name: "adyen_checkout",
     platforms: [
-        .iOS("12.0")
+        .iOS("13.0")
     ],
     products: [
         .library(name: "adyen-checkout", targets: ["adyen_checkout"])


### PR DESCRIPTION
## Summary

Bumps the plugin's minimum iOS deployment target from 12.0 to 13.0.

## Rationale

- Flutter itself requires iOS 13 (see [flutter/flutter#167735](https://github.com/flutter/flutter/issues/167735))
- The plugin advertising iOS 12 was misleading — no Flutter app can run on iOS 12 anymore
- The example app was already at iOS 13
- iOS 12 market share is negligible (<1% as of 2025)
- Still within Adyen iOS SDK 5.x support range (12+)

## Changes

- `ios/adyen_checkout.podspec`: `s.platform = :ios, '13.0'`
- `ios/adyen_checkout/Package.swift`: `.iOS("13.0")`
- `README.md`: Updated iOS requirement from 12 to 13
- `CHANGELOG.md`: Added 1.12.0 (in development) section

## Notes

- No `#available(iOS 13, *)` guards were found in the plugin code that could be removed
