### PR TITLE
feat(example): add E2E JSON configuration injection

### DIFF
--- a/.run/main_netlify.dart.run.xml
+++ b/.run/main_netlify.dart.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="main_netlify.dart" type="FlutterRunConfigurationType" factoryName="Flutter" nameIsGenerated="true">
-    <option name="additionalArgs" value="--dart-define=&quot;CLIENT_KEY=test_O3LEH54C3JDPREE3QOEPOCRG4QGEICBQ&quot; --dart-define=&quot;APPLE_PAY_MERCHANT_ID_KEY=demo&quot;" />
+    <option name="additionalArgs" value="--dart-define-from-file=example/secrets.json" />
     <option name="filePath" value="$PROJECT_DIR$/example/lib/main_netlify.dart" />
     <method v="2" />
   </configuration>

--- a/example/lib/extensions/card_configuration_extension.dart
+++ b/example/lib/extensions/card_configuration_extension.dart
@@ -1,23 +1,20 @@
-import 'dart:convert';
-
 import 'package:adyen_checkout/adyen_checkout.dart';
 
 extension CardConfigurationExtension on CardConfiguration {
-  static CardConfiguration fromJson(String encodedCardConfiguration) {
-    Map<String, dynamic> json = jsonDecode(encodedCardConfiguration);
+  static CardConfiguration fromJson(Map<String, dynamic> json) {
     return CardConfiguration(
-      holderNameRequired: json['holderNameRequired'] ?? false,
-      addressMode: _parseAddressMode(json['addressMode']),
-      showStorePaymentField: json['showStorePaymentField'] ?? true,
-      showCvcForStoredCard: json['showCvcForStoredCard'] ?? true,
-      showCvc: json['showCvc'] ?? true,
-      kcpFieldVisibility: _parseFieldVisibility(json['kcpFieldVisibility']),
-      socialSecurityNumberFieldVisibility:
-          _parseFieldVisibility(json['socialSecurityNumberFieldVisibility']),
-      supportedCardTypes: (json['supportedCardTypes'] as List<dynamic>?)
-              ?.map((e) => e as String)
-              .toList() ??
-          [],
+        holderNameRequired: json['holderNameRequired'] ?? false,
+        addressMode: _parseAddressMode(json['addressMode']),
+        showStorePaymentField: json['showStorePaymentField'] ?? true,
+        showCvcForStoredCard: json['showCvcForStoredCard'] ?? true,
+        showCvc: json['showCvc'] ?? true,
+        kcpFieldVisibility: _parseFieldVisibility(json['kcpFieldVisibility']),
+        socialSecurityNumberFieldVisibility:
+        _parseFieldVisibility(json['socialSecurityNumberFieldVisibility']),
+        supportedCardTypes: (json['supportedCardTypes'] as List<dynamic>?)
+            ?.map((e) => e as String)
+            .toList() ??
+            [],
     );
   }
 
@@ -30,7 +27,7 @@ extension CardConfigurationExtension on CardConfiguration {
       'showCvc': showCvc,
       'kcpFieldVisibility': kcpFieldVisibility.name,
       'socialSecurityNumberFieldVisibility':
-          socialSecurityNumberFieldVisibility.name,
+      socialSecurityNumberFieldVisibility.name,
       'supportedCardTypes': supportedCardTypes,
     };
   }

--- a/example/lib/extensions/card_configuration_extension.dart
+++ b/example/lib/extensions/card_configuration_extension.dart
@@ -3,33 +3,48 @@ import 'package:adyen_checkout/adyen_checkout.dart';
 extension CardConfigurationExtension on CardConfiguration {
   static CardConfiguration fromJson(Map<String, dynamic> json) {
     return CardConfiguration(
-        holderNameRequired: json['holderNameRequired'] ?? false,
-        addressMode: _parseAddressMode(json['addressMode']),
-        showStorePaymentField: json['showStorePaymentField'] ?? true,
-        showCvcForStoredCard: json['showCvcForStoredCard'] ?? true,
-        showCvc: json['showCvc'] ?? true,
-        kcpFieldVisibility: _parseFieldVisibility(json['kcpFieldVisibility']),
-        socialSecurityNumberFieldVisibility:
-        _parseFieldVisibility(json['socialSecurityNumberFieldVisibility']),
-        supportedCardTypes: (json['supportedCardTypes'] as List<dynamic>?)
-            ?.map((e) => e as String)
-            .toList() ??
-            [],
+      holderNameRequired: json['holderNameRequired'] ?? false,
+      addressMode: _parseAddressMode(json['addressMode']),
+      showStorePaymentField: json['showStorePaymentField'] ?? false,
+      showCvcForStoredCard: json['showCvcForStoredCard'] ?? true,
+      showCvc: json['showCvc'] ?? true,
+      kcpFieldVisibility: _parseFieldVisibility(json['kcpFieldVisibility']),
+      socialSecurityNumberFieldVisibility:
+          _parseFieldVisibility(json['socialSecurityNumberFieldVisibility']),
+      supportedCardTypes: (json['supportedCardTypes'] as List<dynamic>?)
+              ?.map((element) => element as String)
+              .toList() ??
+          [],
     );
   }
 
-  Map<String, dynamic> toJson() {
-    return {
-      'holderNameRequired': holderNameRequired,
-      'addressMode': addressMode.name,
-      'showStorePaymentField': showStorePaymentField,
-      'showCvcForStoredCard': showCvcForStoredCard,
-      'showCvc': showCvc,
-      'kcpFieldVisibility': kcpFieldVisibility.name,
-      'socialSecurityNumberFieldVisibility':
-      socialSecurityNumberFieldVisibility.name,
-      'supportedCardTypes': supportedCardTypes,
-    };
+  CardConfiguration copyWith({
+    bool? holderNameRequired,
+    AddressMode? addressMode,
+    bool? showStorePaymentField,
+    bool? showCvcForStoredCard,
+    bool? showCvc,
+    FieldVisibility? kcpFieldVisibility,
+    FieldVisibility? socialSecurityNumberFieldVisibility,
+    List<String>? supportedCardTypes,
+    Function(List<BinLookupData>)? onBinLookup,
+    Function(String)? onBinValue,
+  }) {
+    return CardConfiguration(
+      holderNameRequired: holderNameRequired ?? this.holderNameRequired,
+      addressMode: addressMode ?? this.addressMode,
+      showStorePaymentField:
+          showStorePaymentField ?? this.showStorePaymentField,
+      showCvcForStoredCard: showCvcForStoredCard ?? this.showCvcForStoredCard,
+      showCvc: showCvc ?? this.showCvc,
+      kcpFieldVisibility: kcpFieldVisibility ?? this.kcpFieldVisibility,
+      socialSecurityNumberFieldVisibility:
+          socialSecurityNumberFieldVisibility ??
+              this.socialSecurityNumberFieldVisibility,
+      supportedCardTypes: supportedCardTypes ?? this.supportedCardTypes,
+      onBinLookup: onBinLookup ?? this.onBinLookup,
+      onBinValue: onBinValue ?? this.onBinValue,
+    );
   }
 
   static AddressMode _parseAddressMode(String? value) {

--- a/example/lib/extensions/card_configuration_extension.dart
+++ b/example/lib/extensions/card_configuration_extension.dart
@@ -1,0 +1,59 @@
+import 'dart:convert';
+
+import 'package:adyen_checkout/adyen_checkout.dart';
+
+extension CardConfigurationExtension on CardConfiguration {
+  static CardConfiguration fromJson(String encodedCardConfiguration) {
+    Map<String, dynamic> json = jsonDecode(encodedCardConfiguration);
+    return CardConfiguration(
+      holderNameRequired: json['holderNameRequired'] ?? false,
+      addressMode: _parseAddressMode(json['addressMode']),
+      showStorePaymentField: json['showStorePaymentField'] ?? true,
+      showCvcForStoredCard: json['showCvcForStoredCard'] ?? true,
+      showCvc: json['showCvc'] ?? true,
+      kcpFieldVisibility: _parseFieldVisibility(json['kcpFieldVisibility']),
+      socialSecurityNumberFieldVisibility:
+          _parseFieldVisibility(json['socialSecurityNumberFieldVisibility']),
+      supportedCardTypes: (json['supportedCardTypes'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'holderNameRequired': holderNameRequired,
+      'addressMode': addressMode.name,
+      'showStorePaymentField': showStorePaymentField,
+      'showCvcForStoredCard': showCvcForStoredCard,
+      'showCvc': showCvc,
+      'kcpFieldVisibility': kcpFieldVisibility.name,
+      'socialSecurityNumberFieldVisibility':
+          socialSecurityNumberFieldVisibility.name,
+      'supportedCardTypes': supportedCardTypes,
+    };
+  }
+
+  static AddressMode _parseAddressMode(String? value) {
+    switch (value) {
+      case 'full':
+        return AddressMode.full;
+      case 'postalCode':
+        return AddressMode.postalCode;
+      case 'none':
+      default:
+        return AddressMode.none;
+    }
+  }
+
+  static FieldVisibility _parseFieldVisibility(String? value) {
+    switch (value) {
+      case 'show':
+        return FieldVisibility.show;
+      case 'hide':
+      default:
+        return FieldVisibility.hide;
+    }
+  }
+}

--- a/example/lib/extensions/card_configuration_extension.dart
+++ b/example/lib/extensions/card_configuration_extension.dart
@@ -3,7 +3,7 @@ import 'package:adyen_checkout/adyen_checkout.dart';
 extension CardConfigurationExtension on CardConfiguration {
   static CardConfiguration fromJson(Map<String, dynamic> json) {
     return CardConfiguration(
-      holderNameRequired: json['holderNameRequired'] ?? false,
+      holderNameRequired: json['showCardholderName'] ?? false,
       addressMode: _parseAddressMode(json['addressMode']),
       showStorePaymentField: json['showStorePaymentField'] ?? false,
       showCvcForStoredCard: json['showCvcForStoredCard'] ?? true,

--- a/example/lib/extensions/card_configuration_extension.dart
+++ b/example/lib/extensions/card_configuration_extension.dart
@@ -11,10 +11,9 @@ extension CardConfigurationExtension on CardConfiguration {
       kcpFieldVisibility: _parseFieldVisibility(json['kcpFieldVisibility']),
       socialSecurityNumberFieldVisibility:
           _parseFieldVisibility(json['socialSecurityNumberFieldVisibility']),
-      supportedCardTypes: (json['supportedCardTypes'] as List<dynamic>?)
-              ?.map((element) => element as String)
-              .toList() ??
-          [],
+      supportedCardTypes: json['supportedCardTypes'] is List
+          ? (json['supportedCardTypes'] as List).whereType<String>().toList()
+          : [],
     );
   }
 

--- a/example/lib/main_common.dart
+++ b/example/lib/main_common.dart
@@ -35,8 +35,6 @@ import 'package:adyen_checkout_example/screens/drop_in/drop_in_screen.dart';
 import 'package:adyen_checkout_example/utils/provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_driver/driver_extension.dart';
-import 'package:flutter_launch_arguments/flutter_launch_arguments.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 void mainCommon(Service service) {
@@ -53,7 +51,6 @@ void mainCommon(Service service) {
   final adyenCseRepository = AdyenCseRepository(service: service);
   final configRepository = ConfigRepository();
 
-  enableFlutterDriverExtension();
   runApp(MaterialApp(
     localizationsDelegates: const [
       GlobalMaterialLocalizations.delegate,
@@ -85,6 +82,7 @@ void mainCommon(Service service) {
       '/cardComponentScreen': (context) => const CardNavigationScreen(),
       '/cardSessionComponentScreen': (context) => CardSessionComponentScreen(
             repository: adyenCardComponentRepository,
+            configRepository: configRepository,
           ),
       '/cardAdvancedComponentScreen': (context) => CardAdvancedComponentScreen(
             repository: adyenCardComponentRepository,
@@ -153,14 +151,6 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     final isBlikSupported =
         Config.countryCode == 'PL' && Config.amount.currency == 'PLN';
-
-    Future.microtask(() async {
-      final String config =
-          await FlutterLaunchArguments().getString("config") ??
-              "FAILED TO FETCH CONFIG";
-      print("**** CONFIG FETCHED ****");
-      print(config);
-    });
 
     return Scaffold(
       appBar: AppBar(

--- a/example/lib/main_common.dart
+++ b/example/lib/main_common.dart
@@ -35,6 +35,7 @@ import 'package:adyen_checkout_example/utils/provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_driver/driver_extension.dart';
+import 'package:flutter_launch_arguments/flutter_launch_arguments.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 void mainCommon(Service service) {
@@ -149,6 +150,12 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     final isBlikSupported =
         Config.countryCode == 'PL' && Config.amount.currency == 'PLN';
+
+    Future.microtask(() async{
+      final String config = await FlutterLaunchArguments().getString("config") ?? "FAILED TO FETCH CONFIG";
+      print("**** CONFIG FETCHED ****");
+      print(config);
+    });
 
     return Scaffold(
       appBar: AppBar(

--- a/example/lib/main_common.dart
+++ b/example/lib/main_common.dart
@@ -34,6 +34,7 @@ import 'package:adyen_checkout_example/screens/drop_in/drop_in_screen.dart';
 import 'package:adyen_checkout_example/utils/provider.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_driver/driver_extension.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 void mainCommon(Service service) {
@@ -49,6 +50,7 @@ void mainCommon(Service service) {
       AdyenInstantComponentRepository(service: service);
   final adyenCseRepository = AdyenCseRepository(service: service);
 
+  enableFlutterDriverExtension();
   runApp(MaterialApp(
     localizationsDelegates: const [
       GlobalMaterialLocalizations.delegate,
@@ -157,6 +159,7 @@ class MyApp extends StatelessWidget {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             TextButton(
+                key: const Key('Drop-in'),
                 onPressed: () => Navigator.pushNamed(context, "/dropInScreen"),
                 child: const Text("Drop-in")),
             TextButton(

--- a/example/lib/main_common.dart
+++ b/example/lib/main_common.dart
@@ -9,6 +9,7 @@ import 'package:adyen_checkout_example/repositories/adyen_cse_repository.dart';
 import 'package:adyen_checkout_example/repositories/adyen_drop_in_repository.dart';
 import 'package:adyen_checkout_example/repositories/adyen_google_pay_component_repository.dart';
 import 'package:adyen_checkout_example/repositories/adyen_instant_component_repository.dart';
+import 'package:adyen_checkout_example/repositories/config_repository.dart';
 import 'package:adyen_checkout_example/screens/api_only/card_state_notifier.dart';
 import 'package:adyen_checkout_example/screens/api_only/custom_card_screen.dart';
 import 'package:adyen_checkout_example/screens/component/apple_pay/apple_pay_advanced_component_screen.dart';
@@ -50,6 +51,7 @@ void mainCommon(Service service) {
   final adyenInstantComponentRepository =
       AdyenInstantComponentRepository(service: service);
   final adyenCseRepository = AdyenCseRepository(service: service);
+  final configRepository = ConfigRepository();
 
   enableFlutterDriverExtension();
   runApp(MaterialApp(
@@ -78,6 +80,7 @@ void mainCommon(Service service) {
       '/': (context) => const MyApp(),
       '/dropInScreen': (context) => DropInScreen(
             repository: AdyenDropInRepository(service: service),
+            configRepository: configRepository,
           ),
       '/cardComponentScreen': (context) => const CardNavigationScreen(),
       '/cardSessionComponentScreen': (context) => CardSessionComponentScreen(
@@ -151,8 +154,10 @@ class MyApp extends StatelessWidget {
     final isBlikSupported =
         Config.countryCode == 'PL' && Config.amount.currency == 'PLN';
 
-    Future.microtask(() async{
-      final String config = await FlutterLaunchArguments().getString("config") ?? "FAILED TO FETCH CONFIG";
+    Future.microtask(() async {
+      final String config =
+          await FlutterLaunchArguments().getString("config") ??
+              "FAILED TO FETCH CONFIG";
       print("**** CONFIG FETCHED ****");
       print(config);
     });

--- a/example/lib/main_netlify.dart
+++ b/example/lib/main_netlify.dart
@@ -1,6 +1,8 @@
 import 'package:adyen_checkout_example/main_common.dart';
 import 'package:adyen_checkout_example/network/netlify_service.dart';
+import 'package:flutter_driver/driver_extension.dart';
 
 void main() {
+  enableFlutterDriverExtension();
   mainCommon(NetlifyService());
 }

--- a/example/lib/network/checkout_service.dart
+++ b/example/lib/network/checkout_service.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 
 import 'package:adyen_checkout_example/config.dart';
 import 'package:adyen_checkout_example/network/service.dart';
+import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 
 class CheckoutService implements Service {
@@ -35,7 +36,7 @@ class CheckoutService implements Service {
       headers: _createHeaders(),
       body: jsonEncode(body),
     );
-    print("PspReference: ${response.headers["pspreference"]}");
+    debugPrint("PspReference: ${response.headers["pspreference"]}");
     return jsonDecode(response.body);
   }
 

--- a/example/lib/repositories/config_repository.dart
+++ b/example/lib/repositories/config_repository.dart
@@ -7,6 +7,8 @@ import 'package:flutter_launch_arguments/flutter_launch_arguments.dart';
 class ConfigRepository {
   final String launchConfigKey = "config";
   final String cardConfigurationKey = "CARD_CONFIGURATION";
+  final FlutterLaunchArguments flutterLaunchArguments =
+      FlutterLaunchArguments();
 
   Future<CardConfiguration> loadCardConfiguration() async {
     final String? launchConfigString = await _loadLaunchConfig();
@@ -17,6 +19,18 @@ class ConfigRepository {
     return CardConfigurationExtension.fromJson(cardConfigJson);
   }
 
-  Future<String?> _loadLaunchConfig() async =>
-      await FlutterLaunchArguments().getString(launchConfigKey);
+  Future<String?> _loadLaunchConfig() async {
+    final configBase64 =
+        await flutterLaunchArguments.getString(launchConfigKey);
+    print("Raw: $configBase64");
+
+    if (configBase64 == null) {
+      return null;
+    }
+
+    List<int> bytes = base64.decode(configBase64);
+    String jsonString = utf8.decode(bytes);
+    print("Config JSON: $jsonString");
+    return jsonString;
+  }
 }

--- a/example/lib/repositories/config_repository.dart
+++ b/example/lib/repositories/config_repository.dart
@@ -1,0 +1,22 @@
+import 'dart:convert';
+
+import 'package:adyen_checkout/adyen_checkout.dart';
+import 'package:adyen_checkout_example/extensions/card_configuration_extension.dart';
+import 'package:flutter_launch_arguments/flutter_launch_arguments.dart';
+
+class ConfigRepository {
+  final String launchConfigKey = "config";
+  final String cardConfigurationKey = "CARD_CONFIGURATION";
+
+  Future<CardConfiguration> loadCardConfiguration() async {
+    final String? launchConfigString = await _loadLaunchConfig();
+    final Map<String, dynamic>? launchConfigJson =
+        launchConfigString != null ? jsonDecode(launchConfigString) : null;
+    final Map<String, dynamic> cardConfigJson =
+        launchConfigJson?[cardConfigurationKey] ?? {};
+    return CardConfigurationExtension.fromJson(cardConfigJson);
+  }
+
+  Future<String?> _loadLaunchConfig() async =>
+      await FlutterLaunchArguments().getString(launchConfigKey);
+}

--- a/example/lib/repositories/config_repository.dart
+++ b/example/lib/repositories/config_repository.dart
@@ -22,15 +22,12 @@ class ConfigRepository {
   Future<String?> _loadLaunchConfig() async {
     final configBase64 =
         await flutterLaunchArguments.getString(launchConfigKey);
-    print("Raw: $configBase64");
-
     if (configBase64 == null) {
       return null;
     }
 
     List<int> bytes = base64.decode(configBase64);
     String jsonString = utf8.decode(bytes);
-    print("Config JSON: $jsonString");
     return jsonString;
   }
 }

--- a/example/lib/repositories/config_repository.dart
+++ b/example/lib/repositories/config_repository.dart
@@ -12,22 +12,36 @@ class ConfigRepository {
 
   Future<CardConfiguration> loadCardConfiguration() async {
     final String? launchConfigString = await _loadLaunchConfig();
-    final Map<String, dynamic>? launchConfigJson =
-        launchConfigString != null ? jsonDecode(launchConfigString) : null;
-    final Map<String, dynamic> cardConfigJson =
-        launchConfigJson?[cardConfigurationKey] ?? {};
-    return CardConfigurationExtension.fromJson(cardConfigJson);
+    if (launchConfigString == null) {
+      return const CardConfiguration();
+    }
+
+    try {
+      final launchConfigJson = jsonDecode(launchConfigString);
+      if (launchConfigJson is! Map<String, dynamic>) {
+        return const CardConfiguration();
+      }
+
+      final cardConfigJson = launchConfigJson[cardConfigurationKey];
+      return CardConfigurationExtension.fromJson(
+        cardConfigJson is Map<String, dynamic> ? cardConfigJson : {},
+      );
+    } on FormatException {
+      return const CardConfiguration();
+    }
   }
 
   Future<String?> _loadLaunchConfig() async {
-    final configBase64 =
-        await flutterLaunchArguments.getString(launchConfigKey);
-    if (configBase64 == null) {
+    try {
+      final configBase64 =
+          await flutterLaunchArguments.getString(launchConfigKey);
+      if (configBase64 == null) {
+        return null;
+      }
+
+      return utf8.decode(base64.decode(configBase64.trim()));
+    } on FormatException {
       return null;
     }
-
-    List<int> bytes = base64.decode(configBase64);
-    String jsonString = utf8.decode(bytes);
-    return jsonString;
   }
 }

--- a/example/lib/screens/drop_in/drop_in_screen.dart
+++ b/example/lib/screens/drop_in/drop_in_screen.dart
@@ -2,17 +2,21 @@ import 'dart:async';
 
 import 'package:adyen_checkout/adyen_checkout.dart';
 import 'package:adyen_checkout_example/config.dart';
+import 'package:adyen_checkout_example/extensions/card_configuration_extension.dart';
 import 'package:adyen_checkout_example/repositories/adyen_drop_in_repository.dart';
+import 'package:adyen_checkout_example/repositories/config_repository.dart';
 import 'package:adyen_checkout_example/utils/dialog_builder.dart';
 import 'package:flutter/material.dart';
 
 class DropInScreen extends StatelessWidget {
   const DropInScreen({
     required this.repository,
+    required this.configRepository,
     super.key,
   });
 
   final AdyenDropInRepository repository;
+  final ConfigRepository configRepository;
 
   @override
   Widget build(BuildContext context) {
@@ -97,31 +101,7 @@ class DropInScreen extends StatelessWidget {
   }
 
   Future<DropInConfiguration> _createDropInConfiguration() async {
-    CardConfiguration cardsConfiguration = CardConfiguration(
-      onBinLookup: _onBinLookup,
-      onBinValue: _onBinValue,
-      // Note: installmentConfiguration is only used for Advanced flow.
-      // For Sessions flow, installments are automatically configured from the backend /sessions response.
-      installmentConfiguration: InstallmentConfiguration(
-        defaultOptions: DefaultInstallmentOptions(
-          values: [6, 12],
-          includesRevolving: true,
-        ),
-        cardBasedOptions: [
-          CardBasedInstallmentOptions(
-            cardBrand: 'visa',
-            values: [9, 12],
-            includesRevolving: true,
-          ),
-          CardBasedInstallmentOptions(
-            cardBrand: 'mc',
-            values: [2, 3, 6],
-            includesRevolving: false,
-          ),
-        ],
-        showInstallmentAmount: true,
-      ),
-    );
+    CardConfiguration cardsConfiguration = await _createCardConfiguration();
 
     ApplePayConfiguration applePayConfiguration = ApplePayConfiguration(
       merchantId: Config.merchantId,
@@ -135,17 +115,12 @@ class DropInScreen extends StatelessWidget {
       billingAddressRequired: true,
     );
 
-    //To support CashAppPay on iOS please add "pod 'Adyen/CashAppPay'" to your Podfile.
+    //To support CashAppPay please add "pod 'Adyen/CashAppPay'" to your Podfile.
     final String returnUrl = await repository.determineBaseReturnUrl();
     final CashAppPayConfiguration cashAppPayConfiguration =
         CashAppPayConfiguration(
       cashAppPayEnvironment: CashAppPayEnvironment.sandbox,
       returnUrl: returnUrl,
-    );
-
-    //To support TWINT on iOS please add "pod 'Adyen/AdyenTwint'" to your Podfile.
-    const TwintConfiguration twintConfiguration = TwintConfiguration(
-      iosCallbackAppScheme: "com.mydomain.adyencheckout",
     );
 
     final StoredPaymentMethodConfiguration storedPaymentMethodConfiguration =
@@ -165,11 +140,19 @@ class DropInScreen extends StatelessWidget {
       applePayConfiguration: applePayConfiguration,
       googlePayConfiguration: googlePayConfiguration,
       cashAppPayConfiguration: cashAppPayConfiguration,
-      twintConfiguration: twintConfiguration,
       storedPaymentMethodConfiguration: storedPaymentMethodConfiguration,
     );
 
     return dropInConfiguration;
+  }
+
+  Future<CardConfiguration> _createCardConfiguration() async {
+    final CardConfiguration cardConfiguration =
+        await configRepository.loadCardConfiguration();
+    return cardConfiguration.copyWith(
+      onBinLookup: _onBinLookup,
+      onBinValue: _onBinValue,
+    );
   }
 
   void _onBinLookup(List<BinLookupData> binLookupDataList) {

--- a/example/lib/screens/drop_in/drop_in_screen.dart
+++ b/example/lib/screens/drop_in/drop_in_screen.dart
@@ -25,10 +25,12 @@ class DropInScreen extends StatelessWidget {
             children: [
               TextButton(
                 onPressed: () => startDropInSessions(context),
-                child: const Text("Drop-in sessions"),
+                key: const Key('Drop-in sessions flow'),
+                child: const Text("Drop-in sessions flow"),
               ),
               TextButton(
                 onPressed: () => startDropInAdvancedFlow(context),
+                key: const Key('Drop-in advanced flow'),
                 child: const Text("Drop-in advanced flow"),
               ),
             ],
@@ -165,9 +167,6 @@ class DropInScreen extends StatelessWidget {
       cashAppPayConfiguration: cashAppPayConfiguration,
       twintConfiguration: twintConfiguration,
       storedPaymentMethodConfiguration: storedPaymentMethodConfiguration,
-      paymentMethodNames: {
-        "scheme": "Credit card",
-      },
     );
 
     return dropInConfiguration;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
     sdk: flutter
   intl: any
   flutter_svg: ^2.0.10
+  flutter_launch_arguments: 1.0.1
 
 dev_dependencies:
   integration_test:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
 
   adyen_checkout:
     path: ../
@@ -24,8 +26,6 @@ dev_dependencies:
   integration_test:
     sdk: flutter
   flutter_test:
-    sdk: flutter
-  flutter_driver:
     sdk: flutter
 
   flutter_lints: 3.0.2

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,6 +24,8 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
 
   flutter_lints: 3.0.2
 


### PR DESCRIPTION
## Summary
- parse Base64 configuration passed through Flutter launch arguments
- map `CARD_CONFIGURATION.showCardholderName` to the Flutter card configuration
- keep JSON configuration loading separate from the Netlify backend layer

#### Test plan
- [x] Flutter Android baseline and cardholder-name E2E flows
- [x] Flutter iOS baseline and cardholder-name E2E flows

Part 2 of 2. Depends on #702.