### PR TITLE
Cache Apple Pay/Google Pay availability check to avoid rebuild flicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.12.0 (in development)
 
+### Improved
+
+- For Apple Pay and Google Pay Components: reduced unnecessary re-rendering on widget rebuilds by
+  caching the availability result.
+
 ### Changed
 
 - Minimum iOS version increased from 12.0 to 13.0. This aligns with Flutter's own minimum iOS

--- a/lib/src/components/apple_pay/base_apple_pay_component.dart
+++ b/lib/src/components/apple_pay/base_apple_pay_component.dart
@@ -84,6 +84,7 @@ class _BaseApplePayComponentState extends State<BaseApplePayComponent> {
   final ComponentFlutterApi _componentFlutterApi = ComponentFlutterApi.instance;
   late StreamSubscription<ComponentCommunicationModel>
       _componentCommunicationStream;
+  late final Future<InstantPaymentSetupResultDTO> _applePaySupportedFuture;
 
   @override
   void initState() {
@@ -98,12 +99,13 @@ class _BaseApplePayComponentState extends State<BaseApplePayComponent> {
         .where((communicationModel) =>
             communicationModel.componentId == widget.componentId)
         .listen(widget.handleComponentCommunication);
+    _applePaySupportedFuture = _isApplePaySupported();
   }
 
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      future: _isApplePaySupported(),
+      future: _applePaySupportedFuture,
       builder: (
         BuildContext context,
         AsyncSnapshot<InstantPaymentSetupResultDTO> snapshot,

--- a/lib/src/components/google_pay/base_google_pay_component.dart
+++ b/lib/src/components/google_pay/base_google_pay_component.dart
@@ -85,6 +85,7 @@ class _BaseGooglePayComponentState extends State<BaseGooglePayComponent> {
   late StreamSubscription<ComponentCommunicationModel>
       _componentCommunicationStream;
   late Completer<InstantPaymentSetupResultDTO> _availabilityCompleter;
+  late final Future<InstantPaymentSetupResultDTO> _googlePayAvailableFuture;
 
   @override
   void initState() {
@@ -101,12 +102,13 @@ class _BaseGooglePayComponentState extends State<BaseGooglePayComponent> {
         widget.handleComponentCommunication(communicationModel);
       }
     });
+    _googlePayAvailableFuture = _isGooglePayAvailable();
   }
 
   @override
   Widget build(BuildContext context) {
     return FutureBuilder(
-      future: _isGooglePayAvailable(),
+      future: _googlePayAvailableFuture,
       builder: (
         BuildContext context,
         AsyncSnapshot<InstantPaymentSetupResultDTO> snapshot,


### PR DESCRIPTION
## Summary
- `BaseApplePayComponent`/`BaseGooglePayComponent` called their async availability check directly inside `build()` via `FutureBuilder`. Since an async call returns a new `Future` on every invocation, `FutureBuilder` reset to the waiting state on every rebuild, causing the button to flash blank and the layout to jump whenever an ancestor widget rebuilds.
- For Google Pay, this also re-triggered the native availability check on every rebuild.
- The check is now performed once in `initState()` and the resulting `Future` is reused across rebuilds. `State` persists across widget rebuilds as long as the widget's key/type/position in the tree stay the same, so this does not change behavior when the component is actually removed/recreated.

Fixes #713

## Test plan
- [x] `dart format --set-exit-if-changed` on both files: no changes needed
- [x] `flutter analyze`: no issues
- [x] `flutter test`: all existing tests pass
- [x] Manual verification on Android and iOS: place the component inside a widget that rebuilds due to unrelated state (e.g. a checkbox) and confirm the button no longer flashes blank
