### PR TITLE
build: Update Flutter framework support

### DIFF
--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -16,3 +16,7 @@ android.enableJetifier=true
 android.nonTransitiveRClass=false
 android.useAndroidX=true
 org.gradle.jvmargs=-Xmx4096M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/ios/Flutter/AppFrameworkInfo.plist
+++ b/example/ios/Flutter/AppFrameworkInfo.plist
@@ -20,7 +20,5 @@
   <string>????</string>
   <key>CFBundleVersion</key>
   <string>1.0</string>
-  <key>MinimumOSVersion</key>
-  <string>13.0</string>
 </dict>
 </plist>

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -71,7 +71,7 @@
 		75072B932F3508AB00DB2A56 /* ConfigurationMapperTests+Blik.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ConfigurationMapperTests+Blik.swift"; sourceTree = "<group>"; };
 		7525B4FB2F3F77B600095BAD /* ThreeDS2CustomizationMapperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreeDS2CustomizationMapperTests.swift; sourceTree = "<group>"; };
 		75609D6F2D3159AB0057CFC3 /* CardValidatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CardValidatorTests.swift; sourceTree = "<group>"; };
-		75645AF32FA8887C00637895 /* adyen_checkout */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = adyen_checkout; path = ../../ios/adyen_checkout; sourceTree = "<group>"; };
+		75645AF32FA8887C00637895 /* adyen_checkout */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = adyen_checkout; path = Flutter/ephemeral/Packages/.packages/adyen-flutter; sourceTree = "<group>"; };
 		7567D95D2DB7C7BB00868648 /* en-US */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-US"; path = "en-US.lproj/Main.strings"; sourceTree = "<group>"; };
 		7567D95E2DB7C7BB00868648 /* en-US */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "en-US"; path = "en-US.lproj/LaunchScreen.strings"; sourceTree = "<group>"; };
 		7567D9642DB7D0B900868648 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };

--- a/example/lib/config.dart
+++ b/example/lib/config.dart
@@ -27,7 +27,7 @@ class Config {
   static const String shopperReference = "Test reference";
   static const Environment environment = Environment.test;
   static const String baseUrl = "checkout-test.adyen.com";
-  static const String apiVersion = "v71";
+  static const String apiVersion = "v72";
   static const String iOSReturnUrl = "com.mydomain.adyencheckout://";
   static const GooglePayEnvironment googlePayEnvironment =
       GooglePayEnvironment.test;


### PR DESCRIPTION
## Summary
- Point the iOS example's local package reference at Flutter's generated ephemeral package.
- Apply Flutter migrator project configuration updates for Android and iOS.
- Update the example Checkout API version to v72.

#### Test plan
- [x] `dart format example/lib/config.dart`
- [x] `flutter analyze example/lib/config.dart`
- [x] `plutil -lint example/ios/Flutter/AppFrameworkInfo.plist`
- [x] `plutil -lint example/ios/Runner.xcodeproj/project.pbxproj`
- [x] `xcodebuild -list -project example/ios/Runner.xcodeproj`