### PR TITLE
build: Add Flutter 3.47 CI coverage

### DIFF
--- a/.github/workflows/android_clean_build.yml
+++ b/.github/workflows/android_clean_build.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         api-level: [ 36 ]
-        flutter-version: [ 3.16.x, 3.19.x, 3.22.x, 3.24.x, 3.27.x, 3.29.x, 3.32.x, 3.35.x, 3.38.x, 3.41.x, 3.44.x ]
+        flutter-version: [ 3.16.x, 3.19.x, 3.22.x, 3.24.x, 3.27.x, 3.29.x, 3.32.x, 3.35.x, 3.38.x, 3.41.x, 3.44.x, 3.47.x ]
         agp_version: [ 8.13.2 ]
         gradle_version: [ 8.14.5 ]
     env:
@@ -107,7 +107,7 @@ jobs:
                     
           # Suppress Kotlin 2.2.x strict JVM target consistency errors in dependencies (Flutter 3.44.x+)
           # pay_android 3.2.x defaults to JVM 1.8 which conflicts with our JVM 11 target
-          if [[ "$FLUTTER_VERSION" == "3.44.x" ]]; then
+          if [[ "$FLUTTER_VERSION" == "3.44.x" || "$FLUTTER_VERSION" == "3.47.x" ]]; then
             echo "kotlin.jvm.target.validation.mode=warning" >> android/gradle.properties
           fi
 

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -6,7 +6,7 @@ on:
       flutter-version:
         description: 'Flutter version'
         required: false
-        default: '3.44.x'
+        default: '3.47.x'
         type: string
 
 permissions:

--- a/.github/workflows/android_tests.yml
+++ b/.github/workflows/android_tests.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
         with:
-          gradle-version: '8.13'
+          gradle-version: '8.14.5'
 
       - name: Init gradle wrapper
         run: gradle wrapper

--- a/.github/workflows/flutter_tests.yml
+++ b/.github/workflows/flutter_tests.yml
@@ -6,7 +6,7 @@ on:
       flutter-version:
         description: 'Flutter version'
         required: false
-        default: '3.44.x'
+        default: '3.47.x'
         type: string
 
 jobs:

--- a/.github/workflows/ios_clean_build.yml
+++ b/.github/workflows/ios_clean_build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flutter-version: [ 3.16.x, 3.19.x, 3.22.x, 3.24.x, 3.27.x, 3.29.x, 3.32.x, 3.35.x, 3.38.x, 3.41.x, 3.44.x ]
+        flutter-version: [ 3.16.x, 3.19.x, 3.22.x, 3.24.x, 3.27.x, 3.29.x, 3.32.x, 3.35.x, 3.38.x, 3.41.x, 3.44.x, 3.47.x ]
     env:
       IPHONE_MODEL: "iPhone 17"
 

--- a/.github/workflows/ios_spm_build.yml
+++ b/.github/workflows/ios_spm_build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        flutter-version: [ 3.32.x, 3.35.x, 3.38.x, 3.41.x, 3.44.x ]
+        flutter-version: [ 3.32.x, 3.35.x, 3.38.x, 3.41.x, 3.44.x, 3.47.x ]
     env:
       IPHONE_MODEL: "iPhone 17"
 


### PR DESCRIPTION
## Summary
- add Flutter 3.47.x to Android and iOS clean-build matrices
- make Flutter 3.47.x the default SDK for unit-test workflows
- apply the Android Kotlin JVM-target workaround to the new SDK version

#### Test plan
- [x] Parse updated GitHub Actions workflow YAML
- [x] Run `git diff --check`