### PR TITLE
chore: gitignore .devin folder and add missing changelog entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,10 @@ secrets.json
 .history
 .svn/
 
-#windsurf
+#Harnesses and LLMs
 .windsurf/
 .factory
+.devin/
 
 # IntelliJ related
 *.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## 1.12.0 (in development)
 
+### Fixed
+
+- For Card Component on Android: the configured `countryCode` is now applied as the
+  default country for full-address forms.
+
 ### Changed
 
 - Minimum iOS version increased from 12.0 to 13.0. This aligns with Flutter's own minimum iOS


### PR DESCRIPTION
## Summary
- Add `.devin/` to `.gitignore` alongside other harness/LLM tooling directories.
- Add missing changelog entry for #710, which fixes the default `countryCode` applied to the Android card full-address form.

#### Test plan
- [x] Verified `.gitignore` now ignores `.devin/`.
- [x] Verified changelog entry reflects the change from #710.