### PR TITLE
example-app: Improve SceneDelegate to consume handled iOS redirect URLs

### DIFF
--- a/example/ios/Runner/SceneDelegate.swift
+++ b/example/ios/Runner/SceneDelegate.swift
@@ -8,8 +8,9 @@ import UIKit
 
 final class SceneDelegate: FlutterSceneDelegate {
     override func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        let unhandledURLContexts = URLContexts.filter {
-            !RedirectComponent.applicationDidOpen(from: $0.url)
+        var unhandledURLContexts = Set<UIOpenURLContext>()
+        for context in URLContexts where !RedirectComponent.applicationDidOpen(from: context.url) {
+            unhandledURLContexts.insert(context)
         }
         guard !unhandledURLContexts.isEmpty else { return }
         super.scene(scene, openURLContexts: unhandledURLContexts)

--- a/example/ios/Runner/SceneDelegate.swift
+++ b/example/ios/Runner/SceneDelegate.swift
@@ -8,7 +8,10 @@ import UIKit
 
 final class SceneDelegate: FlutterSceneDelegate {
     override func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
-        URLContexts.forEach { RedirectComponent.applicationDidOpen(from: $0.url) }
-        super.scene(scene, openURLContexts: URLContexts)
+        let unhandledURLContexts = URLContexts.filter {
+            !RedirectComponent.applicationDidOpen(from: $0.url)
+        }
+        guard !unhandledURLContexts.isEmpty else { return }
+        super.scene(scene, openURLContexts: unhandledURLContexts)
     }
 }


### PR DESCRIPTION
## Summary
- consume return URLs handled by Adyen before forwarding URL contexts to Flutter
- preserve Flutter deep-link handling for URLs that do not belong to an active Adyen redirect
- prevent Flutter from treating `redirectResult` callbacks as unknown named routes

#### Test plan
- [x] `swiftformat example/ios/Runner/SceneDelegate.swift --config ios/.swiftformat`
- [x] `swiftlint lint --config ios/.swiftlint.yml example/ios/Runner/SceneDelegate.swift`
- [x] `flutter analyze`