### PR TITLE
chore: Update Android SDK to v5.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
   | Name | Version |
   |---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|---------|
   | [pay](https://pub.dev/packages/pay) | 3.2.1 -> **3.3.0** |
+  | [Android Drop-in/Components](https://docs.adyen.com/online-payments/release-notes/?title%5B0%5D=Android+Components%2FDrop-in&version%5B0%5D=5.20.0) | 5.19.0 -> **5.20.0** |
 
   `pay_android` is now pulled in transitively by `pay` (endorsed implementation).
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Pub Package](https://img.shields.io/pub/v/adyen_checkout.svg)](https://pub.dev/packages/adyen_checkout)
 [![Adyen iOS](https://img.shields.io/badge/ios-v5.25.1-brightgreen.svg)](https://github.com/Adyen/adyen-ios/releases/tag/5.25.1)
-[![Adyen Android](https://img.shields.io/badge/android-v5.19.0-brightgreen.svg)](https://github.com/Adyen/adyen-android/releases/tag/5.19.0)
+[![Adyen Android](https://img.shields.io/badge/android-v5.20.0-brightgreen.svg)](https://github.com/Adyen/adyen-android/releases/tag/5.20.0)
 
 The Adyen Flutter package provides you with the building blocks to create a checkout experience for
 your shoppers, allowing them to pay using the payment method of their choice. This is

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -50,7 +50,7 @@ android {
     }
 
     dependencies {
-        implementation 'com.adyen.checkout:drop-in:5.19.0'
+        implementation 'com.adyen.checkout:drop-in:5.20.0'
         implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
         testImplementation 'org.jetbrains.kotlin:kotlin-test'
         testImplementation 'org.mockito:mockito-core:5.23.0'


### PR DESCRIPTION
## Summary

Bumps the native Adyen Android Drop-in/Components dependency from `5.19.0` to `5.20.0`.

Release notes: https://github.com/Adyen/adyen-android/releases/tag/5.20.0

The 5.20.0 release only changes the compile/target SDK level (API 36); no breaking API changes affecting the Flutter plugin were found.

## Changes

- `android/build.gradle`: bump `com.adyen.checkout:drop-in` to `5.20.0`
- `README.md`: update Android platform badge to `5.20.0`
- `CHANGELOG.md`: update dependency versions table in the unreleased section

## Verification

- `flutter pub get` succeeds
- `flutter build apk --debug` succeeds from `example/`