### PR TITLE
chore(android): bump minSdk to 23 and update pay dependencies

### DIFF
--- a/.github/workflows/android_clean_build.yml
+++ b/.github/workflows/android_clean_build.yml
@@ -80,6 +80,7 @@ jobs:
             sed -i "s/ext.kotlin_version = '1.7.10'/ext.kotlin_version = '1.8.22'/g" android/build.gradle
             sed -i "s/gradle-7.5-all/gradle-$GRADLE_VERSION-all/g" android/gradle/wrapper/gradle-wrapper.properties
             change_agp_version
+            change_sdk_versions
           fi
           
           # Change Kotlin version and adjust Gradle for Flutter 3.19.x - 3.24.x versions
@@ -87,6 +88,12 @@ jobs:
             sed -i 's/"org.jetbrains.kotlin.android" version "1.7.10"/"org.jetbrains.kotlin.android" version "1.8.22"/g' android/settings.gradle
             sed -i "s/gradle-7.6.3-all/gradle-$GRADLE_VERSION-all/g" android/gradle/wrapper/gradle-wrapper.properties
             change_agp_version
+            change_sdk_versions
+          fi
+
+          # Ensure the demo app meets the plugin's minimum Android SDK requirement for Flutter 3.27.x - 3.32.x
+          if [[ "$FLUTTER_VERSION" == "3.27.x" || "$FLUTTER_VERSION" == "3.29.x" || "$FLUTTER_VERSION" == "3.32.x" ]]; then
+            change_sdk_versions
           fi  
 
           # Add missing Kotlin options for Flutter 3.22.x
@@ -104,9 +111,6 @@ jobs:
             echo "kotlin.jvm.target.validation.mode=warning" >> android/gradle.properties
           fi
 
-          # Ensure the demo app meets the plugin's minimum Android SDK requirement
-          change_sdk_versions
-          
           dart pub add 'adyen_checkout:{"path":"../"}'
           flutter build apk --debug  
 

