### PR TITLE
fix: use country code for Android card address

### DIFF
--- a/android/src/main/kotlin/com/adyen/checkout/flutter/utils/ConfigurationMapper.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/utils/ConfigurationMapper.kt
@@ -269,9 +269,10 @@ object ConfigurationMapper {
 
     private fun AddressMode.mapToAddressConfiguration(countryCode: String?): AddressConfiguration =
         when (this) {
-            AddressMode.FULL -> AddressConfiguration.FullAddress(
-                defaultCountryCode = countryCode?.takeIf { it.isNotBlank() },
-            )
+            AddressMode.FULL ->
+                AddressConfiguration.FullAddress(
+                    defaultCountryCode = countryCode?.takeIf { it.isNotBlank() },
+                )
             AddressMode.POSTAL_CODE -> AddressConfiguration.PostalCode()
             AddressMode.NONE -> AddressConfiguration.None
         }

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/utils/ConfigurationMapper.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/utils/ConfigurationMapper.kt
@@ -269,7 +269,9 @@ object ConfigurationMapper {
 
     private fun AddressMode.mapToAddressConfiguration(countryCode: String?): AddressConfiguration =
         when (this) {
-            AddressMode.FULL -> AddressConfiguration.FullAddress(defaultCountryCode = countryCode)
+            AddressMode.FULL -> AddressConfiguration.FullAddress(
+                defaultCountryCode = countryCode?.takeIf { it.isNotBlank() },
+            )
             AddressMode.POSTAL_CODE -> AddressConfiguration.PostalCode()
             AddressMode.NONE -> AddressConfiguration.None
         }

--- a/android/src/main/kotlin/com/adyen/checkout/flutter/utils/ConfigurationMapper.kt
+++ b/android/src/main/kotlin/com/adyen/checkout/flutter/utils/ConfigurationMapper.kt
@@ -172,7 +172,7 @@ object ConfigurationMapper {
         ).apply {
             cardConfigurationDTO?.let { configurationDTO ->
                 card {
-                    addressConfiguration = configurationDTO.addressMode.mapToAddressConfiguration()
+                    addressConfiguration = configurationDTO.addressMode.mapToAddressConfiguration(countryCode)
                     isStorePaymentFieldVisible = configurationDTO.showStorePaymentField
                     isHideCvcStoredCard = !configurationDTO.showCvcForStoredCard
                     isHideCvc = !configurationDTO.showCvc
@@ -267,9 +267,9 @@ object ConfigurationMapper {
         return AnalyticsConfiguration(analyticsLevel)
     }
 
-    private fun AddressMode.mapToAddressConfiguration(): AddressConfiguration =
+    private fun AddressMode.mapToAddressConfiguration(countryCode: String?): AddressConfiguration =
         when (this) {
-            AddressMode.FULL -> AddressConfiguration.FullAddress()
+            AddressMode.FULL -> AddressConfiguration.FullAddress(defaultCountryCode = countryCode)
             AddressMode.POSTAL_CODE -> AddressConfiguration.PostalCode()
             AddressMode.NONE -> AddressConfiguration.None
         }

--- a/android/src/test/kotlin/com/adyen/checkout/flutter/ConfigurationMapperTest.kt
+++ b/android/src/test/kotlin/com/adyen/checkout/flutter/ConfigurationMapperTest.kt
@@ -408,6 +408,34 @@ class ConfigurationMapperTest {
         }
 
         @Test
+        fun `when card configuration has blank country code, then map to null default country code`() {
+            val cardConfigurationDTO = CardConfigurationDTO(
+                holderNameRequired = true,
+                addressMode = AddressMode.FULL,
+                showStorePaymentField = true,
+                showCvcForStoredCard = true,
+                showCvc = true,
+                kcpFieldVisibility = FieldVisibility.HIDE,
+                socialSecurityNumberFieldVisibility = FieldVisibility.HIDE,
+                supportedCardTypes = emptyList()
+            )
+            val cardComponentConfigurationDTO = CardComponentConfigurationDTO(
+                environment = Environment.TEST,
+                clientKey = TEST_CLIENT_KEY,
+                countryCode = " ",
+                amount = AmountDTO("USD", 1824),
+                analyticsOptionsDTO = AnalyticsOptionsDTO(false, "0.0.1"),
+                cardConfiguration = cardConfigurationDTO,
+            )
+
+            val checkoutConfiguration = cardComponentConfigurationDTO.toCheckoutConfiguration()
+            val cardConfiguration = checkoutConfiguration.getConfiguration<CardConfiguration>(PaymentMethodTypes.SCHEME)
+            val addressConfiguration = assertIs<AddressConfiguration.FullAddress>(cardConfiguration?.addressConfiguration)
+
+            assertNull(addressConfiguration.defaultCountryCode)
+        }
+
+        @Test
         fun `when card configuration has address mode POSTAL_CODE, then map to PostalCode`() {
             val cardConfigurationDTO = CardConfigurationDTO(
                 holderNameRequired = false,

--- a/android/src/test/kotlin/com/adyen/checkout/flutter/ConfigurationMapperTest.kt
+++ b/android/src/test/kotlin/com/adyen/checkout/flutter/ConfigurationMapperTest.kt
@@ -403,7 +403,8 @@ class ConfigurationMapperTest {
             val checkoutConfiguration = cardComponentConfigurationDTO.toCheckoutConfiguration()
             val cardConfiguration = checkoutConfiguration.getConfiguration<CardConfiguration>(PaymentMethodTypes.SCHEME)
 
-            assertIs<AddressConfiguration.FullAddress>(cardConfiguration?.addressConfiguration)
+            val addressConfiguration = assertIs<AddressConfiguration.FullAddress>(cardConfiguration?.addressConfiguration)
+            assertEquals("US", addressConfiguration.defaultCountryCode)
         }
 
         @Test


### PR DESCRIPTION
## Summary

- Apply the configured top-level `countryCode` as the default country for Android card full-address forms.
- Add regression coverage for the mapped `defaultCountryCode` value.

Closes #709

#### Test plan

- [x] Added a regression assertion to `ConfigurationMapperTest`.
- [x] Verified the staged diff and whitespace checks.