### PR TITLE
Update Kotlin Gradle plugin for CVE-2026-53914

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.0.20'
+    ext.kotlin_version = '2.4.20'
     repositories {
         google()
         mavenCentral()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '2.4.20'
+    ext.kotlin_version = '2.0.20'
     repositories {
         google()
         mavenCentral()

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
     id "com.android.application" version "8.13.2" apply false
-    id "org.jetbrains.kotlin.android" version "2.2.21" apply false
+    id "org.jetbrains.kotlin.android" version "2.4.20" apply false
 }
 
 include ':app'


### PR DESCRIPTION
## Summary
- Update the example app Kotlin Gradle plugin from 2.2.21 to 2.4.20.
- Keep AGP 8.13.2 unchanged; CVE-2026-53914 affects the Kotlin Gradle plugin, not AGP.

#### Test plan
- [x] `flutter test` (59 tests passed)
- [x] `git diff --check`