--- a/.github/workflows/android_clean_build.yml
+++ b/.github/workflows/android_clean_build.yml
@@ -61,8 +61,14 @@ jobs:
           cd demo_project
           
           change_sdk_versions() {
-            sed -i "s/flutter.compileSdkVersion/$COMPILE_SDK_VERSION/g" android/app/build.gradle
-            sed -i "s/flutter.minSdkVersion/23/g" android/app/build.gradle
+            if [ -f android/app/build.gradle ]; then
+              sed -i "s/flutter.compileSdkVersion/$COMPILE_SDK_VERSION/g" android/app/build.gradle
+              sed -i "s/flutter.minSdkVersion/23/g" android/app/build.gradle
+            fi
+            if [ -f android/app/build.gradle.kts ]; then
+              sed -i "s/flutter.compileSdkVersion/$COMPILE_SDK_VERSION/g" android/app/build.gradle.kts
+              sed -i "s/flutter.minSdkVersion/23/g" android/app/build.gradle.kts
+            fi
           }
           
           change_agp_version() {

--- a/.github/workflows/android_clean_build.yml
+++ b/.github/workflows/android_clean_build.yml
@@ -62,7 +62,7 @@ jobs:
           
           change_sdk_versions() {
             sed -i "s/flutter.compileSdkVersion/$COMPILE_SDK_VERSION/g" android/app/build.gradle
-            sed -i "s/flutter.minSdkVersion/21/g" android/app/build.gradle
+            sed -i "s/flutter.minSdkVersion/23/g" android/app/build.gradle
           }
           
           change_agp_version() {
@@ -74,7 +74,6 @@ jobs:
             sed -i "s/ext.kotlin_version = '1.7.10'/ext.kotlin_version = '1.8.22'/g" android/build.gradle
             sed -i "s/gradle-7.5-all/gradle-$GRADLE_VERSION-all/g" android/gradle/wrapper/gradle-wrapper.properties
             change_agp_version
-            change_sdk_versions
           fi
           
           # Change Kotlin version and adjust Gradle for Flutter 3.19.x - 3.24.x versions
@@ -82,10 +81,9 @@ jobs:
             sed -i 's/"org.jetbrains.kotlin.android" version "1.7.10"/"org.jetbrains.kotlin.android" version "1.8.22"/g' android/settings.gradle
             sed -i "s/gradle-7.6.3-all/gradle-$GRADLE_VERSION-all/g" android/gradle/wrapper/gradle-wrapper.properties
             change_agp_version
-            change_sdk_versions
           fi  
 
-          #Add missing Kotlin options for Flutter 3.22.x
+          # Add missing Kotlin options for Flutter 3.22.x
           if [ $FLUTTER_VERSION == '3.22.x' ]; then
             sed -i '/defaultConfig {/i \
               kotlinOptions {\
@@ -95,10 +93,13 @@ jobs:
           fi
                     
           # Suppress Kotlin 2.2.x strict JVM target consistency errors in dependencies (Flutter 3.44.x+)
-          # pay_android 3.1.x defaults to JVM 1.8 which conflicts with our JVM 11 target
+          # pay_android 3.2.x defaults to JVM 1.8 which conflicts with our JVM 11 target
           if [[ "$FLUTTER_VERSION" == "3.44.x" ]]; then
             echo "kotlin.jvm.target.validation.mode=warning" >> android/gradle.properties
           fi
+
+          # Ensure the demo app meets the plugin's minimum Android SDK requirement
+          change_sdk_versions
           
           dart pub add 'adyen_checkout:{"path":"../"}'
           flutter build apk --debug  

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 - Minimum iOS version increased from 12.0 to 13.0. This aligns with Flutter's own minimum iOS
   requirement.
+- Minimum Android version increased from API 21 to API 23. This aligns with the Adyen Android SDK
+  and the latest `pay` package requirements.
+- Dependency versions:
+  | Name | Version |
+  |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
+  | [pay](https://pub.dev/packages/pay) | 3.2.1 -> **3.3.0** |
+
+  `pay_android` is now pulled in transitively by `pay` (endorsed implementation).
 
 ## 1.11.0
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ release a new version when we need to.
 
 #### Android
 
-* [Android 5.0](https://www.android.com/versions/lollipop-5-0/) (API 21) or later.
+* [Android 6.0](https://www.android.com/versions/marshmallow-6-0/) (API 23) or later.
 * [Kotlin 2.0.20](https://kotlinlang.org/docs/releases.html) or later.
 * [AGP 8.1](https://developer.android.com/build/releases/gradle-plugin) or later with Gradle 8.
 * Requires the usage of a `FlutterFragmentActivity` instead of the default `FlutterActivity` in the

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -28,7 +28,7 @@ apply from: 'jacoco.gradle'
 
 android {
     namespace = "com.adyen.checkout.flutter"
-    compileSdk 35
+    compileSdk 36
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
@@ -45,7 +45,7 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 23
         consumerProguardFiles 'proguard-rules.pro'
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,8 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
-  pay: '>=3.2.1 <3.3.0' # v3.3.0+ requires Android minSDK 23
-  pay_android: '>=3.1.1 <3.2.0' # v3.2.0+ requires Android minSDK 23
+  pay: ^3.3.0 # Requires Android minSdk 23
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.1.8
-  pay: ^3.3.0 # Requires Android minSdk 23
+  pay: ^3.3.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- Increase Android `minSdkVersion` from 21 to 23 to align with the Adyen Android SDK.
- Align plugin `compileSdk` with the example app and native SDK at 36.
- Update `pay` to 3.3.0; `pay_android` is now pulled in transitively via the endorsed implementation.
- Update the Android clean build workflow to override `flutter.minSdkVersion` with 23 for relevant matrix versions.
- Update README and CHANGELOG to reflect the new minimum Android version.

#### Test plan
- [x] `flutter test` passes.
- [x] Example app `flutter build apk --debug` passes after `flutter clean`.
- [x] Android unit tests (`:adyen_checkout:jacocoTestReport`) pass.
- [x] Android lint/ktlint run completed.