### PR TITLE
Prevent overlapping Drop-in launches in example app

### DIFF
--- a/example/lib/screens/drop_in/drop_in_screen.dart
+++ b/example/lib/screens/drop_in/drop_in_screen.dart
@@ -37,18 +37,14 @@ class _DropInScreenState extends State<DropInScreen> {
               TextButton(
                 onPressed: _isStartingDropIn
                     ? null
-                    : () => _runDropIn(
-                          () => startDropInSessions(context),
-                        ),
+                    : () => _runDropIn(startDropInSessions),
                 key: const Key('Drop-in sessions flow'),
                 child: const Text("Drop-in sessions flow"),
               ),
               TextButton(
                 onPressed: _isStartingDropIn
                     ? null
-                    : () => _runDropIn(
-                          () => startDropInAdvancedFlow(context),
-                        ),
+                    : () => _runDropIn(startDropInAdvancedFlow),
                 key: const Key('Drop-in advanced flow'),
                 child: const Text("Drop-in advanced flow"),
               ),
@@ -74,7 +70,7 @@ class _DropInScreenState extends State<DropInScreen> {
     }
   }
 
-  Future<void> startDropInSessions(BuildContext context) async {
+  Future<void> startDropInSessions() async {
     try {
       final Map<String, dynamic> sessionResponse =
           await widget.repository.fetchSession();
@@ -94,7 +90,7 @@ class _DropInScreenState extends State<DropInScreen> {
         checkout: sessionCheckout,
       );
 
-      if (context.mounted) {
+      if (mounted) {
         DialogBuilder.showPaymentResultDialog(paymentResult, context);
       }
     } catch (error) {
@@ -102,7 +98,7 @@ class _DropInScreenState extends State<DropInScreen> {
     }
   }
 
-  Future<void> startDropInAdvancedFlow(BuildContext context) async {
+  Future<void> startDropInAdvancedFlow() async {
     try {
       final paymentMethodsResponse =
           await widget.repository.fetchPaymentMethods();
@@ -123,7 +119,7 @@ class _DropInScreenState extends State<DropInScreen> {
         checkout: advancedCheckout,
       );
 
-      if (context.mounted) {
+      if (mounted) {
         DialogBuilder.showPaymentResultDialog(paymentResult, context);
       }
     } catch (error) {

--- a/example/lib/screens/drop_in/drop_in_screen.dart
+++ b/example/lib/screens/drop_in/drop_in_screen.dart
@@ -8,7 +8,7 @@ import 'package:adyen_checkout_example/repositories/config_repository.dart';
 import 'package:adyen_checkout_example/utils/dialog_builder.dart';
 import 'package:flutter/material.dart';
 
-class DropInScreen extends StatelessWidget {
+class DropInScreen extends StatefulWidget {
   const DropInScreen({
     required this.repository,
     required this.configRepository,
@@ -17,6 +17,13 @@ class DropInScreen extends StatelessWidget {
 
   final AdyenDropInRepository repository;
   final ConfigRepository configRepository;
+
+  @override
+  State<DropInScreen> createState() => _DropInScreenState();
+}
+
+class _DropInScreenState extends State<DropInScreen> {
+  bool _isStartingDropIn = false;
 
   @override
   Widget build(BuildContext context) {
@@ -28,12 +35,20 @@ class DropInScreen extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               TextButton(
-                onPressed: () => startDropInSessions(context),
+                onPressed: _isStartingDropIn
+                    ? null
+                    : () => _runDropIn(
+                          () => startDropInSessions(context),
+                        ),
                 key: const Key('Drop-in sessions flow'),
                 child: const Text("Drop-in sessions flow"),
               ),
               TextButton(
-                onPressed: () => startDropInAdvancedFlow(context),
+                onPressed: _isStartingDropIn
+                    ? null
+                    : () => _runDropIn(
+                          () => startDropInAdvancedFlow(context),
+                        ),
                 key: const Key('Drop-in advanced flow'),
                 child: const Text("Drop-in advanced flow"),
               ),
@@ -44,10 +59,25 @@ class DropInScreen extends StatelessWidget {
     );
   }
 
+  Future<void> _runDropIn(Future<void> Function() flow) async {
+    if (_isStartingDropIn) {
+      return;
+    }
+
+    setState(() => _isStartingDropIn = true);
+    try {
+      await flow();
+    } finally {
+      if (mounted) {
+        setState(() => _isStartingDropIn = false);
+      }
+    }
+  }
+
   Future<void> startDropInSessions(BuildContext context) async {
     try {
       final Map<String, dynamic> sessionResponse =
-          await repository.fetchSession();
+          await widget.repository.fetchSession();
       final DropInConfiguration dropInConfiguration =
           await _createDropInConfiguration();
 
@@ -74,15 +104,16 @@ class DropInScreen extends StatelessWidget {
 
   Future<void> startDropInAdvancedFlow(BuildContext context) async {
     try {
-      final paymentMethodsResponse = await repository.fetchPaymentMethods();
+      final paymentMethodsResponse =
+          await widget.repository.fetchPaymentMethods();
       final dropInConfiguration = await _createDropInConfiguration();
       final advancedCheckout = AdvancedCheckout(
-        onSubmit: repository.onSubmit,
-        onAdditionalDetails: repository.onAdditionalDetails,
+        onSubmit: widget.repository.onSubmit,
+        onAdditionalDetails: widget.repository.onAdditionalDetails,
         partialPayment: PartialPayment(
-          onCheckBalance: repository.onCheckBalance,
-          onRequestOrder: repository.onRequestOrder,
-          onCancelOrder: repository.onCancelOrder,
+          onCheckBalance: widget.repository.onCheckBalance,
+          onRequestOrder: widget.repository.onRequestOrder,
+          onCancelOrder: widget.repository.onCancelOrder,
         ),
       );
 
@@ -116,7 +147,7 @@ class DropInScreen extends StatelessWidget {
     );
 
     //To support CashAppPay please add "pod 'Adyen/CashAppPay'" to your Podfile.
-    final String returnUrl = await repository.determineBaseReturnUrl();
+    final String returnUrl = await widget.repository.determineBaseReturnUrl();
     final CashAppPayConfiguration cashAppPayConfiguration =
         CashAppPayConfiguration(
       cashAppPayEnvironment: CashAppPayEnvironment.sandbox,
@@ -127,7 +158,8 @@ class DropInScreen extends StatelessWidget {
         StoredPaymentMethodConfiguration(
       showPreselectedStoredPaymentMethod: false,
       isRemoveStoredPaymentMethodEnabled: true,
-      deleteStoredPaymentMethodCallback: repository.deleteStoredPaymentMethod,
+      deleteStoredPaymentMethodCallback:
+          widget.repository.deleteStoredPaymentMethod,
     );
 
     final DropInConfiguration dropInConfiguration = DropInConfiguration(
@@ -148,7 +180,7 @@ class DropInScreen extends StatelessWidget {
 
   Future<CardConfiguration> _createCardConfiguration() async {
     final CardConfiguration cardConfiguration =
-        await configRepository.loadCardConfiguration();
+        await widget.configRepository.loadCardConfiguration();
     return cardConfiguration.copyWith(
       onBinLookup: _onBinLookup,
       onBinValue: _onBinValue,

--- a/example/lib/screens/drop_in/drop_in_screen.dart
+++ b/example/lib/screens/drop_in/drop_in_screen.dart
@@ -23,6 +23,7 @@ class DropInScreen extends StatefulWidget {
 }
 
 class _DropInScreenState extends State<DropInScreen> {
+  // Prevent multiple Drop-in flows from starting at the same time.
   bool _isStartingDropIn = false;
 
   @override
@@ -35,12 +36,12 @@ class _DropInScreenState extends State<DropInScreen> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               TextButton(
-                onPressed: () => _runDropIn(_startDropInSessions),
+                onPressed: startDropInSessions,
                 key: const Key('Drop-in sessions flow'),
                 child: const Text("Drop-in sessions flow"),
               ),
               TextButton(
-                onPressed: () => _runDropIn(_startDropInAdvancedFlow),
+                onPressed: startDropInAdvancedFlow,
                 key: const Key('Drop-in advanced flow'),
                 child: const Text("Drop-in advanced flow"),
               ),
@@ -51,18 +52,12 @@ class _DropInScreenState extends State<DropInScreen> {
     );
   }
 
-  Future<void> _runDropIn(Future<void> Function() paymentFlow) async {
-    // Prevent multiple Drop-in flows from starting at the same time.
+  Future<void> startDropInSessions() async {
     if (_isStartingDropIn) {
       return;
     }
 
     setState(() => _isStartingDropIn = true);
-    await paymentFlow();
-    setState(() => _isStartingDropIn = false);
-  }
-
-  Future<void> _startDropInSessions() async {
     try {
       final Map<String, dynamic> sessionResponse =
           await widget.repository.fetchSession();
@@ -86,10 +81,17 @@ class _DropInScreenState extends State<DropInScreen> {
       }
     } catch (error) {
       debugPrint(error.toString());
+    } finally {
+      setState(() => _isStartingDropIn = false);
     }
   }
 
-  Future<void> _startDropInAdvancedFlow() async {
+  Future<void> startDropInAdvancedFlow() async {
+    if (_isStartingDropIn) {
+      return;
+    }
+
+    setState(() => _isStartingDropIn = true);
     try {
       final Map<String, dynamic> paymentMethodsResponse =
           await widget.repository.fetchPaymentMethods();
@@ -116,6 +118,8 @@ class _DropInScreenState extends State<DropInScreen> {
       }
     } catch (error) {
       debugPrint(error.toString());
+    } finally {
+      setState(() => _isStartingDropIn = false);
     }
   }
 

--- a/example/lib/screens/drop_in/drop_in_screen.dart
+++ b/example/lib/screens/drop_in/drop_in_screen.dart
@@ -35,16 +35,12 @@ class _DropInScreenState extends State<DropInScreen> {
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               TextButton(
-                onPressed: _isStartingDropIn
-                    ? null
-                    : () => _runDropIn(startDropInSessions),
+                onPressed: () => _runDropIn(_startDropInSessions),
                 key: const Key('Drop-in sessions flow'),
                 child: const Text("Drop-in sessions flow"),
               ),
               TextButton(
-                onPressed: _isStartingDropIn
-                    ? null
-                    : () => _runDropIn(startDropInAdvancedFlow),
+                onPressed: () => _runDropIn(_startDropInAdvancedFlow),
                 key: const Key('Drop-in advanced flow'),
                 child: const Text("Drop-in advanced flow"),
               ),
@@ -55,28 +51,23 @@ class _DropInScreenState extends State<DropInScreen> {
     );
   }
 
-  Future<void> _runDropIn(Future<void> Function() flow) async {
+  Future<void> _runDropIn(Future<void> Function() paymentFlow) async {
+    // Prevent multiple Drop-in flows from starting at the same time.
     if (_isStartingDropIn) {
       return;
     }
 
     setState(() => _isStartingDropIn = true);
-    try {
-      await flow();
-    } finally {
-      if (mounted) {
-        setState(() => _isStartingDropIn = false);
-      }
-    }
+    await paymentFlow();
+    setState(() => _isStartingDropIn = false);
   }
 
-  Future<void> startDropInSessions() async {
+  Future<void> _startDropInSessions() async {
     try {
       final Map<String, dynamic> sessionResponse =
           await widget.repository.fetchSession();
       final DropInConfiguration dropInConfiguration =
           await _createDropInConfiguration();
-
       final SessionCheckout sessionCheckout =
           await AdyenCheckout.session.create(
         sessionId: sessionResponse["id"],
@@ -98,12 +89,13 @@ class _DropInScreenState extends State<DropInScreen> {
     }
   }
 
-  Future<void> startDropInAdvancedFlow() async {
+  Future<void> _startDropInAdvancedFlow() async {
     try {
-      final paymentMethodsResponse =
+      final Map<String, dynamic> paymentMethodsResponse =
           await widget.repository.fetchPaymentMethods();
-      final dropInConfiguration = await _createDropInConfiguration();
-      final advancedCheckout = AdvancedCheckout(
+      final DropInConfiguration dropInConfiguration =
+          await _createDropInConfiguration();
+      final AdvancedCheckout advancedCheckout = AdvancedCheckout(
         onSubmit: widget.repository.onSubmit,
         onAdditionalDetails: widget.repository.onAdditionalDetails,
         partialPayment: PartialPayment(


### PR DESCRIPTION
## Summary
- guard the example app against concurrent Drop-in launch attempts
- disable both sessions and advanced-flow buttons while either flow is active
- release the guard after completion, cancellation, or errors

#### Test plan
- [x] Run `dart format --output=none --set-exit-if-changed lib/screens/drop_in/drop_in_screen.dart`
- [x] Run `flutter analyze` from the example directory
- [x] Manually verify rapid taps only launch one Drop-in flow at a time